### PR TITLE
Update PyPI publish action

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -34,6 +34,6 @@ jobs:
           python -m pip install --upgrade twine pkginfo
           python -m twine check dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@8a08d616893759ef8e1aa1f2785787c0b97e20d6
+        uses: pypa/gh-action-pypi-publish@03f86fee9ac21f854951f5c6e2a02c2a1324aec7
         with:
-          verify_metadata: false
+          verify-metadata: false

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -101,7 +101,7 @@ jobs:
           python -m twine check dist/*
       - name: Publish to TestPyPI
         if: steps.tag.outputs.tag != ''
-        uses: pypa/gh-action-pypi-publish@8a08d616893759ef8e1aa1f2785787c0b97e20d6
+        uses: pypa/gh-action-pypi-publish@03f86fee9ac21f854951f5c6e2a02c2a1324aec7
         with:
           repository-url: https://test.pypi.org/legacy/
-          verify_metadata: false
+          verify-metadata: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ doc_requires:
 doc_reviewed_as_of:
   README.md: 58
   CONTRIBUTING.md: 68
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_invariants:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ doc_requires:
 doc_reviewed_as_of:
   README.md: 58
   AGENTS.md: 12
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_invariants:

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 25
+doc_revision: 26
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -22,7 +22,7 @@ doc_reviewed_as_of:
   CONTRIBUTING.md: 68
   AGENTS.md: 12
   glossary.md: 9
-  docs/publishing_practices.md: 20
+  docs/publishing_practices.md: 21
 doc_commutes_with:
   - glossary.md
 doc_change_protocol: "POLICY_SEED.md §6"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ doc_requires:
   - AGENTS.md
   - CONTRIBUTING.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
   AGENTS.md: 12
   CONTRIBUTING.md: 68

--- a/docs/influence_index.md
+++ b/docs/influence_index.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58

--- a/docs/publishing_practices.md
+++ b/docs/publishing_practices.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 20
+doc_revision: 21
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: publishing_practices
 doc_role: practices
@@ -13,7 +13,7 @@ doc_requires:
   - POLICY_SEED.md
   - CONTRIBUTING.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   CONTRIBUTING.md: 68
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_erasure:
@@ -107,7 +107,7 @@ Rationale: publishing is a sensitive surface.
 Metadata checks: `hatchling` emits core metadata version 2.4, which older
 `pkginfo` versions cannot parse. The release workflows run `twine check dist/*`
 with an up-to-date `twine/pkginfo` and disable the action’s built-in metadata
-check (`verify_metadata: false`) to avoid false failures.
+check (`verify-metadata: false`) to avoid false failures.
 
 Current workflows:
 - `.github/workflows/release-tag.yml` (creates tags from `next` and `release`)

--- a/glossary.md
+++ b/glossary.md
@@ -17,7 +17,7 @@ doc_reviewed_as_of:
   README.md: 58
   CONTRIBUTING.md: 68
   AGENTS.md: 12
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
 doc_commutes_with:
   - POLICY_SEED.md
 doc_change_protocol: "POLICY_SEED.md §6"

--- a/out/out-1.md
+++ b/out/out-1.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58

--- a/out/out-2.md
+++ b/out/out-2.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 25
+  POLICY_SEED.md: 26
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58


### PR DESCRIPTION
## Summary
- bump pypa/gh-action-pypi-publish to latest commit (metadata 2.4 support)
- normalize verify-metadata input
- refresh doc review references for POLICY_SEED + publishing practices

## Testing
- mise exec -- python scripts/policy_check.py --workflows