### PR TITLE
Add configurable refactor compatibility shim support

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -660,6 +660,8 @@ def build_refactor_payload(
     target_path: Optional[Path],
     target_functions: Optional[List[str]],
     compatibility_shim: bool,
+    compatibility_shim_warnings: bool,
+    compatibility_shim_overloads: bool,
     rationale: Optional[str],
 ) -> JSONObject:
     check_deadline()
@@ -680,13 +682,22 @@ def build_refactor_payload(
         field_specs.append({"name": name, "type_hint": type_hint})
     if not bundle and field_specs:
         bundle = [spec["name"] for spec in field_specs]
+    compatibility_shim_payload: bool | dict[str, bool]
+    if compatibility_shim:
+        compatibility_shim_payload = {
+            "enabled": True,
+            "emit_deprecation_warning": compatibility_shim_warnings,
+            "emit_overload_stubs": compatibility_shim_overloads,
+        }
+    else:
+        compatibility_shim_payload = False
     return {
         "protocol_name": protocol_name,
         "bundle": bundle or [],
         "fields": field_specs,
         "target_path": str(target_path),
         "target_functions": target_functions or [],
-        "compatibility_shim": compatibility_shim,
+        "compatibility_shim": compatibility_shim_payload,
         "rationale": rationale,
     }
 
@@ -2115,6 +2126,12 @@ def refactor_protocol(
     compatibility_shim: bool = typer.Option(
         False, "--compat-shim/--no-compat-shim"
     ),
+    compatibility_shim_warnings: bool = typer.Option(
+        True, "--compat-shim-warnings/--no-compat-shim-warnings"
+    ),
+    compatibility_shim_overloads: bool = typer.Option(
+        True, "--compat-shim-overloads/--no-compat-shim-overloads"
+    ),
     rationale: Optional[str] = typer.Option(None, "--rationale"),
 ) -> None:
     """Generate protocol refactor edits from a JSON payload (prototype)."""
@@ -2128,6 +2145,8 @@ def refactor_protocol(
             target_path=target_path,
             target_functions=target_functions,
             compatibility_shim=compatibility_shim,
+            compatibility_shim_warnings=compatibility_shim_warnings,
+            compatibility_shim_overloads=compatibility_shim_overloads,
             rationale=rationale,
         )
 
@@ -2142,6 +2161,8 @@ def _run_refactor_protocol(
     target_path: Optional[Path],
     target_functions: Optional[List[str]],
     compatibility_shim: bool,
+    compatibility_shim_warnings: bool,
+    compatibility_shim_overloads: bool,
     rationale: Optional[str],
     runner: Runner = run_command,
 ) -> None:
@@ -2163,6 +2184,8 @@ def _run_refactor_protocol(
         target_path=target_path,
         target_functions=target_functions,
         compatibility_shim=compatibility_shim,
+        compatibility_shim_warnings=compatibility_shim_warnings,
+        compatibility_shim_overloads=compatibility_shim_overloads,
         rationale=rationale,
     )
     result = dispatch_command(

--- a/src/gabion/refactor/__init__.py
+++ b/src/gabion/refactor/__init__.py
@@ -1,4 +1,17 @@
 from gabion.refactor.engine import RefactorEngine
-from gabion.refactor.model import FieldSpec, RefactorPlan, RefactorRequest, TextEdit
+from gabion.refactor.model import (
+    CompatibilityShimConfig as RefactorCompatibilityShimConfig,
+    FieldSpec,
+    RefactorPlan,
+    RefactorRequest,
+    TextEdit,
+)
 
-__all__ = ["FieldSpec", "RefactorEngine", "RefactorPlan", "RefactorRequest", "TextEdit"]
+__all__ = [
+    "FieldSpec",
+    "RefactorCompatibilityShimConfig",
+    "RefactorEngine",
+    "RefactorPlan",
+    "RefactorRequest",
+    "TextEdit",
+]

--- a/src/gabion/refactor/model.py
+++ b/src/gabion/refactor/model.py
@@ -21,13 +21,30 @@ class FieldSpec:
 
 
 @dataclass(frozen=True)
+class CompatibilityShimConfig:
+    enabled: bool = True
+    emit_deprecation_warning: bool = True
+    emit_overload_stubs: bool = True
+
+
+def normalize_compatibility_shim(
+    compatibility_shim: bool | CompatibilityShimConfig,
+) -> CompatibilityShimConfig:
+    if isinstance(compatibility_shim, CompatibilityShimConfig):
+        return compatibility_shim
+    if compatibility_shim:
+        return CompatibilityShimConfig(enabled=True)
+    return CompatibilityShimConfig(enabled=False)
+
+
+@dataclass(frozen=True)
 class RefactorRequest:
     protocol_name: str
     bundle: List[str]
     target_path: str
     fields: List[FieldSpec] = field(default_factory=list)
     target_functions: List[str] = field(default_factory=list)
-    compatibility_shim: bool = False
+    compatibility_shim: bool | CompatibilityShimConfig = False
     rationale: Optional[str] = None
 
 

--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -64,13 +64,19 @@ class RefactorFieldDTO(BaseModel):
     type_hint: Optional[str] = None
 
 
+class RefactorCompatibilityShimDTO(BaseModel):
+    enabled: bool = True
+    emit_deprecation_warning: bool = True
+    emit_overload_stubs: bool = True
+
+
 class RefactorRequest(BaseModel):
     protocol_name: str
     bundle: List[str]
     fields: List[RefactorFieldDTO] = []
     target_path: str
     target_functions: List[str] = []
-    compatibility_shim: bool = False
+    compatibility_shim: bool | RefactorCompatibilityShimDTO = False
     rationale: Optional[str] = None
 
 

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -115,6 +115,7 @@ from gabion.analysis.type_fingerprints import (
 from gabion.refactor import (
     FieldSpec,
     RefactorEngine,
+    RefactorCompatibilityShimConfig,
     RefactorRequest as RefactorRequestModel,
 )
 from gabion.schema import (
@@ -4400,6 +4401,15 @@ def _execute_refactor_total(ls: LanguageServer, payload: dict[str, object]) -> d
         if ls.workspace.root_path:
             project_root = Path(ls.workspace.root_path)
         engine = RefactorEngine(project_root=project_root)
+        compatibility_shim = request.compatibility_shim
+        if isinstance(compatibility_shim, bool):
+            normalized_shim: bool | RefactorCompatibilityShimConfig = compatibility_shim
+        else:
+            normalized_shim = RefactorCompatibilityShimConfig(
+                enabled=compatibility_shim.enabled,
+                emit_deprecation_warning=compatibility_shim.emit_deprecation_warning,
+                emit_overload_stubs=compatibility_shim.emit_overload_stubs,
+            )
         plan = engine.plan_protocol_extraction(
             RefactorRequestModel(
                 protocol_name=request.protocol_name,
@@ -4410,7 +4420,7 @@ def _execute_refactor_total(ls: LanguageServer, payload: dict[str, object]) -> d
                 ],
                 target_path=request.target_path,
                 target_functions=request.target_functions,
-                compatibility_shim=request.compatibility_shim,
+                compatibility_shim=normalized_shim,
                 rationale=request.rationale,
             )
         )

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -412,6 +412,8 @@ def test_build_refactor_payload_input_payload_passthrough() -> None:
         target_path=None,
         target_functions=None,
         compatibility_shim=False,
+        compatibility_shim_warnings=True,
+        compatibility_shim_overloads=True,
         rationale=None,
     ) == payload
 
@@ -426,6 +428,8 @@ def test_build_refactor_payload_requires_fields(tmp_path: Path) -> None:
             target_path=None,
             target_functions=None,
             compatibility_shim=False,
+            compatibility_shim_warnings=True,
+            compatibility_shim_overloads=True,
             rationale=None,
         )
 
@@ -436,6 +440,8 @@ def test_build_refactor_payload_requires_fields(tmp_path: Path) -> None:
         target_path=tmp_path / "target.py",
         target_functions=None,
         compatibility_shim=False,
+        compatibility_shim_warnings=True,
+        compatibility_shim_overloads=True,
         rationale=None,
     )
     assert payload["bundle"] == ["a", "b"]
