### PR TITLE
Refactor dataflow_audit: extract decision surfaces, exception obligations, and rendering adapters

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -130,6 +130,29 @@ from .projection_registry import (
     spec_metadata_payload,
 )
 from .wl_refinement import emit_wl_refinement_facets
+from .dataflow_decision_surfaces import (
+    compute_fingerprint_coherence as _ds_compute_fingerprint_coherence,
+    compute_fingerprint_rewrite_plans as _ds_compute_fingerprint_rewrite_plans,
+    extract_smell_sample as _ds_extract_smell_sample,
+    lint_lines_from_bundle_evidence as _ds_lint_lines_from_bundle_evidence,
+    lint_lines_from_constant_smells as _ds_lint_lines_from_constant_smells,
+    lint_lines_from_type_evidence as _ds_lint_lines_from_type_evidence,
+    lint_lines_from_unused_arg_smells as _ds_lint_lines_from_unused_arg_smells,
+    parse_lint_location as _ds_parse_lint_location,
+    summarize_coherence_witnesses as _ds_summarize_coherence_witnesses,
+    summarize_deadness_witnesses as _ds_summarize_deadness_witnesses,
+    summarize_rewrite_plans as _ds_summarize_rewrite_plans,
+)
+from .dataflow_exception_obligations import (
+    exception_param_names as _exc_exception_param_names,
+    exception_type_name as _exc_exception_type_name,
+    handler_is_broad as _exc_handler_is_broad,
+    handler_label as _exc_handler_label,
+    node_in_try_body as _exc_node_in_try_body,
+)
+from .dataflow_report_rendering import (
+    render_synthesis_section as _report_render_synthesis_section,
+)
 from gabion.schema import SynthesisResponse
 from gabion.synthesis import NamingContext, SynthesisConfig, Synthesizer
 from gabion.synthesis.merge import merge_bundles
@@ -3271,27 +3294,11 @@ def _summarize_deadness_witnesses(
     *,
     max_entries: int = 10,
 ) -> list[str]:
