### PR TITLE
Normalize TestPyPI version

### DIFF
--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -74,6 +74,12 @@ jobs:
           version = tag[len("test-v") :]
           if not version:
               raise SystemExit("Missing version in tag")
+          if "+" in version:
+              base, local = version.split("+", 1)
+              digits = "".join(ch for ch in local if ch.isdigit())
+              if not digits:
+                  raise SystemExit("Missing timestamp digits in test tag")
+              version = f"{base}.dev{digits}"
           path = Path("pyproject.toml")
           text = path.read_text()
           updated = re.sub(r'(?m)^version = ".*"$', f'version = "{version}"', text, count=1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ doc_requires:
 doc_reviewed_as_of:
   README.md: 58
   CONTRIBUTING.md: 68
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_invariants:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ doc_requires:
 doc_reviewed_as_of:
   README.md: 58
   AGENTS.md: 12
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_invariants:

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 26
+doc_revision: 27
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -22,7 +22,7 @@ doc_reviewed_as_of:
   CONTRIBUTING.md: 68
   AGENTS.md: 12
   glossary.md: 9
-  docs/publishing_practices.md: 21
+  docs/publishing_practices.md: 22
 doc_commutes_with:
   - glossary.md
 doc_change_protocol: "POLICY_SEED.md §6"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ doc_requires:
   - AGENTS.md
   - CONTRIBUTING.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
   AGENTS.md: 12
   CONTRIBUTING.md: 68

--- a/docs/influence_index.md
+++ b/docs/influence_index.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58

--- a/docs/publishing_practices.md
+++ b/docs/publishing_practices.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 21
+doc_revision: 22
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: publishing_practices
 doc_role: practices
@@ -13,7 +13,7 @@ doc_requires:
   - POLICY_SEED.md
   - CONTRIBUTING.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   CONTRIBUTING.md: 68
 doc_change_protocol: "POLICY_SEED.md §6"
 doc_erasure:
@@ -81,8 +81,9 @@ Tags should be created by the `release-tag` workflow. The workflow enforces:
 An optional automation can create `test-v*` tags after `mirror-next` succeeds.
 This is allowed only when `next` mirrors `main` and the tag is derived from the
 current `project.version` in `pyproject.toml`, with a `+YYYYMMDDTHHMMSSZ` suffix.
-The TestPyPI workflow rewrites `project.version` to match the tag so uploads
-remain unique.
+The TestPyPI workflow normalizes the tag into a PEP 440 dev release
+(`X.Y.Z.devYYYYMMDDHHMMSS`) before rewriting `project.version` so uploads remain
+unique and acceptable to PyPI.
 
 A tag ruleset should limit `v*`/`test-v*` creation to the maintainer and GitHub Actions.
 Note: personal repositories cannot enforce actor-restricted rulesets; rely on

--- a/glossary.md
+++ b/glossary.md
@@ -17,7 +17,7 @@ doc_reviewed_as_of:
   README.md: 58
   CONTRIBUTING.md: 68
   AGENTS.md: 12
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
 doc_commutes_with:
   - POLICY_SEED.md
 doc_change_protocol: "POLICY_SEED.md §6"

--- a/out/out-1.md
+++ b/out/out-1.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58

--- a/out/out-2.md
+++ b/out/out-2.md
@@ -15,7 +15,7 @@ doc_requires:
   - CONTRIBUTING.md
   - README.md
 doc_reviewed_as_of:
-  POLICY_SEED.md: 26
+  POLICY_SEED.md: 27
   glossary.md: 9
   CONTRIBUTING.md: 68
   README.md: 58


### PR DESCRIPTION
## Summary
- normalize test tag local versions into PEP 440 dev releases for TestPyPI
- update publishing practices + policy review references

## Testing
- mise exec -- python scripts/policy_check.py --workflows