### PR TITLE
Release hardening + v0.1.4 alignment

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -40,6 +40,48 @@ jobs:
             echo "release=$RELEASE_SHA"
             exit 1
           fi
+      - name: Ensure tag matches project version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" != v* ]]; then
+            echo "Unexpected tag format: $TAG"
+            exit 1
+          fi
+          PROJECT_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path("pyproject.toml").read_text()
+          match = re.search(r'^version\\s*=\\s*"([^"]+)"\\s*$', text, re.M)
+          if not match:
+              raise SystemExit("project.version not found in pyproject.toml")
+          print(match.group(1))
+          PY
+          )"
+          PACKAGE_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path("src/gabion/__init__.py").read_text()
+          match = re.search(r'^__version__\\s*=\\s*"([^"]+)"\\s*$', text, re.M)
+          if not match:
+              raise SystemExit("__version__ not found in src/gabion/__init__.py")
+          print(match.group(1))
+          PY
+          )"
+          TAG_VERSION="${TAG#v}"
+          if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then
+            echo "Tag version must match project.version in pyproject.toml."
+            echo "tag=$TAG_VERSION"
+            echo "project.version=$PROJECT_VERSION"
+            exit 1
+          fi
+          if [ "$PROJECT_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "project.version must match src/gabion/__init__.__version__."
+            echo "project.version=$PROJECT_VERSION"
+            echo "__version__=$PACKAGE_VERSION"
+            exit 1
+          fi
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -69,6 +69,39 @@ jobs:
             echo "Tag already exists: $TAG"
             exit 1
           fi
+      - name: Ensure tag matches project version
+        run: |
+          TAG="${{ inputs.tag }}"
+          PROJECT_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path("pyproject.toml").read_text()
+          match = re.search(r'^version\\s*=\\s*"([^"]+)"\\s*$', text, re.M)
+          if not match:
+              raise SystemExit("project.version not found in pyproject.toml")
+          print(match.group(1))
+          PY
+          )"
+          case "$TAG" in
+            v*)
+              TAG_VERSION="${TAG#v}"
+              ;;
+            test-v*)
+              TAG_VERSION="${TAG#test-v}"
+              ;;
+            *)
+              echo "Unexpected tag format: $TAG"
+              exit 1
+              ;;
+          esac
+          BASE_VERSION="${TAG_VERSION%%+*}"
+          if [ "$BASE_VERSION" != "$PROJECT_VERSION" ]; then
+            echo "Tag version must match project.version in pyproject.toml."
+            echo "tag=$TAG"
+            echo "project.version=$PROJECT_VERSION"
+            exit 1
+          fi
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -109,6 +109,17 @@ jobs:
           if updated == text:
               raise SystemExit("Failed to update project.version in pyproject.toml")
           path.write_text(updated)
+          init_path = Path("src/gabion/__init__.py")
+          init_text = init_path.read_text()
+          init_updated = re.sub(
+              r'(?m)^__version__\\s*=\\s*"[^"]+"\\s*$',
+              f'__version__ = "{version}"',
+              init_text,
+              count=1,
+          )
+          if init_updated == init_text:
+              raise SystemExit("Failed to update __version__ in src/gabion/__init__.py")
+          init_path.write_text(init_updated)
           print(f"Set project.version to {version}")
           PY
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gabion"
-version = "0.1.1"
+version = "0.1.4"
 description = "Architectural linter that stabilizes loose parameters into structural bundles."
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/src/gabion/__init__.py
+++ b/src/gabion/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.4"


### PR DESCRIPTION
- Align project.version and __version__ to 0.1.4
- Add tag/version checks to release workflows
- Ensure TestPyPI flow rewrites __version__ with test tags

CI: green on stage