### PR TITLE
Fix promote-release tag handling

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -7,13 +7,13 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   promote:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'test-v') &&
       (github.event.workflow_run.actor.login == github.repository_owner ||
         github.event.workflow_run.actor.login == 'github-actions[bot]')
     steps:
@@ -21,10 +21,26 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Download test tag artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: release-testpypi-tag
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts/release-testpypi
       - name: Promote next to release
         run: |
           git fetch origin main next release --tags
-          TAG="${{ github.event.workflow_run.head_branch }}"
+          TAG=""
+          if [ -f artifacts/release-testpypi/tag.txt ]; then
+            TAG="$(cat artifacts/release-testpypi/tag.txt)"
+          elif [[ "${{ github.event.workflow_run.head_branch }}" == test-v* ]]; then
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "Missing test tag for promotion."
+            exit 1
+          fi
           HEAD_SHA=$(git rev-parse HEAD)
           NEXT_SHA=$(git rev-parse origin/next)
           TAG_SHA=$(git rev-parse "refs/tags/$TAG")

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -52,6 +52,17 @@ jobs:
             exit 0
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Persist test tag
+        if: steps.tag.outputs.tag != ''
+        run: |
+          mkdir -p artifacts/release-testpypi
+          echo "${{ steps.tag.outputs.tag }}" > artifacts/release-testpypi/tag.txt
+      - name: Upload test tag artifact
+        if: steps.tag.outputs.tag != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-testpypi-tag
+          path: artifacts/release-testpypi/tag.txt
       - name: Ensure tag is on main/next
         if: steps.tag.outputs.tag != ''
         run: |


### PR DESCRIPTION
## Summary
- persist TestPyPI tag as artifact in release-testpypi
- promote-release downloads tag artifact and validates promotion
- relax policy check to accept artifact-based tag validation

## Testing
- mise exec -- python scripts/policy_check.py --workflows