@@ -1322,6 +1328,8 @@ def test_run_refactor_protocol_accepts_object_payload(tmp_path: Path) -> None:
         target_path=None,
         target_functions=None,
         compatibility_shim=False,
+        compatibility_shim_warnings=True,
+        compatibility_shim_overloads=True,
         rationale=None,
         runner=runner,
     )

--- a/tests/test_cli_payloads.py
+++ b/tests/test_cli_payloads.py
@@ -318,12 +318,18 @@ def test_refactor_protocol_payload(tmp_path: Path) -> None:
         target_path=tmp_path / "sample.py",
         target_functions=["alpha"],
         compatibility_shim=True,
+        compatibility_shim_warnings=True,
+        compatibility_shim_overloads=True,
         rationale="use bundle",
     )
     assert payload["protocol_name"] == "Bundle"
     assert payload["bundle"] == ["a", "b"]
     assert payload["target_functions"] == ["alpha"]
-    assert payload["compatibility_shim"] is True
+    assert payload["compatibility_shim"] == {
+        "enabled": True,
+        "emit_deprecation_warning": True,
+        "emit_overload_stubs": True,
+    }
 
 
 # gabion:evidence E:decision_surface/direct::cli.py::gabion.cli.build_refactor_payload::bundle,input_payload,protocol_name,target_path
