### PR TITLE
Add VS Code command wiring, diagnostics UX, and smoke checks

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,24 +1,64 @@
 # Gabion VS Code Extension (Thin Wrapper)
 
-This is a thin wrapper that launches the Gabion Python LSP server over stdio.
-It does not embed analysis logic.
+This extension launches the Gabion Python LSP server over stdio and keeps
+analysis logic on the server side.
 
-## Requirements
-- Python environment with `gabion` installed (editable or package).
-- VS Code with Node available for extension dependencies.
+## Project setup
 
-## Configuration
-- `gabion.pythonPath`: Python executable that can run the server.
-- `gabion.serverArgs`: Arguments passed to the Python command (default: `-m gabion.server`).
+1. Install and activate the repo toolchain:
+   ```bash
+   mise install
+   mise exec -- python -m pip install -e .
+   ```
+2. In VS Code, choose the Python interpreter that has `gabion` installed:
+   - Command Palette → `Python: Select Interpreter`
+   - Pick the interpreter used by `mise exec -- python`.
+3. Configure the extension if needed:
+   - `gabion.pythonPath` (default `python`)
+   - `gabion.serverArgs` (default `-m gabion.server`)
 
-## Commands
-- `Gabion: Extract Protocol (stub)` runs the refactor protocol command against
-  the active file and prints the response in the "Gabion" output channel.
+## What appears in the editor
+
+- **Diagnostics** are published by the Gabion server (for example, implicit
+  bundle detections).
+- **Code actions** are surfaced for Gabion diagnostics:
+  - `Gabion: Synthesis plan for bundle`
+  - `Gabion: Refactor protocol from bundle`
+- **Result panels** are emitted into the **Gabion** output channel for synthesis,
+  refactor, and structure diff command responses.
+
+## Command Palette actions
+
+The extension wires these server commands directly:
+
+- `Gabion: Synthesis Plan` → `gabion.synthesisPlan`
+  - Prompted for bundle fields and existing protocol names.
+  - Prints synthesis suggestions and warnings/errors in the output channel.
+- `Gabion: Refactor Protocol` → `gabion.refactorProtocol`
+  - Prompted for protocol name, bundle fields, and optional target functions.
+  - Prints refactor entry-point edits and warnings/errors in the output channel.
+- `Gabion: Structure Diff` → `gabion.structureDiff`
+  - Prompted for baseline/current snapshot paths.
+  - Prints diff results in the output channel.
+
+## End-to-end example
+
+1. Open a Python file containing a function with repeated parameter bundles.
+2. Save the file and wait for Gabion diagnostics to appear.
+3. Use `Quick Fix...` on a Gabion diagnostic and choose
+   `Gabion: Synthesis plan for bundle`.
+4. Review the generated protocol suggestions in the **Gabion** output channel.
+5. Run `Gabion: Refactor Protocol` from the Command Palette and provide the
+   proposed protocol name and bundle fields.
+6. Review the returned edit plan in the output channel and apply it manually
+   (or via your own workflow tooling).
 
 ## Development (local)
-```
+
+```bash
 cd extensions/vscode
 npm install