-    check_deadline()
-    if not entries:
-        return []
-    lines: list[str] = []
-    for entry in entries[:max_entries]:
-        check_deadline()
-        path = entry.get("path", "?")
-        function = entry.get("function", "?")
-        bundle = entry.get("bundle", [])
-        predicate = entry.get("predicate", "")
-        environment = entry.get("environment", {})
-        result = entry.get("result", "UNKNOWN")
-        core = entry.get("core", [])
-        core_count = len(core) if isinstance(core, list) else 0
-        lines.append(
-            f"{path}:{function} bundle {bundle} result={result} "
-            f"predicate={predicate} env={environment} core={core_count}"
-        )
-    if len(entries) > max_entries:
-        lines.append(f"... {len(entries) - max_entries} more")
-    return lines
+    return _ds_summarize_deadness_witnesses(
+        entries,
+        max_entries=max_entries,
+        check_deadline=check_deadline,
+    )
 
 
 def _compute_fingerprint_coherence(
@@ -3299,53 +3306,11 @@ def _compute_fingerprint_coherence(
     *,
     synth_version: str,
 ) -> list[JSONObject]:
-    check_deadline()
-    witnesses: list[JSONObject] = []
-    for entry in entries:
-        check_deadline()
-        matches = entry.get("glossary_matches") or []
-        if not isinstance(matches, list) or len(matches) < 2:
-            continue
-        path = entry.get("path")
-        function = entry.get("function")
-        bundle = entry.get("bundle")
-        provenance_id = entry.get("provenance_id")
-        base_keys = entry.get("base_keys") or []
-        ctor_keys = entry.get("ctor_keys") or []
-        bundle_key = ",".join(bundle or [])
-        witnesses.append(
-            {
-                "coherence_id": f"{path}:{function}:{bundle_key}:glossary-ambiguity",
-                "site": {
-                    "path": path,
-                    "function": function,
-                    "bundle": bundle,
-                },
-                "boundary": {
-                    "base_keys": base_keys,
-                    "ctor_keys": ctor_keys,
-                    "synth_version": synth_version,
-                },
-                "alternatives": ordered_or_sorted(
-                    set(str(m) for m in matches),
-                    source="_compute_fingerprint_coherence.alternatives",
-                ),
-                "fork_signature": "glossary-ambiguity",
-                "frack_path": ["provenance", "glossary"],
-                "result": "UNKNOWN",
-                "remainder": {"glossary_matches": matches},
-                "provenance_id": provenance_id,
-            }
-        )
-    return ordered_or_sorted(
-        witnesses,
-        source="_compute_fingerprint_coherence.witnesses",
-        key=lambda entry: (
-            str(entry.get("site", {}).get("path", "")),
-            str(entry.get("site", {}).get("function", "")),
-            ",".join(entry.get("site", {}).get("bundle", []) or []),
-            str(entry.get("fork_signature", "")),
-        ),
+    return _ds_compute_fingerprint_coherence(
+        entries,
+        synth_version=synth_version,
+        check_deadline=check_deadline,
+        ordered_or_sorted=ordered_or_sorted,
     )
 
 
@@ -3354,26 +3319,11 @@ def _summarize_coherence_witnesses(
     *,
     max_entries: int = 10,
 ) -> list[str]:
-    check_deadline()
-    if not entries:
-        return []
-    lines: list[str] = []
-    for entry in entries[:max_entries]:
-        check_deadline()
-        site = entry.get("site", {})
-        path = site.get("path", "?")
-        function = site.get("function", "?")
-        bundle = site.get("bundle", [])
-        result = entry.get("result", "UNKNOWN")
-        fork_signature = entry.get("fork_signature", "")
-        alternatives = entry.get("alternatives", [])
-        lines.append(
-            f"{path}:{function} bundle {bundle} result={result} "
-            f"fork={fork_signature} alternatives={alternatives}"
-        )
-    if len(entries) > max_entries:
-        lines.append(f"... {len(entries) - max_entries} more")
-    return lines
+    return _ds_summarize_coherence_witnesses(
+        entries,
+        max_entries=max_entries,
+        check_deadline=check_deadline,
+    )
 
 
 def _compute_fingerprint_rewrite_plans(
@@ -3383,146 +3333,15 @@ def _compute_fingerprint_rewrite_plans(
     synth_version: str,
     exception_obligations: list[JSONObject] | None = None,
 ) -> list[JSONObject]:
-    check_deadline()
-    coherence_map: dict[tuple[str, str, str], JSONObject] = {}
-    for entry in coherence:
-        check_deadline()
-        raw_site = entry.get("site", {}) or {}
-        site = Site.from_payload(raw_site)
-        if site is None:
-            continue
-        coherence_map[site.key()] = entry
-
-    include_exception_predicates = exception_obligations is not None
-    exception_summary_map: dict[tuple[str, str, str], dict[str, int]] = {}
-    if exception_obligations is not None:
-        for entry in exception_obligations:
-            check_deadline()
-            raw_site = entry.get("site", {}) or {}
-            site = Site.from_payload(raw_site)
-            if site is None:
-                continue
-            if not site.path or not site.function:
-                continue
-            summary = exception_summary_map.setdefault(
-                site.key(),
-                {"UNKNOWN": 0, "DEAD": 0, "HANDLED": 0, "total": 0},
-            )
-            status = str(entry.get("status", "UNKNOWN") or "UNKNOWN")
-            if status not in {"UNKNOWN", "DEAD", "HANDLED"}:
-                status = "UNKNOWN"
-            summary[status] += 1
-            summary["total"] += 1
-
-    plans: list[JSONObject] = []
-    for entry in provenance:
-        check_deadline()
-        matches = entry.get("glossary_matches") or []
-        if not isinstance(matches, list) or len(matches) < 2:
-            continue
-        site = Site.from_payload(entry)
-        if site is None or not site.path or not site.function:
-            continue
-        bundle_key = site.bundle_key()
-        coherence_entry = coherence_map.get(site.key())
-        coherence_id = None
-        if coherence_entry:
-            coherence_id = coherence_entry.get("coherence_id")
-        plan_id = f"rewrite:{site.path}:{site.function}:{bundle_key}:glossary-ambiguity"
-        candidates = ordered_or_sorted(
-            set(str(m) for m in matches),
-            source="_compute_fingerprint_rewrite_plans.candidates",
-        )
-        pre_exception_summary: dict[str, int] | None = None
-        if include_exception_predicates:
-            pre_exception_summary = exception_summary_map.get(
-                site.key(),
-                {"UNKNOWN": 0, "DEAD": 0, "HANDLED": 0, "total": 0},
-            )
-        plans.append(
-            {
-                "plan_id": plan_id,
-                "status": "UNVERIFIED",
-                "site": {
-                    "path": site.path,
-                    "function": site.function,
-                    "bundle": list(site.bundle),
-                },
-                "pre": {
-                    "base_keys": entry.get("base_keys") or [],
-                    "ctor_keys": entry.get("ctor_keys") or [],
-                    "glossary_matches": matches,
-                    "remainder": entry.get("remainder") or {},
-                    "synth_version": synth_version,
-                    **(
-                        {"exception_obligations_summary": pre_exception_summary}
-                        if pre_exception_summary is not None
-                        else {}
-                    ),
-                },
-                "rewrite": {
-                    "kind": "BUNDLE_ALIGN",
-                    "selector": {"bundle": list(site.bundle)},
-                    "parameters": {"candidates": candidates},
-                },
-                "evidence": {
-                    "provenance_id": entry.get("provenance_id"),
-                    "coherence_id": coherence_id,
-                },
-                "post_expectation": {
-                    "match_strata": "exact",
-                    "base_conservation": True,
-                    "ctor_coherence": True,
-                },
-                "verification": {
-                    "mode": "re-audit",
-                    "status": "UNVERIFIED",
-                    # Minimal executable predicate set (see in/in-26.md §6).
-                    # The evaluator (`verify_rewrite_plan`) intentionally treats transport
-                    # details as erased; only the semantic payloads matter.
-                    "predicates": [
-                        {
-                            "kind": "base_conservation",
-                            "expect": True,
-                        },
-                        {
-                            "kind": "ctor_coherence",
-                            "expect": True,
-                        },
-                        {
-                            "kind": "match_strata",
-                            "expect": "exact",
-                            "candidates": candidates,
-                        },
-                        {
-                            "kind": "remainder_non_regression",
-                            "expect": "no-new-remainder",
-                        },
-                        *(
-                            [
-                                {
-                                    "kind": "exception_obligation_non_regression",
-                                    "expect": "XV1",
-                                }
-                            ]
-                            if include_exception_predicates
-                            else []
-                        ),
-                    ],
-                },
-            }
-        )
-    return ordered_or_sorted(
-        plans,
-        source="_compute_fingerprint_rewrite_plans.plans",
-        key=lambda plan: (
-            str(plan.get("site", {}).get("path", "")),
-            str(plan.get("site", {}).get("function", "")),
-            ",".join(plan.get("site", {}).get("bundle", []) or []),
-            str(plan.get("plan_id", "")),
-        ),
+    return _ds_compute_fingerprint_rewrite_plans(
+        provenance,
+        coherence,
+        synth_version=synth_version,
+        exception_obligations=exception_obligations,
+        check_deadline=check_deadline,
+        ordered_or_sorted=ordered_or_sorted,
+        site_from_payload=Site.from_payload,
     )
-
 
 def _glossary_match_strata(matches: object) -> str:
     if not isinstance(matches, list) or not matches:
@@ -3802,26 +3621,11 @@ def _summarize_rewrite_plans(
     *,
     max_entries: int = 10,
 ) -> list[str]:
-    check_deadline()
-    if not entries:
-        return []
-    lines: list[str] = []
-    for entry in entries[:max_entries]:
-        check_deadline()
-        plan_id = entry.get("plan_id", "?")
-        site = entry.get("site", {})
-        path = site.get("path", "?")
-        function = site.get("function", "?")
-        bundle = site.get("bundle", [])
-        kind = entry.get("rewrite", {}).get("kind", "?")
-        status = entry.get("status", "UNVERIFIED")
-        lines.append(
-            f"{plan_id} {path}:{function} bundle={bundle} kind={kind} status={status}"
-        )
-    if len(entries) > max_entries:
-        lines.append(f"... {len(entries) - max_entries} more")
-    return lines
-
+    return _ds_summarize_rewrite_plans(
+        entries,
+        max_entries=max_entries,
+        check_deadline=check_deadline,
+    )
 
 def _enclosing_function_node(
     node: ast.AST, parents: dict[ast.AST, ast.AST]
@@ -3837,27 +3641,10 @@ def _enclosing_function_node(
 
 
 def _exception_param_names(expr: ast.AST | None, params: set[str]) -> list[str]:
-    check_deadline()
-    if expr is None:
-        return []
-    names: set[str] = set()
-    for node in ast.walk(expr):
-        check_deadline()
-        if isinstance(node, ast.Name) and node.id in params:
-            names.add(node.id)
-    return ordered_or_sorted(
-        names,
-        source="_exception_param_names.names",
-    )
-
+    return _exc_exception_param_names(expr, params, check_deadline=check_deadline)
 
 def _exception_type_name(expr: ast.AST | None) -> str | None:
-    if expr is None:
-        return None
-    if isinstance(expr, ast.Call):
-        return _decorator_name(expr.func)
-    return _decorator_name(expr)
-
+    return _exc_exception_type_name(expr, decorator_name=_decorator_name)
 
 def _exception_path_id(
     *,
@@ -3872,36 +3659,13 @@ def _exception_path_id(
 
 
 def _handler_is_broad(handler: ast.ExceptHandler) -> bool:
-    if handler.type is None:
-        return True
-    if isinstance(handler.type, ast.Name):
-        return handler.type.id in {"Exception", "BaseException"}
-    if isinstance(handler.type, ast.Attribute):
-        return handler.type.attr in {"Exception", "BaseException"}
-    return False
-
+    return _exc_handler_is_broad(handler)
 
 def _handler_label(handler: ast.ExceptHandler) -> str:
-    if handler.type is None:
-        return "except:"
-    try:
-        return f"except {ast.unparse(handler.type)}"
-    except _AST_UNPARSE_ERROR_TYPES:
-        return "except <unknown>"
-
+    return _exc_handler_label(handler)
 
 def _node_in_try_body(node: ast.AST, try_node: ast.Try) -> bool:
-    check_deadline()
-    for stmt in try_node.body:
-        check_deadline()
-        if node is stmt:
-            return True
-        for child in ast.walk(stmt):
-            check_deadline()
-            if node is child:
-                return True
-    return False
-
+    return _exc_node_in_try_body(node, try_node, check_deadline=check_deadline)
 
 def _find_handling_try(
     node: ast.AST, parents: dict[ast.AST, ast.AST]
@@ -7010,20 +6774,7 @@ def _exception_protocol_evidence(entries: list[JSONObject]) -> list[str]:
 
 
 def _parse_lint_location(line: str) -> tuple[str, int, int, str] | None:
-    match = re.match(r"^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)", line)
-    if not match:
-        return None
-    path = match.group("path")
-    lineno = int(match.group("line"))
-    col = int(match.group("col"))
-    remainder = line[match.end() :].lstrip(": ").strip()
-    if remainder.startswith("-"):
-        trimmed = remainder[1:]
-        range_match = re.match(r"^(\d+):(\d+)(:)?\s*", trimmed)
-        if range_match:
-            remainder = trimmed[range_match.end() :].strip()
-    return path, lineno, col, remainder
-
+    return _ds_parse_lint_location(line)
 
 def _lint_line(path: str, line: int, col: int, code: str, message: str) -> str:
     return f"{path}:{line}:{col}: {code} {message}".strip()
@@ -8219,32 +7970,18 @@ def _emit_call_ambiguities(
 
 
 def _lint_lines_from_bundle_evidence(evidence: Iterable[str]) -> list[str]:
-    check_deadline()
-    lines: list[str] = []
-    for entry in evidence:
-        check_deadline()
-        parsed = _parse_lint_location(entry)
-        if not parsed:
-            continue
-        path, lineno, col, remainder = parsed
-        message = remainder or "undocumented bundle"
-        lines.append(_lint_line(path, lineno, col, "GABION_BUNDLE_UNDOC", message))
-    return lines
-
+    return _ds_lint_lines_from_bundle_evidence(
+        evidence,
+        check_deadline=check_deadline,
+        lint_line=_lint_line,
+    )
 
 def _lint_lines_from_type_evidence(evidence: Iterable[str]) -> list[str]:
-    check_deadline()
-    lines: list[str] = []
-    for entry in evidence:
-        check_deadline()
-        parsed = _parse_lint_location(entry)
-        if not parsed:
-            continue
-        path, lineno, col, remainder = parsed
-        message = remainder or "type-flow evidence"
-        lines.append(_lint_line(path, lineno, col, "GABION_TYPE_FLOW", message))
-    return lines
-
+    return _ds_lint_lines_from_type_evidence(
+        evidence,
+        check_deadline=check_deadline,
+        lint_line=_lint_line,
+    )
 
 def _lint_lines_from_call_ambiguities(entries: Iterable[JSONObject]) -> list[str]:
     check_deadline()
@@ -8272,42 +8009,21 @@ def _lint_lines_from_call_ambiguities(entries: Iterable[JSONObject]) -> list[str
 
 
 def _lint_lines_from_unused_arg_smells(smells: Iterable[str]) -> list[str]:
-    check_deadline()
-    lines: list[str] = []
-    for entry in smells:
-        check_deadline()
-        parsed = _parse_lint_location(entry)
-        if not parsed:
-            continue
-        path, lineno, col, remainder = parsed
-        message = remainder or "unused argument flow"
-        lines.append(_lint_line(path, lineno, col, "GABION_UNUSED_ARG", message))
-    return lines
-
+    return _ds_lint_lines_from_unused_arg_smells(
+        smells,
+        check_deadline=check_deadline,
+        lint_line=_lint_line,
+    )
 
 def _extract_smell_sample(entry: str) -> str | None:
-    match = re.search(r"\(e\.g\.\s*([^)]+)\)", entry)
-    if not match:
-        return None
-    return match.group(1).strip()
-
+    return _ds_extract_smell_sample(entry)
 
 def _lint_lines_from_constant_smells(smells: Iterable[str]) -> list[str]:
-    check_deadline()
-    lines: list[str] = []
-    for entry in smells:
-        check_deadline()
-        parsed = _parse_lint_location(entry)
-        if not parsed:
-            sample = _extract_smell_sample(entry)
-            if sample:
-                parsed = _parse_lint_location(sample)
-        if not parsed:
-            continue
-        path, lineno, col, _ = parsed
-        lines.append(_lint_line(path, lineno, col, "GABION_CONST_FLOW", entry))
-    return lines
-
+    return _ds_lint_lines_from_constant_smells(
+        smells,
+        check_deadline=check_deadline,
+        lint_line=_lint_line,
+    )
 
 def _parse_exception_path_id(value: str) -> tuple[str, int, int] | None:
     parts = value.split(":", 5)
@@ -14585,55 +14301,7 @@ def build_synthesis_plan(
 
 
 def render_synthesis_section(plan: JSONObject) -> str:
-    check_deadline()
-    protocols = plan.get("protocols", [])
-    warnings = plan.get("warnings", [])
-    errors = plan.get("errors", [])
-    lines = ["", "## Synthesis plan (prototype)", ""]
-    if not protocols:
-        lines.append("No protocol candidates.")
-    else:
-        evidence_counts: Counter[str] = Counter()
-        for spec in protocols:
-            check_deadline()
-            name = spec.get("name", "Bundle")
-            tier = spec.get("tier", "?")
-            fields = spec.get("fields", [])
-            parts = []
-            for field in fields:
-                check_deadline()
-                fname = field.get("name", "")
-                type_hint = field.get("type_hint") or "Any"
-                if fname:
-                    parts.append(f"{fname}: {type_hint}")
-            field_list = ", ".join(parts) if parts else "(no fields)"
-            evidence = spec.get("evidence", [])
-            if evidence:
-                evidence_str = ", ".join(sorted(evidence))
-                lines.append(f"- {name} (tier {tier}; evidence: {evidence_str}): {field_list}")
-                evidence_counts.update(evidence)
-            else:
-                lines.append(f"- {name} (tier {tier}): {field_list}")
-        if evidence_counts:
-            summary = ", ".join(
-                f"{key}={count}" for key, count in evidence_counts.most_common()
-            )
-            lines.append("")
-            lines.append(f"Evidence summary: {summary}")
-    if warnings:
-        lines.append("")
-        lines.append("Warnings:")
-        lines.append("```")
-        lines.extend(str(w) for w in warnings)
-        lines.append("```")
-    if errors:
-        lines.append("")
-        lines.append("Errors:")
-        lines.append("```")
-        lines.extend(str(e) for e in errors)
-        lines.append("```")
-    return "\n".join(lines)
-
+    return _report_render_synthesis_section(plan, check_deadline=check_deadline)
 
 def render_protocol_stubs(plan: JSONObject, kind: str = "dataclass") -> str:
     check_deadline()

--- a/src/gabion/analysis/dataflow_decision_surfaces.py
+++ b/src/gabion/analysis/dataflow_decision_surfaces.py
@@ -1,0 +1,392 @@
+"""Decision-surface helpers extracted from ``dataflow_audit``.
+
+These helpers are intentionally dependency-light and receive runtime hooks
+(deadline checks, sorting, and payload conversion) from the caller so
+``dataflow_audit`` can keep stable public façades while internal call sites
+migrate incrementally.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+import re
+
+from gabion.analysis.json_types import JSONObject
+
+
+def summarize_deadness_witnesses(
+    entries: list[JSONObject],
+    *,
+    max_entries: int = 10,
+    check_deadline: Callable[[], None],
+) -> list[str]:
+    check_deadline()
+    if not entries:
+        return []
+    lines: list[str] = []
+    for entry in entries[:max_entries]:
+        check_deadline()
+        path = entry.get("path", "?")
+        function = entry.get("function", "?")
+        bundle = entry.get("bundle", [])
+        predicate = entry.get("predicate", "")
+        environment = entry.get("environment", {})
+        result = entry.get("result", "UNKNOWN")
+        core = entry.get("core", [])
+        core_count = len(core) if isinstance(core, list) else 0
+        lines.append(
+            f"{path}:{function} bundle {bundle} result={result} "
+            f"predicate={predicate} env={environment} core={core_count}"
+        )
+    if len(entries) > max_entries:
+        lines.append(f"... {len(entries) - max_entries} more")
+    return lines
+
+
+def compute_fingerprint_coherence(
+    entries: list[JSONObject],
+    *,
+    synth_version: str,
+    check_deadline: Callable[[], None],
+    ordered_or_sorted: Callable[..., list],
+) -> list[JSONObject]:
+    check_deadline()
+    witnesses: list[JSONObject] = []
+    for entry in entries:
+        check_deadline()
+        matches = entry.get("glossary_matches") or []
+        if not isinstance(matches, list) or len(matches) < 2:
+            continue
+        path = entry.get("path")
+        function = entry.get("function")
+        bundle = entry.get("bundle")
+        provenance_id = entry.get("provenance_id")
+        base_keys = entry.get("base_keys") or []
+        ctor_keys = entry.get("ctor_keys") or []
+        bundle_key = ",".join(bundle or [])
+        witnesses.append(
+            {
+                "coherence_id": f"{path}:{function}:{bundle_key}:glossary-ambiguity",
+                "site": {
+                    "path": path,
+                    "function": function,
+                    "bundle": bundle,
+                },
+                "boundary": {
+                    "base_keys": base_keys,
+                    "ctor_keys": ctor_keys,
+                    "synth_version": synth_version,
+                },
+                "alternatives": ordered_or_sorted(
+                    set(str(m) for m in matches),
+                    source="_compute_fingerprint_coherence.alternatives",
+                ),
+                "fork_signature": "glossary-ambiguity",
+                "frack_path": ["provenance", "glossary"],
+                "result": "UNKNOWN",
+                "remainder": {"glossary_matches": matches},
+                "provenance_id": provenance_id,
+            }
+        )
+    return ordered_or_sorted(
+        witnesses,
+        source="_compute_fingerprint_coherence.witnesses",
+        key=lambda entry: (
+            str(entry.get("site", {}).get("path", "")),
+            str(entry.get("site", {}).get("function", "")),
+            ",".join(entry.get("site", {}).get("bundle", []) or []),
+            str(entry.get("fork_signature", "")),
+        ),
+    )
+
+
+def summarize_coherence_witnesses(
+    entries: list[JSONObject],
+    *,
+    max_entries: int = 10,
+    check_deadline: Callable[[], None],
+) -> list[str]:
+    check_deadline()
+    if not entries:
+        return []
+    lines: list[str] = []
+    for entry in entries[:max_entries]:
+        check_deadline()
+        site = entry.get("site", {})
+        path = site.get("path", "?")
+        function = site.get("function", "?")
+        bundle = site.get("bundle", [])
+        result = entry.get("result", "UNKNOWN")
+        fork_signature = entry.get("fork_signature", "")
+        alternatives = entry.get("alternatives", [])
+        lines.append(
+            f"{path}:{function} bundle {bundle} result={result} "
+            f"fork={fork_signature} alternatives={alternatives}"
+        )
+    if len(entries) > max_entries:
+        lines.append(f"... {len(entries) - max_entries} more")
+    return lines
+
+
+def compute_fingerprint_rewrite_plans(
+    provenance: list[JSONObject],
+    coherence: list[JSONObject],
+    *,
+    synth_version: str,
+    exception_obligations: list[JSONObject] | None,
+    check_deadline: Callable[[], None],
+    ordered_or_sorted: Callable[..., list],
+    site_from_payload: Callable[[JSONObject], object | None],
+) -> list[JSONObject]:
+    check_deadline()
+    coherence_map: dict[tuple[str, str, str], JSONObject] = {}
+    for entry in coherence:
+        check_deadline()
+        raw_site = entry.get("site", {}) or {}
+        site = site_from_payload(raw_site)
+        if site is None:
+            continue
+        coherence_map[site.key()] = entry
+
+    include_exception_predicates = exception_obligations is not None
+    exception_summary_map: dict[tuple[str, str, str], dict[str, int]] = {}
+    if exception_obligations is not None:
+        for entry in exception_obligations:
+            check_deadline()
+            raw_site = entry.get("site", {}) or {}
+            site = site_from_payload(raw_site)
+            if site is None:
+                continue
+            if not site.path or not site.function:
+                continue
+            summary = exception_summary_map.setdefault(
+                site.key(),
+                {"UNKNOWN": 0, "DEAD": 0, "HANDLED": 0, "total": 0},
+            )
+            status = str(entry.get("status", "UNKNOWN") or "UNKNOWN")
+            if status not in {"UNKNOWN", "DEAD", "HANDLED"}:
+                status = "UNKNOWN"
+            summary[status] += 1
+            summary["total"] += 1
+
+    plans: list[JSONObject] = []
+    for entry in provenance:
+        check_deadline()
+        matches = entry.get("glossary_matches") or []
+        if not isinstance(matches, list) or len(matches) < 2:
+            continue
+        site = site_from_payload(entry)
+        if site is None or not site.path or not site.function:
+            continue
+        bundle_key = site.bundle_key()
+        coherence_entry = coherence_map.get(site.key())
+        coherence_id = coherence_entry.get("coherence_id") if coherence_entry else None
+        plan_id = f"rewrite:{site.path}:{site.function}:{bundle_key}:glossary-ambiguity"
+        candidates = ordered_or_sorted(
+            set(str(m) for m in matches),
+            source="_compute_fingerprint_rewrite_plans.candidates",
+        )
+        pre_exception_summary: dict[str, int] | None = None
+        if include_exception_predicates:
+            pre_exception_summary = exception_summary_map.get(
+                site.key(),
+                {"UNKNOWN": 0, "DEAD": 0, "HANDLED": 0, "total": 0},
+            )
+        plans.append(
+            {
+                "plan_id": plan_id,
+                "status": "UNVERIFIED",
+                "site": {
+                    "path": site.path,
+                    "function": site.function,
+                    "bundle": list(site.bundle),
+                },
+                "pre": {
+                    "base_keys": entry.get("base_keys") or [],
+                    "ctor_keys": entry.get("ctor_keys") or [],
+                    "glossary_matches": matches,
+                    "remainder": entry.get("remainder") or {},
+                    "synth_version": synth_version,
+                    **(
+                        {"exception_obligations_summary": pre_exception_summary}
+                        if pre_exception_summary is not None
+                        else {}
+                    ),
+                },
+                "rewrite": {
+                    "kind": "BUNDLE_ALIGN",
+                    "selector": {"bundle": list(site.bundle)},
+                    "parameters": {"candidates": candidates},
+                },
+                "evidence": {
+                    "provenance_id": entry.get("provenance_id"),
+                    "coherence_id": coherence_id,
+                },
+                "post_expectation": {
+                    "match_strata": "exact",
+                    "base_conservation": True,
+                    "ctor_coherence": True,
+                },
+                "verification": {
+                    "mode": "re-audit",
+                    "status": "UNVERIFIED",
+                    "predicates": [
+                        {"kind": "base_conservation", "expect": True},
+                        {"kind": "ctor_coherence", "expect": True},
+                        {
+                            "kind": "match_strata",
+                            "expect": "exact",
+                            "candidates": candidates,
+                        },
+                        {
+                            "kind": "remainder_non_regression",
+                            "expect": "no-new-remainder",
+                        },
+                        *(
+                            [
+                                {
+                                    "kind": "exception_obligation_non_regression",
+                                    "expect": "XV1",
+                                }
+                            ]
+                            if include_exception_predicates
+                            else []
+                        ),
+                    ],
+                },
+            }
+        )
+    return ordered_or_sorted(
+        plans,
+        source="_compute_fingerprint_rewrite_plans.plans",
+        key=lambda entry: str(entry.get("plan_id", "")),
+    )
+
+
+def summarize_rewrite_plans(
+    entries: list[JSONObject],
+    *,
+    max_entries: int = 10,
+    check_deadline: Callable[[], None],
+) -> list[str]:
+    check_deadline()
+    if not entries:
+        return []
+    lines: list[str] = []
+    for entry in entries[:max_entries]:
+        check_deadline()
+        plan_id = entry.get("plan_id", "?")
+        site = entry.get("site", {})
+        path = site.get("path", "?")
+        function = site.get("function", "?")
+        bundle = site.get("bundle", [])
+        kind = entry.get("rewrite", {}).get("kind", "?")
+        status = entry.get("status", "UNVERIFIED")
+        lines.append(
+            f"{plan_id} {path}:{function} bundle={bundle} kind={kind} status={status}"
+        )
+    if len(entries) > max_entries:
+        lines.append(f"... {len(entries) - max_entries} more")
+    return lines
+
+
+def parse_lint_location(line: str) -> tuple[str, int, int, str] | None:
+    match = re.match(r"^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)", line)
+    if not match:
+        return None
+    path = match.group("path")
+    lineno = int(match.group("line"))
+    col = int(match.group("col"))
+    remainder = line[match.end() :].lstrip(": ").strip()
+    if remainder.startswith("-"):
+        trimmed = remainder[1:]
+        range_match = re.match(r"^(\d+):(\d+)(:)?\s*", trimmed)
+        if range_match:
+            remainder = trimmed[range_match.end() :].strip()
+    return path, lineno, col, remainder
+
+
+def lint_lines_from_bundle_evidence(
+    evidence: Iterable[str],
+    *,
+    check_deadline: Callable[[], None],
+    lint_line: Callable[[str, int, int, str, str], str],
+) -> list[str]:
+    check_deadline()
+    lines: list[str] = []
+    for entry in evidence:
+        check_deadline()
+        parsed = parse_lint_location(entry)
+        if not parsed:
+            continue
+        path, lineno, col, remainder = parsed
+        message = remainder or "undocumented bundle"
+        lines.append(lint_line(path, lineno, col, "GABION_BUNDLE_UNDOC", message))
+    return lines
+
+
+def lint_lines_from_type_evidence(
+    evidence: Iterable[str],
+    *,
+    check_deadline: Callable[[], None],
+    lint_line: Callable[[str, int, int, str, str], str],
+) -> list[str]:
+    check_deadline()
+    lines: list[str] = []
+    for entry in evidence:
+        check_deadline()
+        parsed = parse_lint_location(entry)
+        if not parsed:
+            continue
+        path, lineno, col, remainder = parsed
+        message = remainder or "type-flow evidence"
+        lines.append(lint_line(path, lineno, col, "GABION_TYPE_FLOW", message))
+    return lines
+
+
+def lint_lines_from_unused_arg_smells(
+    smells: Iterable[str],
+    *,
+    check_deadline: Callable[[], None],
+    lint_line: Callable[[str, int, int, str, str], str],
+) -> list[str]:
+    check_deadline()
+    lines: list[str] = []
+    for entry in smells:
+        check_deadline()
+        parsed = parse_lint_location(entry)
+        if not parsed:
+            continue
+        path, lineno, col, remainder = parsed
+        message = remainder or "unused argument flow"
+        lines.append(lint_line(path, lineno, col, "GABION_UNUSED_ARG", message))
+    return lines
+
+
+def extract_smell_sample(entry: str) -> str | None:
+    match = re.search(r"\(e\.g\.\s*([^)]+)\)", entry)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def lint_lines_from_constant_smells(
+    smells: Iterable[str],
+    *,
+    check_deadline: Callable[[], None],
+    lint_line: Callable[[str, int, int, str, str], str],
+) -> list[str]:
+    check_deadline()
+    lines: list[str] = []
+    for entry in smells:
+        check_deadline()
+        parsed = parse_lint_location(entry)
+        if not parsed:
+            sample = extract_smell_sample(entry)
+            if sample:
+                parsed = parse_lint_location(sample)
+        if not parsed:
+            continue
+        path, lineno, col, _ = parsed
+        lines.append(lint_line(path, lineno, col, "GABION_CONST_FLOW", entry))
+    return lines

--- a/src/gabion/analysis/dataflow_exception_obligations.py
+++ b/src/gabion/analysis/dataflow_exception_obligations.py
@@ -1,0 +1,81 @@
+"""Exception-obligation helpers extracted from ``dataflow_audit``."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+
+from gabion.order_contract import ordered_or_sorted
+
+_AST_UNPARSE_ERROR_TYPES = (
+    AttributeError,
+    TypeError,
+    ValueError,
+    RecursionError,
+)
+
+
+def exception_param_names(
+    expr: ast.AST | None,
+    params: set[str],
+    *,
+    check_deadline: Callable[[], None],
+) -> list[str]:
+    check_deadline()
+    if expr is None:
+        return []
+    names: set[str] = set()
+    for node in ast.walk(expr):
+        check_deadline()
+        if isinstance(node, ast.Name) and node.id in params:
+            names.add(node.id)
+    return ordered_or_sorted(names, source="_exception_param_names.names")
+
+
+def exception_type_name(
+    expr: ast.AST | None,
+    *,
+    decorator_name: Callable[[ast.AST], str | None],
+) -> str | None:
+    if expr is None:
+        return None
+    if isinstance(expr, ast.Call):
+        return decorator_name(expr.func)
+    return decorator_name(expr)
+
+
+def handler_is_broad(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:
+        return True
+    if isinstance(handler.type, ast.Name):
+        return handler.type.id in {"Exception", "BaseException"}
+    if isinstance(handler.type, ast.Attribute):
+        return handler.type.attr in {"Exception", "BaseException"}
+    return False
+
+
+def handler_label(handler: ast.ExceptHandler) -> str:
+    if handler.type is None:
+        return "except:"
+    try:
+        return f"except {ast.unparse(handler.type)}"
+    except _AST_UNPARSE_ERROR_TYPES:
+        return "except <unknown>"
+
+
+def node_in_try_body(
+    node: ast.AST,
+    try_node: ast.Try,
+    *,
+    check_deadline: Callable[[], None],
+) -> bool:
+    check_deadline()
+    for stmt in try_node.body:
+        check_deadline()
+        if node is stmt:
+            return True
+        for child in ast.walk(stmt):
+            check_deadline()
+            if node is child:
+                return True
+    return False

--- a/src/gabion/analysis/dataflow_report_rendering.py
+++ b/src/gabion/analysis/dataflow_report_rendering.py
@@ -1,0 +1,63 @@
+"""Rendering adapters extracted from ``dataflow_audit``."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+from gabion.analysis.json_types import JSONObject
+
+
+def render_synthesis_section(
+    plan: JSONObject,
+    *,
+    check_deadline: Callable[[], None],
+) -> str:
+    check_deadline()
+    protocols = plan.get("protocols", [])
+    warnings = plan.get("warnings", [])
+    errors = plan.get("errors", [])
+    lines = ["", "## Synthesis plan (prototype)", ""]
+    if not protocols:
+        lines.append("No protocol candidates.")
+    else:
+        evidence_counts: Counter[str] = Counter()
+        for spec in protocols:
+            check_deadline()
+            name = spec.get("name", "Bundle")
+            tier = spec.get("tier", "?")
+            fields = spec.get("fields", [])
+            parts = []
+            for field in fields:
+                check_deadline()
+                fname = field.get("name", "")
+                type_hint = field.get("type_hint") or "Any"
+                if fname:
+                    parts.append(f"{fname}: {type_hint}")
+            field_list = ", ".join(parts) if parts else "(no fields)"
+            evidence = spec.get("evidence", [])
+            if evidence:
+                evidence_str = ", ".join(sorted(evidence))
+                lines.append(f"- {name} (tier {tier}; evidence: {evidence_str}): {field_list}")
+                evidence_counts.update(evidence)
+            else:
+                lines.append(f"- {name} (tier {tier}): {field_list}")
+        if evidence_counts:
+            summary = ", ".join(
+                f"{key}={count}" for key, count in evidence_counts.most_common()
+            )
+            lines.append("")
+            lines.append(f"Evidence summary: {summary}")
+    if warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        lines.append("```")
+        lines.extend(str(w) for w in warnings)
+        lines.append("```")
+    if errors:
+        lines.append("")
+        lines.append("Errors:")
+        lines.append("```")
+        lines.extend(str(e) for e in errors)
+        lines.append("```")
+    return "\n".join(lines)

--- a/tests/test_dataflow_decision_surfaces_module.py
+++ b/tests/test_dataflow_decision_surfaces_module.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from gabion.analysis.dataflow_decision_surfaces import (
+    compute_fingerprint_coherence,
+    compute_fingerprint_rewrite_plans,
+    extract_smell_sample,
+    lint_lines_from_bundle_evidence,
+    lint_lines_from_constant_smells,
+    lint_lines_from_type_evidence,
+    lint_lines_from_unused_arg_smells,
+    parse_lint_location,
+    summarize_coherence_witnesses,
+    summarize_deadness_witnesses,
+    summarize_rewrite_plans,
+)
+from gabion.analysis.evidence import Site
+from gabion.order_contract import ordered_or_sorted
+
+
+def _check_deadline() -> None:
+    return None
+
+
+def _lint_line(path: str, line: int, col: int, code: str, message: str) -> str:
+    return f"{path}:{line}:{col}: {code} {message}".strip()
+
+
+def test_decision_surface_summaries_and_plans_cover_edges() -> None:
+    assert summarize_deadness_witnesses([], check_deadline=_check_deadline) == []
+    lines = summarize_deadness_witnesses(
+        [
+            {
+                "path": "a.py",
+                "function": "f",
+                "bundle": ["a"],
+                "predicate": "P",
+                "environment": {},
+                "result": "UNKNOWN",
+                "core": [],
+            }
+            for _ in range(12)
+        ],
+        max_entries=10,
+        check_deadline=_check_deadline,
+    )
+    assert any("... 2 more" in line for line in lines)
+
+    coherence = compute_fingerprint_coherence(
+        [
+            {
+                "path": "a.py",
+                "function": "f",
+                "bundle": ["a", "b"],
+                "provenance_id": "prov:a.py:f:a,b",
+                "base_keys": ["int", "str"],
+                "ctor_keys": [],
+                "glossary_matches": ["ctx_a", "ctx_b"],
+            }
+        ],
+        synth_version="synth@1",
+        check_deadline=_check_deadline,
+        ordered_or_sorted=ordered_or_sorted,
+    )
+    assert coherence
+    assert summarize_coherence_witnesses([], check_deadline=_check_deadline) == []
+
+    plans = compute_fingerprint_rewrite_plans(
+        [
+            {
+                "path": "a.py",
+                "function": "f",
+                "bundle": ["a", "b"],
+                "provenance_id": "prov:a.py:f:a,b",
+                "base_keys": ["int", "str"],
+                "ctor_keys": [],
+                "glossary_matches": ["ctx_a", "ctx_b"],
+            }
+        ],
+        coherence,
+        synth_version="synth@1",
+        exception_obligations=[
+            {"site": "not-a-dict"},
+            {"site": {"path": "", "function": "f", "bundle": ["a", "b"]}},
+            {
+                "site": {"path": "a.py", "function": "f", "bundle": ["a", "b"]},
+                "status": "WEIRD",
+            },
+        ],
+        check_deadline=_check_deadline,
+        ordered_or_sorted=ordered_or_sorted,
+        site_from_payload=Site.from_payload,
+    )
+    assert plans
+    assert plans[0]["pre"]["exception_obligations_summary"]["UNKNOWN"] == 1
+
+    assert summarize_rewrite_plans([], check_deadline=_check_deadline) == []
+    rewrite_summary = summarize_rewrite_plans(
+        [
+            {
+                "plan_id": f"plan:{i}",
+                "site": {"path": "a.py", "function": "f", "bundle": ["a"]},
+                "rewrite": {"kind": "BUNDLE_ALIGN"},
+                "status": "UNVERIFIED",
+            }
+            for i in range(12)
+        ],
+        max_entries=10,
+        check_deadline=_check_deadline,
+    )
+    assert any("... 2 more" in line for line in rewrite_summary)
+
+
+def test_decision_surface_lint_parsing_helpers_cover_edges() -> None:
+    assert parse_lint_location("bad") is None
+    assert parse_lint_location("p:1:2:-3:4: msg") == ("p", 1, 2, "msg")
+    assert extract_smell_sample("no example") is None
+    assert extract_smell_sample("smell (e.g. p:1:2: msg)") == "p:1:2: msg"
+
+    assert lint_lines_from_bundle_evidence(["bad"], check_deadline=_check_deadline, lint_line=_lint_line) == []
+    assert lint_lines_from_type_evidence(["bad"], check_deadline=_check_deadline, lint_line=_lint_line) == []
+    assert lint_lines_from_unused_arg_smells(["bad"], check_deadline=_check_deadline, lint_line=_lint_line) == []
+    assert lint_lines_from_constant_smells(["no location"], check_deadline=_check_deadline, lint_line=_lint_line) == []
+    constant = "mod.py:f.a only observed constant 1 (e.g. mod.py:1:2: msg)"
+    assert lint_lines_from_constant_smells([constant], check_deadline=_check_deadline, lint_line=_lint_line)

--- a/tests/test_dataflow_exception_obligations_module.py
+++ b/tests/test_dataflow_exception_obligations_module.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import ast
+
+from gabion.analysis.dataflow_exception_obligations import (
+    exception_param_names,
+    exception_type_name,
+    handler_is_broad,
+    handler_label,
+    node_in_try_body,
+)
+
+
+def _check_deadline() -> None:
+    return None
+
+
+def _decorator_name(expr: ast.AST) -> str | None:
+    if isinstance(expr, ast.Name):
+        return expr.id
+    if isinstance(expr, ast.Attribute):
+        return expr.attr
+    return None
+
+
+def test_exception_obligation_module_edges() -> None:
+    assert exception_param_names(None, {"a"}, check_deadline=_check_deadline) == []
+    expr = ast.parse("a + b").body[0].value
+    assert exception_param_names(expr, {"a"}, check_deadline=_check_deadline) == ["a"]
+
+    assert exception_type_name(None, decorator_name=_decorator_name) is None
+    assert exception_type_name(ast.parse("ValueError").body[0].value, decorator_name=_decorator_name) == "ValueError"
+    assert exception_type_name(ast.parse("ValueError()") .body[0].value, decorator_name=_decorator_name) == "ValueError"
+
+    handler_any = ast.ExceptHandler(type=None, name=None, body=[])
+    assert handler_is_broad(handler_any) is True
+    assert handler_label(handler_any) == "except:"
+
+    handler_attr = ast.ExceptHandler(
+        type=ast.Attribute(
+            value=ast.Name(id="builtins", ctx=ast.Load()),
+            attr="Exception",
+            ctx=ast.Load(),
+        ),
+        name=None,
+        body=[],
+    )
+    assert handler_is_broad(handler_attr) is True
+
+    handler_weird = ast.ExceptHandler(type=object(), name=None, body=[])
+    assert handler_is_broad(handler_weird) is False
+    assert handler_label(handler_weird) == "except <unknown>"
+
+    tree = ast.parse("try:\n    foo(1)\nexcept Exception:\n    pass\n")
+    try_node = tree.body[0]
+    assert isinstance(try_node, ast.Try)
+    call_node = try_node.body[0].value
+    assert node_in_try_body(call_node, try_node, check_deadline=_check_deadline) is True
+    other_call = ast.parse("bar()").body[0].value
+    assert node_in_try_body(other_call, try_node, check_deadline=_check_deadline) is False

--- a/tests/test_dataflow_report_rendering_module.py
+++ b/tests/test_dataflow_report_rendering_module.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from gabion.analysis.dataflow_report_rendering import render_synthesis_section
+
+
+def _check_deadline() -> None:
+    return None
+
+
+def test_render_synthesis_section_module_evidence_summary_and_blank_fields() -> None:
+    plan = {
+        "protocols": [
+            {
+                "name": "Bundle",
+                "tier": 2,
+                "fields": [
+                    {"name": "a", "type_hint": "int", "source_params": ["a"]},
+                    {"name": "", "type_hint": "str", "source_params": []},
+                ],
+                "bundle": ["a"],
+                "rationale": "test",
+                "evidence": ["dataflow", "decision_surface"],
+            }
+        ],
+        "warnings": [],
+        "errors": [],
+    }
+    text = render_synthesis_section(plan, check_deadline=_check_deadline)
+    assert "evidence:" in text
+    assert "Evidence summary:" in text
+
+    blank_fields_plan = {
+        "protocols": [
+            {
+                "name": "Bundle",
+                "tier": 2,
+                "fields": [
+                    {"name": "", "type_hint": "int", "source_params": []},
+                    {"type_hint": "str", "source_params": []},
+                ],
+                "bundle": [],
+                "rationale": "test",
+                "evidence": [],
+            }
+        ],
+        "warnings": [],
+        "errors": [],
+    }
+    assert "(no fields)" in render_synthesis_section(blank_fields_plan, check_deadline=_check_deadline)


### PR DESCRIPTION
### Motivation
- Decompose the large `dataflow_audit.py` into cohesive domains (decision surfaces, exception-obligation helpers, report rendering) to improve modularity and make incremental migration safe. 
- Preserve the public API surface so external call sites and `src/gabion/analysis/__init__.py` exports remain stable while internals are moved. 
- Add small, dependency-light modules with injected runtime hooks so `dataflow_audit.py` can provide thin façades and callers can migrate gradually.

### Description
- Extracted decision-surface helpers into `src/gabion/analysis/dataflow_decision_surfaces.py` (deadness/coherence summaries, rewrite-plan construction, lint parsing, smell/lint adapters) and wired them back into `dataflow_audit.py` via façade delegates. 
- Extracted exception-obligation helpers into `src/gabion/analysis/dataflow_exception_obligations.py` (exception param extraction, exception type naming, broad-handler detection, handler labeling, try-body membership). 
- Extracted synthesis report rendering into `src/gabion/analysis/dataflow_report_rendering.py` and delegated `render_synthesis_section` in `dataflow_audit.py` to the adapter. 
- Kept the public API stable by adding thin façade functions in `src/gabion/analysis/dataflow_audit.py` that call the new modules (e.g. `_ds_compute_fingerprint_rewrite_plans`, `_exc_exception_param_names`, `_report_render_synthesis_section`), without changing the outward exports in `src/gabion/analysis/__init__.py`.
- Added unit tests that mirror the edge-case coverage previously exercised through `tests/test_dataflow_audit_coverage_gaps.py` as per-module tests: `tests/test_dataflow_decision_surfaces_module.py`, `tests/test_dataflow_exception_obligations_module.py`, and `tests/test_dataflow_report_rendering_module.py`.

### Testing
- Ran byte-compile check with `python -m py_compile src/gabion/analysis/dataflow_audit.py src/gabion/analysis/dataflow_decision_surfaces.py src/gabion/analysis/dataflow_exception_obligations.py src/gabion/analysis/dataflow_report_rendering.py`, which succeeded. 
- Executed the test subset with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_dataflow_audit_coverage_gaps.py tests/test_dataflow_decision_surfaces_module.py tests/test_dataflow_exception_obligations_module.py tests/test_dataflow_report_rendering_module.py`, and all tests passed (`107 passed`). 
- An attempt to run tests via the pinned toolchain wrapper `mise exec -- python` failed due to environment/toolchain resolution warnings (network/tool resolution), so tests were validated using the repository `PYTHONPATH` fallback and the results above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a970dad08324ada33e57c8ae8b3e)