@@ -335,6 +341,8 @@ def test_refactor_payload_infers_bundle(tmp_path: Path) -> None:
         target_path=tmp_path / "sample.py",
         target_functions=[],
         compatibility_shim=False,
+        compatibility_shim_warnings=True,
+        compatibility_shim_overloads=True,
         rationale=None,
     )
     assert payload["bundle"] == ["a", "b"]

--- a/tests/test_refactor_engine_helpers.py
+++ b/tests/test_refactor_engine_helpers.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import libcst as cst
 
-from gabion.refactor import engine as refactor_engine
+from gabion.refactor import RefactorCompatibilityShimConfig, engine as refactor_engine
 
 
 # gabion:evidence E:decision_surface/direct::engine.py::gabion.refactor.engine._find_import_insert_index::body E:decision_surface/direct::engine.py::gabion.refactor.engine._module_expr_to_str::expr E:decision_surface/direct::engine.py::gabion.refactor.engine._is_docstring::stmt E:decision_surface/direct::engine.py::gabion.refactor.engine._is_import::stmt
@@ -19,7 +19,9 @@ def test_import_helpers_and_insert_index() -> None:
     assert refactor_engine._has_typing_overload_import(body) is False
     assert refactor_engine._has_warnings_import(body) is False
 
-    module = refactor_engine._ensure_compat_imports(module)
+    module = refactor_engine._ensure_compat_imports(
+        module, RefactorCompatibilityShimConfig(enabled=True)
+    )
     new_body = list(module.body)
     assert refactor_engine._has_typing_overload_import(new_body) is True
     assert refactor_engine._has_warnings_import(new_body) is True


### PR DESCRIPTION
### Motivation
- Replace the crude boolean `compatibility_shim` toggle with a small concrete config so shim emission can be tuned (overload stubs, deprecation warnings) while preserving boolean compatibility for callers.
- Emit compatibility wrappers that accept legacy call shapes and delegate to the new protocol-based implementation, and control import insertion and stub generation via configuration.

### Description
- Add `CompatibilityShimConfig` and `normalize_compatibility_shim` to `src/gabion/refactor/model.py` and allow `RefactorRequest.compatibility_shim` to be a boolean or structured config.
- Extend the API DTOs in `src/gabion/schema.py` with `RefactorCompatibilityShimDTO` and accept the union shape for `compatibility_shim`.
- Update `src/gabion/refactor/engine.py` to normalize shim settings, change `_ensure_compat_imports` to take the shim config, and make `_RefactorTransformer` conditional on `emit_overload_stubs` and `emit_deprecation_warning` when generating overload stubs, deprecation warnings, and wrapper nodes.
- Plumb the new config through the CLI in `src/gabion/cli.py` (`refactor-protocol` adds `--compat-shim-warnings` and `--compat-shim-overloads` and encodes a structured payload) and through the LSP handler in `src/gabion/server.py` (map schema union to model config); export the config via `src/gabion/refactor/__init__.py`.
- Add and adjust tests in `tests/` to cover import placement, shim node generation, and legacy call-site interoperability with the new settings, and update CLI payload tests to match the new payload shape.

### Testing
- Ran a byte-compile sanity check: `PYTHONPATH=src python -m py_compile src/gabion/cli.py src/gabion/refactor/__init__.py src/gabion/refactor/engine.py src/gabion/refactor/model.py src/gabion/schema.py src/gabion/server.py` which succeeded.
- Executed the focused test set with: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_refactor_engine_more.py tests/test_refactor_engine_helpers.py tests/test_cli_payloads.py tests/test_cli_helpers.py tests/test_cli_commands.py -q` and all tests passed (`125 passed`).
- Note: initial `mise` invocation reported tool/config trust resolution warnings in this environment; the tests above were run directly with `PYTHONPATH=src` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a96cc750832499ef6d5239a659d1)