+npm run check
 ```
 
-Use VS Code "Run Extension" (F5) to launch a dev instance.
+Use VS Code **Run Extension** (F5) to launch a development host.

--- a/extensions/vscode/extension.js
+++ b/extensions/vscode/extension.js
@@ -3,7 +3,279 @@
 const vscode = require("vscode");
 const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
 
+const SYNTHESIS_COMMAND = "gabion.synthesisPlan";
+const REFACTOR_COMMAND = "gabion.refactorProtocol";
+const STRUCTURE_DIFF_COMMAND = "gabion.structureDiff";
+
 let client;
+
+function createResultPanel(outputChannel, title, payload, result) {
+  outputChannel.appendLine(`\\n=== ${title} ===`);
+  outputChannel.appendLine(`Payload:`);
+  outputChannel.appendLine(JSON.stringify(payload, null, 2));
+  outputChannel.appendLine("Result:");
+  outputChannel.appendLine(JSON.stringify(result, null, 2));
+  outputChannel.show(true);
+}
+
+async function executeServerCommand({ command, payload, outputChannel, responseTitle }) {
+  try {
+    const result = await client.sendRequest("workspace/executeCommand", {
+      command,
+      arguments: [payload],
+    });
+    createResultPanel(outputChannel, responseTitle, payload, result);
+    return result;
+  } catch (err) {
+    vscode.window.showErrorMessage(`Gabion command failed (${command}): ${err}`);
+    throw err;
+  }
+}
+
+function parseCsv(input) {
+  return (input || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function normalizeLineInput(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+async function promptForSynthesisPayload(editor) {
+  const bundleInput = await vscode.window.showInputBox({
+    prompt: "Bundle fields (comma-separated)",
+    value: "",
+  });
+  if (bundleInput === undefined) {
+    return null;
+  }
+
+  const existingNamesInput = await vscode.window.showInputBox({
+    prompt: "Existing protocol names (comma-separated, optional)",
+    value: "",
+  });
+  if (existingNamesInput === undefined) {
+    return null;
+  }
+
+  return {
+    bundles: [{ bundle: parseCsv(bundleInput), tier: 2 }],
+    existing_names: parseCsv(existingNamesInput),
+    field_types: {},
+    fallback_prefix: "GabionBundle",
+    max_tier: 3,
+    min_bundle_size: 2,
+    allow_singletons: false,
+    merge_overlap_threshold: 0.5,
+    source_path: editor?.document.uri.fsPath || "",
+  };
+}
+
+async function promptForRefactorPayload(editor, seedBundle = []) {
+  const protocolNameInput = await vscode.window.showInputBox({
+    prompt: "Protocol name",
+    value: "ExtractedBundle",
+  });
+  if (protocolNameInput === undefined) {
+    return null;
+  }
+
+  const bundleInput = await vscode.window.showInputBox({
+    prompt: "Bundle fields (comma-separated)",
+    value: seedBundle.join(", "),
+  });
+  if (bundleInput === undefined) {
+    return null;
+  }
+
+  const targetFunctionsInput = await vscode.window.showInputBox({
+    prompt: "Target function names (comma-separated, optional)",
+    value: "",
+  });
+  if (targetFunctionsInput === undefined) {
+    return null;
+  }
+
+  return {
+    protocol_name: protocolNameInput || "ExtractedBundle",
+    bundle: parseCsv(bundleInput),
+    fields: [],
+    target_path: editor?.document.uri.fsPath || "",
+    target_functions: parseCsv(targetFunctionsInput),
+    compatibility_shim: false,
+    rationale: "Manual refactor protocol command from VS Code extension.",
+  };
+}
+
+async function promptForStructureDiffPayload() {
+  const baselinePath = await vscode.window.showInputBox({
+    prompt: "Baseline snapshot path",
+    value: "artifacts/structure/baseline.json",
+  });
+  if (!baselinePath) {
+    return null;
+  }
+
+  const currentPath = await vscode.window.showInputBox({
+    prompt: "Current snapshot path",
+    value: "artifacts/structure/current.json",
+  });
+  if (!currentPath) {
+    return null;
+  }
+
+  return { baseline: baselinePath, current: currentPath };
+}
+
+function bundleFromDiagnostic(diagnostic) {
+  const marker = "Implicit bundle detected:";
+  if (!diagnostic || typeof diagnostic.message !== "string") {
+    return [];
+  }
+  const idx = diagnostic.message.indexOf(marker);
+  if (idx < 0) {
+    return [];
+  }
+  return parseCsv(diagnostic.message.slice(idx + marker.length));
+}
+
+function createCodeActionsForDiagnostic(diagnostic) {
+  const bundle = bundleFromDiagnostic(diagnostic);
+  const range = diagnostic.range;
+
+  const synthesize = new vscode.CodeAction(
+    "Gabion: Synthesis plan for bundle",
+    vscode.CodeActionKind.QuickFix
+  );
+  synthesize.command = {
+    title: "Gabion: Synthesis plan",
+    command: SYNTHESIS_COMMAND,
+    arguments: [{ bundle, range }],
+  };
+  synthesize.diagnostics = [diagnostic];
+
+  const refactor = new vscode.CodeAction(
+    "Gabion: Refactor protocol from bundle",
+    vscode.CodeActionKind.RefactorExtract
+  );
+  refactor.command = {
+    title: "Gabion: Refactor protocol",
+    command: REFACTOR_COMMAND,
+    arguments: [{ bundle, range }],
+  };
+  refactor.diagnostics = [diagnostic];
+
+  return [synthesize, refactor];
+}
+
+function registerGabionCommands(context, outputChannel) {
+  const synthesisCommand = vscode.commands.registerCommand(
+    SYNTHESIS_COMMAND,
+    async (seed = {}) => {
+      await client.onReady();
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showWarningMessage("Gabion: no active editor found.");
+        return;
+      }
+      const payload = await promptForSynthesisPayload(editor);
+      if (!payload) {
+        return;
+      }
+      if (Array.isArray(seed.bundle) && seed.bundle.length > 0) {
+        payload.bundles = [{ bundle: seed.bundle, tier: 2 }];
+      }
+      await executeServerCommand({
+        command: SYNTHESIS_COMMAND,
+        payload,
+        outputChannel,
+        responseTitle: "Synthesis Suggestions",
+      });
+    }
+  );
+
+  const refactorCommand = vscode.commands.registerCommand(
+    REFACTOR_COMMAND,
+    async (seed = {}) => {
+      await client.onReady();
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showWarningMessage("Gabion: no active editor found.");
+        return;
+      }
+
+      const payload = await promptForRefactorPayload(
+        editor,
+        Array.isArray(seed.bundle) ? seed.bundle : []
+      );
+      if (!payload) {
+        return;
+      }
+
+      if (seed.range && editor.selection.isEmpty) {
+        const startLine = normalizeLineInput(seed.range.start?.line + 1, 1);
+        const endLine = normalizeLineInput(seed.range.end?.line + 1, startLine);
+        payload.target_functions = payload.target_functions.length
+          ? payload.target_functions
+          : [`lines:${startLine}-${endLine}`];
+      }
+
+      await executeServerCommand({
+        command: REFACTOR_COMMAND,
+        payload,
+        outputChannel,
+        responseTitle: "Refactor Entry Points",
+      });
+    }
+  );
+
+  const structureDiffCommand = vscode.commands.registerCommand(
+    STRUCTURE_DIFF_COMMAND,
+    async () => {
+      await client.onReady();
+      const payload = await promptForStructureDiffPayload();
+      if (!payload) {
+        return;
+      }
+      await executeServerCommand({
+        command: STRUCTURE_DIFF_COMMAND,
+        payload,
+        outputChannel,
+        responseTitle: "Structure Diff",
+      });
+    }
+  );
+
+  context.subscriptions.push(synthesisCommand, refactorCommand, structureDiffCommand);
+}
+
+function registerCodeActionProvider(context) {
+  const provider = {
+    provideCodeActions(_document, _range, codeActionContext) {
+      const actions = [];
+      for (const diagnostic of codeActionContext.diagnostics) {
+        if (diagnostic?.source !== "gabion") {
+          continue;
+        }
+        actions.push(...createCodeActionsForDiagnostic(diagnostic));
+      }
+      return actions;
+    },
+  };
+
+  const registration = vscode.languages.registerCodeActionsProvider(
+    { scheme: "file", language: "python" },
+    provider,
+    { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix, vscode.CodeActionKind.RefactorExtract] }
+  );
+  context.subscriptions.push(registration);
+}
 
 function activate(context) {
   const config = vscode.workspace.getConfiguration("gabion");
@@ -25,52 +297,8 @@ function activate(context) {
   client = new LanguageClient("gabion", "Gabion LSP", serverOptions, clientOptions);
   context.subscriptions.push(client.start(), outputChannel);
 
-  const refactorCommand = vscode.commands.registerCommand(
-    "gabion.refactorProtocol",
-    async () => {
-      await client.onReady();
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        vscode.window.showWarningMessage("Gabion: no active editor found.");
-        return;
-      }
-      const protocolName =
-        (await vscode.window.showInputBox({
-          prompt: "Protocol name",
-          value: "TODO_Bundle",
-        })) || "TODO_Bundle";
-      const bundleInput = await vscode.window.showInputBox({
-        prompt: "Bundle fields (comma-separated)",
-        value: "",
-      });
-      const bundle = bundleInput
-        ? bundleInput
-            .split(",")
-            .map((item) => item.trim())
-            .filter((item) => item.length > 0)
-        : [];
-      const payload = {
-        protocol_name: protocolName,
-        bundle,
-        target_path: editor.document.uri.fsPath,
-        target_functions: [],
-        rationale: "Manual refactor protocol command (stub).",
-      };
-      try {
-        const result = await client.sendRequest("workspace/executeCommand", {
-          command: "gabion.refactorProtocol",
-          arguments: [payload],
-        });
-        outputChannel.appendLine(
-          `Refactor response: ${JSON.stringify(result, null, 2)}`
-        );
-        outputChannel.show(true);
-      } catch (err) {
-        vscode.window.showErrorMessage(`Gabion refactor failed: ${err}`);
-      }
-    }
-  );
-  context.subscriptions.push(refactorCommand);
+  registerGabionCommands(context, outputChannel);
+  registerCodeActionProvider(context);
 }
 
 function deactivate() {
@@ -80,4 +308,12 @@ function deactivate() {
   return client.stop();
 }
 
-module.exports = { activate, deactivate };
+module.exports = {
+  activate,
+  deactivate,
+  __test__: {
+    bundleFromDiagnostic,
+    createCodeActionsForDiagnostic,
+    parseCsv,
+  },
+};

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -13,14 +13,24 @@
   ],
   "activationEvents": [
     "onLanguage:python",
-    "onCommand:gabion.refactorProtocol"
+    "onCommand:gabion.synthesisPlan",
+    "onCommand:gabion.refactorProtocol",
+    "onCommand:gabion.structureDiff"
   ],
   "main": "./extension.js",
   "contributes": {
     "commands": [
       {
+        "command": "gabion.synthesisPlan",
+        "title": "Gabion: Synthesis Plan"
+      },
+      {
         "command": "gabion.refactorProtocol",
-        "title": "Gabion: Extract Protocol (stub)"
+        "title": "Gabion: Refactor Protocol"
+      },
+      {
+        "command": "gabion.structureDiff",
+        "title": "Gabion: Structure Diff"
       }
     ],
     "configuration": {
@@ -49,6 +59,8 @@
     "vscode-languageclient": "^9.0.1"
   },
   "scripts": {
-    "lint": "node -c extension.js"
+    "lint": "node -c extension.js",
+    "smoke": "node scripts/smoke-check.js",
+    "check": "npm run lint && npm run smoke"
   }
 }

--- a/extensions/vscode/scripts/smoke-check.js
+++ b/extensions/vscode/scripts/smoke-check.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const Module = require("node:module");
+
+const packageJsonPath = path.join(__dirname, "..", "package.json");
+const extensionPath = path.join(__dirname, "..", "extension.js");
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const contributedCommands = new Set(
+  (packageJson.contributes?.commands || []).map((entry) => entry.command)
+);
+
+for (const expected of [
+  "gabion.synthesisPlan",
+  "gabion.refactorProtocol",
+  "gabion.structureDiff",
+]) {
+  assert(
+    contributedCommands.has(expected),
+    `Expected package.json to contribute command: ${expected}`
+  );
+  assert(
+    (packageJson.activationEvents || []).includes(`onCommand:${expected}`),
+    `Expected activation event for command: ${expected}`
+  );
+}
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "vscode") {
+    class CodeAction {
+      constructor(title, kind) {
+        this.title = title;
+        this.kind = kind;
+      }
+    }
+    return {
+      CodeAction,
+      CodeActionKind: {
+        QuickFix: "quickfix",
+        RefactorExtract: "refactor.extract",
+      },
+    };
+  }
+  if (request === "vscode-languageclient/node") {
+    return {
+      LanguageClient: function noop() {},
+      TransportKind: { stdio: "stdio" },
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const extensionModule = require(extensionPath);
+const testApi = extensionModule.__test__;
+assert(testApi, "Expected extension __test__ API exports");
+
+const actions = testApi.createCodeActionsForDiagnostic({
+  source: "gabion",
+  message: "Implicit bundle detected: db, cache, logger",
+  range: {
+    start: { line: 3, character: 2 },
+    end: { line: 3, character: 14 },
+  },
+});
+
+assert.equal(actions.length, 2, "Expected synthesis/refactor code actions");
+assert.equal(actions[0].command.command, "gabion.synthesisPlan");
+assert.equal(actions[1].command.command, "gabion.refactorProtocol");
+assert.deepEqual(actions[0].command.arguments[0].bundle, ["db", "cache", "logger"]);
+
+console.log("VS Code extension smoke checks passed.");


### PR DESCRIPTION
### Motivation
- Surface key Gabion outputs (bundle violations, synthesis suggestions, refactor entry points, structure diffs) directly in the editor UX by wiring the LSP-driven server commands into VS Code command palette actions and code actions. 
- Make the extension a thin LSP client (LSP-first invariant) so diagnostics and code actions remain server-sourced and the client only provides UX affordances. 
- Add scripted smoke checks to detect regressions in command wiring and code-action mapping as server method names evolve. 

### Description
- Wire server commands `gabion.synthesisPlan`, `gabion.refactorProtocol`, and `gabion.structureDiff` to command-palette actions with guided input prompts and structured result panels in the `Gabion` output channel (`extensions/vscode/extension.js`). 
- Add code-action provider that recognizes Gabion diagnostics (`source: "gabion"`) and exposes quick actions to invoke synthesis and refactor flows seeded from the diagnostic (`extension.js`). 
- Update `extensions/vscode/package.json` to contribute the three commands and activation events and add `smoke`/`check` npm scripts. 
- Expand `extensions/vscode/README.md` with project setup (repo toolchain + `gabion` install), Python interpreter selection guidance, end-to-end usage steps, and expected command behavior. 
- Add an extension-level smoke test script `extensions/vscode/scripts/smoke-check.js` that asserts command contributions/activation wiring and verifies the diagnostic→command argument mapping, and export a small `__test__` API from the extension for these checks. 

### Testing
- Ran `npm install` inside `extensions/vscode` with no errors. 
- Ran `npm run check` inside `extensions/vscode` which executes `node -c extension.js` and the smoke assertions, and it completed successfully. 
- The smoke script assertions (command contributions, activation events, and diagnostic-based code-action arguments) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a957a378832496951c39d2ae802e)