### PR TITLE
Add impact-based test selection for PR workflows

### DIFF
--- a/.github/workflows/pr-dataflow-grammar.yml
+++ b/.github/workflows/pr-dataflow-grammar.yml
@@ -88,6 +88,76 @@ jobs:
           PY
       - name: Install package
         run: mise exec -- python -m pip install -e .
+      - name: Select impacted tests
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p artifacts/audit_reports artifacts/test_runs
+          mise exec -- python scripts/impact_select_tests.py \
+            --root . \
+            --diff-base "$GITHUB_BASE_SHA" \
+            --diff-head "$GITHUB_HEAD_SHA" \
+            --out artifacts/audit_reports/impact_selection.json \
+            --confidence-threshold 0.6
+      - name: Run impacted tests first (fallback to full)
+        env:
+          IMPACT_GATE_MUST_RUN: ${{ vars.IMPACT_GATE_MUST_RUN || 'false' }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import shlex
+          import subprocess
+
+          report = pathlib.Path("artifacts/audit_reports/impact_selection.json")
+          payload = json.loads(report.read_text(encoding="utf-8"))
+          mode = str(payload.get("mode", "full"))
+          selection = payload.get("selection") or {}
+          if not isinstance(selection, dict):
+              selection = {}
+          impacted = [str(item) for item in selection.get("impacted_tests", []) if str(item).strip()]
+          must_run = [str(item) for item in selection.get("must_run_impacted_tests", []) if str(item).strip()]
+          gate_must_run = os.environ.get("IMPACT_GATE_MUST_RUN", "false").lower() in {"1", "true", "yes"}
+          pytest_base = [
+              "mise",
+              "exec",
+              "--",
+              "python",
+              "-m",
+              "pytest",
+              "--cov=src/gabion",
+              "--cov-report=term-missing",
+              "--cov-report=xml:artifacts/test_runs/coverage.xml",
+              "--cov-report=html:artifacts/test_runs/htmlcov",
+              "--cov-fail-under=100",
+              "--junitxml",
+              "artifacts/test_runs/junit.xml",
+              "--log-file",
+              "artifacts/test_runs/pytest.log",
+              "--log-file-level=INFO",
+          ]
+
+          def run_pytest(extra):
+              cmd = [*pytest_base, *extra]
+              print("running:", " ".join(shlex.quote(part) for part in cmd))
+              return subprocess.run(cmd, check=False).returncode
+
+          if mode == "targeted" and impacted:
+              if must_run:
+                  rc = run_pytest(must_run)
+                  if rc != 0 and gate_must_run:
+                      raise SystemExit(rc)
+              rc = run_pytest(impacted)
+              if rc != 0:
+                  raise SystemExit(rc)
+          else:
+              rc = run_pytest([])
+              if rc != 0:
+                  raise SystemExit(rc)
+          PY
       - name: Render dataflow grammar report
         env:
           GABION_LSP_TIMEOUT_SECONDS: "300"
@@ -104,6 +174,102 @@ jobs:
         with:
           name: dataflow-grammar
           path: artifacts/dataflow_grammar
+      - name: Upload impact selection artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: impact-selection
+          path: artifacts/audit_reports/impact_selection.json
+      - name: Comment on PR with impact selection
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import urllib.request
+
+          token = os.environ["GITHUB_TOKEN"]
+          repo = os.environ["REPO"]
+          issue = os.environ["PR_NUMBER"]
+          run_url = os.environ["RUN_URL"]
+          marker = "<!-- impact-selection -->"
+
+          report_path = pathlib.Path("artifacts/audit_reports/impact_selection.json")
+          payload = json.loads(report_path.read_text(encoding="utf-8")) if report_path.exists() else {}
+          selection = payload.get("selection") if isinstance(payload, dict) else {}
+          if not isinstance(selection, dict):
+              selection = {}
+          impacted_tests = [str(item) for item in selection.get("impacted_tests", [])][:20]
+          impacted_docs = [str(item) for item in selection.get("impacted_docs", [])][:20]
+          mode = payload.get("mode", "full") if isinstance(payload, dict) else "full"
+          confidence = payload.get("confidence") if isinstance(payload, dict) else None
+          fallback_reasons = payload.get("fallback_reasons") if isinstance(payload, dict) else []
+          if not isinstance(fallback_reasons, list):
+              fallback_reasons = []
+
+          lines = [
+              marker,
+              "## Impact-based test selection",
+              f"- Mode: `{mode}`",
+              f"- Confidence: `{confidence}`",
+              f"- Fallback reasons: `{', '.join(str(item) for item in fallback_reasons) or 'none'}`",
+              "",
+              "### Impacted tests (first 20)",
+          ]
+          if impacted_tests:
+              lines.extend(f"- `{item}`" for item in impacted_tests)
+          else:
+              lines.append("- _(none)_")
+          lines.append("")
+          lines.append("### Impacted docs (first 20)")
+          if impacted_docs:
+              lines.extend(f"- `{item}`" for item in impacted_docs)
+          else:
+              lines.append("- _(none)_")
+          lines.extend(["", f"- Artifact: impact-selection", f"- Download: {run_url}"])
+          body = "\n".join(lines)
+
+          def request(url, method="GET", payload=None):
+              data = None if payload is None else json.dumps(payload).encode("utf-8")
+              req = urllib.request.Request(
+                  url,
+                  data=data,
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": "application/vnd.github+json",
+                      "Content-Type": "application/json",
+                  },
+                  method=method,
+              )
+              with urllib.request.urlopen(req) as resp:
+                  return json.loads(resp.read().decode("utf-8"))
+
+          comments = []
+          page = 1
+          while True:
+              url = (
+                  f"https://api.github.com/repos/{repo}/issues/{issue}/comments"
+                  f"?per_page=100&page={page}"
+              )
+              batch = request(url)
+              if not batch:
+                  break
+              comments.extend(batch)
+              page += 1
+
+          existing = next((c for c in comments if marker in (c.get("body") or "")), None)
+          if existing:
+              request(existing["url"], method="PATCH", payload={"body": body})
+          else:
+              url = f"https://api.github.com/repos/{repo}/issues/{issue}/comments"
+              request(url, method="POST", payload={"body": body})
+          PY
       - name: Comment on PR with report
         if: github.event.pull_request.head.repo.full_name == github.repository
         env:

--- a/scripts/impact_select_tests.py
+++ b/scripts/impact_select_tests.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+_HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@")
+
+
+@dataclass(frozen=True)
+class ChangedLine:
+    path: str
+    line: int
+
+
+def _parse_changed_lines(diff_text: str) -> list[ChangedLine]:
+    changed: list[ChangedLine] = []
+    current_path: str | None = None
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ "):
+            path_token = raw_line[4:].strip()
+            if path_token == "/dev/null":
+                current_path = None
+                continue
+            if path_token.startswith("b/"):
+                path_token = path_token[2:]
+            current_path = path_token
+            continue
+        if current_path is None:
+            continue
+        match = _HUNK_RE.match(raw_line)
+        if match is None:
+            continue
+        start = int(match.group("start"))
+        count = int(match.group("count") or "1")
+        if count <= 0:
+            continue
+        changed.extend(ChangedLine(path=current_path, line=start + offset) for offset in range(count))
+    return changed
+
+
+def _git_diff_changed_lines(root: Path, *, base: str | None, head: str | None) -> list[ChangedLine]:
+    if base and head:
+        diff_range = f"{base}...{head}"
+        cmd = ["git", "diff", "--unified=0", diff_range]
+    elif base:
+        cmd = ["git", "diff", "--unified=0", base]
+    else:
+        cmd = ["git", "diff", "--unified=0"]
+    proc = subprocess.run(
+        cmd,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        message = proc.stderr.strip() or proc.stdout.strip() or "git diff failed"
+        raise RuntimeError(message)
+    return _parse_changed_lines(proc.stdout)
+
+
+def _load_json(path: Path) -> Mapping[str, object] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _refresh_index(root: Path, index_path: Path, tests_root: str) -> bool:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/extract_test_evidence.py",
+            "--root",
+            str(root),
+            "--tests",
+            tests_root,
+            "--out",
+            str(index_path),
+        ],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def _site_matches_changed_lines(site: Mapping[str, object], lines_by_path: dict[str, set[int]]) -> bool:
+    site_path = str(site.get("path", "") or "").strip()
+    if not site_path:
+        return False
+    changed_lines = lines_by_path.get(site_path)
+    if not changed_lines:
+        return False
+    raw_span = site.get("span")
+    if isinstance(raw_span, list) and len(raw_span) == 4:
+        try:
+            start = int(raw_span[0])
+            end = int(raw_span[2])
+        except (TypeError, ValueError):
+            return True
+        upper = max(start, end)
+        lower = min(start, end)
+        return any(lower <= line <= upper for line in changed_lines)
+    return True
+
+
+def _collect_changed_sets(changed_lines: Iterable[ChangedLine]) -> tuple[dict[str, set[int]], set[str], set[str]]:
+    lines_by_path: dict[str, set[int]] = {}
+    changed_paths: set[str] = set()
+    changed_tests: set[str] = set()
+    for item in changed_lines:
+        changed_paths.add(item.path)
+        lines_by_path.setdefault(item.path, set()).add(item.line)
+        if item.path.startswith("tests/") and item.path.endswith(".py"):
+            changed_tests.add(item.path)
+    return lines_by_path, changed_paths, changed_tests
+
+
+def _select_tests(
+    payload: Mapping[str, object],
+    *,
+    changed_lines: list[ChangedLine],
+    must_run_tests: set[str],
+) -> tuple[list[str], list[str], list[str], float]:
+    lines_by_path, changed_paths, changed_tests = _collect_changed_sets(changed_lines)
+    tests = payload.get("tests")
+    if not isinstance(tests, list):
+        return [], sorted(changed_paths), sorted(changed_tests), 0.0
+
+    impacted: set[str] = set()
+    for entry in tests:
+        if not isinstance(entry, Mapping):
+            continue
+        test_id = str(entry.get("test_id", "") or "").strip()
+        if not test_id:
+            continue
+        test_file = str(entry.get("file", "") or "").strip()
+        if test_file in changed_tests:
+            impacted.add(test_id)
+            continue
+        evidence = entry.get("evidence")
+        if not isinstance(evidence, list):
+            continue
+        for item in evidence:
+            if not isinstance(item, Mapping):
+                continue
+            key = item.get("key")
+            if not isinstance(key, Mapping):
+                continue
+            site = key.get("site")
+            if isinstance(site, Mapping) and _site_matches_changed_lines(site, lines_by_path):
+                impacted.add(test_id)
+                break
+
+    changed_code_paths = {
+        path
+        for path in changed_paths
+        if path.endswith(".py") and not path.startswith("tests/")
+    }
+    mapped_paths = {
+        path
+        for path in changed_code_paths
+        if path in {str((item.get("key") or {}).get("site", {}).get("path", "")) for entry in tests if isinstance(entry, Mapping) for item in (entry.get("evidence") if isinstance(entry.get("evidence"), list) else []) if isinstance(item, Mapping) and isinstance(item.get("key"), Mapping)}
+    }
+    path_coverage = 1.0 if not changed_code_paths else len(mapped_paths) / len(changed_code_paths)
+    test_signal = 1.0 if impacted else 0.0
+    confidence = round(0.7 * path_coverage + 0.3 * test_signal, 4)
+
+    must_run_impacted = sorted(test for test in impacted if test in must_run_tests)
+    return sorted(impacted), sorted(changed_paths), must_run_impacted, confidence
+
+
+def _read_must_run_tests(path: Path | None, inline: Iterable[str]) -> set[str]:
+    tests = {value.strip() for value in inline if value.strip()}
+    if path and path.exists():
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                tests.add(line)
+    return tests
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Select impacted tests from git diff and evidence index.")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--diff-base", default=os.environ.get("GITHUB_BASE_SHA"))
+    parser.add_argument("--diff-head", default=os.environ.get("GITHUB_HEAD_SHA"))
+    parser.add_argument("--index", default="out/test_evidence.json")
+    parser.add_argument("--tests-root", default="tests")
+    parser.add_argument("--out", default="artifacts/audit_reports/impact_selection.json")
+    parser.add_argument("--confidence-threshold", type=float, default=0.6)
+    parser.add_argument("--stale-seconds", type=int, default=86_400)
+    parser.add_argument("--must-run-file")
+    parser.add_argument("--must-run-test", action="append", default=[])
+    parser.add_argument("--no-refresh", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    index_path = root / args.index
+    output_path = root / args.out
+
+    changed_lines = _git_diff_changed_lines(root, base=args.diff_base, head=args.diff_head)
+    changed_count = len(changed_lines)
+    changed_paths = sorted({item.path for item in changed_lines})
+
+    index_payload = _load_json(index_path)
+    stale = False
+    refreshed = False
+    if index_payload is None:
+        stale = True
+    elif args.stale_seconds >= 0:
+        age_seconds = time.time() - index_path.stat().st_mtime
+        stale = age_seconds > args.stale_seconds
+
+    if (index_payload is None or stale) and not args.no_refresh:
+        refreshed = _refresh_index(root, index_path, args.tests_root)
+        index_payload = _load_json(index_path)
+
+    must_run_tests = _read_must_run_tests(
+        Path(args.must_run_file) if args.must_run_file else None,
+        args.must_run_test,
+    )
+
+    reasons: list[str] = []
+    confidence = 0.0
+    impacted_tests: list[str] = []
+    must_run_impacted: list[str] = []
+    if index_payload is None:
+        reasons.append("index_missing")
+    else:
+        impacted_tests, changed_paths, must_run_impacted, confidence = _select_tests(
+            index_payload,
+            changed_lines=changed_lines,
+            must_run_tests=must_run_tests,
+        )
+
+    if stale and not refreshed:
+        reasons.append("index_stale")
+    if confidence < args.confidence_threshold:
+        reasons.append("low_confidence")
+
+    mode = "targeted"
+    if reasons and ("index_missing" in reasons or "index_stale" in reasons or "low_confidence" in reasons):
+        mode = "full"
+
+    impacted_docs = sorted(path for path in changed_paths if path.startswith("docs/") and path.endswith(".md"))
+
+    payload = {
+        "schema_version": 1,
+        "mode": mode,
+        "fallback_reasons": sorted(set(reasons)),
+        "confidence": confidence,
+        "confidence_threshold": args.confidence_threshold,
+        "diff": {
+            "base": args.diff_base,
+            "head": args.diff_head,
+            "changed_line_count": changed_count,
+            "changed_paths": changed_paths,
+        },
+        "index": {
+            "path": str(index_path.relative_to(root)),
+            "present": index_payload is not None,
+            "stale": stale,
+            "refreshed": refreshed,
+        },
+        "selection": {
+            "impacted_tests": impacted_tests,
+            "must_run_impacted_tests": must_run_impacted,
+            "impacted_docs": impacted_docs,
+        },
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_impact_select_tests.py
+++ b/tests/test_impact_select_tests.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import impact_select_tests
+
+
+def test_parse_changed_lines_extracts_hunk_lines() -> None:
+    diff = """diff --git a/src/gabion/example.py b/src/gabion/example.py
+index 1111111..2222222 100644
+--- a/src/gabion/example.py
++++ b/src/gabion/example.py
+@@ -4,0 +5,2 @@
++line a
++line b
+"""
+    changed = impact_select_tests._parse_changed_lines(diff)
+    assert changed == [
+        impact_select_tests.ChangedLine(path="src/gabion/example.py", line=5),
+        impact_select_tests.ChangedLine(path="src/gabion/example.py", line=6),
+    ]
+
+
+def test_select_tests_matches_evidence_site_and_changed_test() -> None:
+    payload = {
+        "tests": [
+            {
+                "test_id": "tests/test_alpha.py::test_one",
+                "file": "tests/test_alpha.py",
+                "evidence": [
+                    {
+                        "key": {
+                            "k": "function_site",
+                            "site": {"path": "src/gabion/example.py", "span": [5, 0, 9, 0]},
+                        }
+                    }
+                ],
+            },
+            {
+                "test_id": "tests/test_beta.py::test_two",
+                "file": "tests/test_beta.py",
+                "evidence": [],
+            },
+        ]
+    }
+    changed = [
+        impact_select_tests.ChangedLine(path="src/gabion/example.py", line=6),
+        impact_select_tests.ChangedLine(path="tests/test_beta.py", line=3),
+    ]
+
+    impacted, changed_paths, must_run_impacted, confidence = impact_select_tests._select_tests(
+        payload,
+        changed_lines=changed,
+        must_run_tests={"tests/test_alpha.py::test_one"},
+    )
+
+    assert impacted == [
+        "tests/test_alpha.py::test_one",
+        "tests/test_beta.py::test_two",
+    ]
+    assert changed_paths == ["src/gabion/example.py", "tests/test_beta.py"]
+    assert must_run_impacted == ["tests/test_alpha.py::test_one"]
+    assert confidence > 0.0
+
+
+def test_main_falls_back_when_index_missing(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path
+
+    monkeypatch.setattr(
+        impact_select_tests,
+        "_git_diff_changed_lines",
+        lambda *_args, **_kwargs: [
+            impact_select_tests.ChangedLine(path="src/gabion/example.py", line=3)
+        ],
+    )
+
+    out_path = root / "artifacts/audit_reports/impact_selection.json"
+    exit_code = impact_select_tests.main(
+        [
+            "--root",
+            str(root),
+            "--index",
+            "out/test_evidence.json",
+            "--out",
+            str(out_path.relative_to(root)),
+            "--no-refresh",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "full"
+    assert "index_missing" in payload["fallback_reasons"]


### PR DESCRIPTION
### Motivation
- Speed up PR feedback by running a targeted subset of tests first based on changed lines and test→evidence mapping, while providing a safe fallback to the full suite when the selector is uncertain. 
- Surface an artifact + PR comment listing impacted tests/docs and allow optional gating on critical (“must-run”) test failures.

### Description
- Add `scripts/impact_select_tests.py` which parses changed lines from `git diff --unified=0`, loads/refreshes the evidence index at `out/test_evidence.json`, computes impacted tests/docs and a confidence score, and writes `artifacts/audit_reports/impact_selection.json`.
- Integrate selection into the PR orchestration by updating `.github/workflows/pr-dataflow-grammar.yml` to run the selector, execute impacted tests first (and optionally gate on must-run failures via `IMPACT_GATE_MUST_RUN`), fall back to a full run when `mode` is `full`, upload the selection artifact, and post a PR comment summarizing the selection.
- Add `tests/test_impact_select_tests.py` with unit tests that cover diff parsing, evidence-site matching for impacted tests, and the missing-index fallback behavior.
- Selector semantics include optional auto-refresh of the evidence index, a confidence threshold, and explicit fallback reasons (`index_missing`, `index_stale`, `low_confidence`) that drive `mode: full` when triggered.

### Testing
- Ran unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_impact_select_tests.py` and all tests passed (3 passed).
- Ran policy checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` which completed successfully.
- Executed the selector end-to-end with `PYTHONPATH=src python scripts/impact_select_tests.py --root . --no-refresh --out artifacts/audit_reports/impact_selection.json` which produced `artifacts/audit_reports/impact_selection.json` successfully.
- Note: attempts to run `mise exec -- python -m pytest ...` failed in this environment due to an untrusted `mise.toml`, and `python -m pip install -e .` failed due to network/proxy constraints installing build deps; these are environmental issues and not regressions in the new code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993af0630ec83248b65af66f6c72611)