### PR TITLE
Fix release tag commit checks

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -47,7 +47,7 @@ jobs:
           fi
           HEAD_SHA=$(git rev-parse HEAD)
           NEXT_SHA=$(git rev-parse origin/next)
-          TAG_SHA=$(git rev-parse "refs/tags/$TAG")
+          TAG_SHA=$(git rev-parse "refs/tags/$TAG^{commit}")
           if [ "$HEAD_SHA" != "$TAG_SHA" ]; then
             echo "Workflow head sha must match tag."
             exit 1

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           git fetch origin main next
           TAG="${{ steps.tag.outputs.tag }}"
-          TAG_SHA=$(git rev-parse "refs/tags/$TAG")
+          TAG_SHA=$(git rev-parse "refs/tags/$TAG^{commit}")
           git merge-base --is-ancestor "$TAG_SHA" origin/main
           git merge-base --is-ancestor "$TAG_SHA" origin/next
       - name: Set version from test tag


### PR DESCRIPTION
- Resolve annotated tag commits before comparing with workflow head\n- Ensure tag ancestry checks use commit SHAs