### PR TITLE
Classify dynamic-dispatch calls; index lambda sites; conservative dict-key & starred-dataclass handling

### DIFF
--- a/tests/test_dataflow_audit_helpers.py
+++ b/tests/test_dataflow_audit_helpers.py
@@ -3786,3 +3786,77 @@ def test_collect_never_invariants_dead_env_edge_cases(tmp_path: Path) -> None:
     by_reason = {str(entry.get("reason", "")): entry for entry in invariants}
     assert by_reason["const-false"]["status"] == "OBLIGATION"
     assert "undecidable_reason" not in by_reason["undecidable-with-env"]
+
+
+def test_resolve_callee_outcome_classifies_dynamic_dispatch_deterministically() -> None:
+    da = _load()
+    caller = da.FunctionInfo(
+        name="caller",
+        qual="pkg.caller",
+        path=Path("pkg/mod.py"),
+        params=[],
+        annots={},
+        calls=[],
+        unused_params=set(),
+        function_span=(0, 0, 0, 1),
+    )
+    outcome1 = da._resolve_callee_outcome(
+        "getattr(service, name)",
+        caller,
+        {},
+        {caller.qual: caller},
+        resolve_callee_fn=lambda *_args, **_kwargs: None,
+    )
+    outcome2 = da._resolve_callee_outcome(
+        "getattr(service, name)",
+        caller,
+        {},
+        {caller.qual: caller},
+        resolve_callee_fn=lambda *_args, **_kwargs: None,
+    )
+    assert outcome1.status == "unresolved_dynamic"
+    assert outcome1 == outcome2
+
+
+def test_pattern_schema_matches_are_stable_across_repeated_runs() -> None:
+    da = _load()
+    groups_by_path = {Path("pkg/mod.py"): {"f": [{"a", "b"}, {"a", "b"}]}}
+    source = (
+        "def one(paths, strictness, project_root):\n"
+        "    return _build_analysis_index(paths, strictness, project_root)\n"
+        "def two(paths, strictness, project_root):\n"
+        "    return _build_call_graph(paths, strictness, project_root)\n"
+        "def three(paths, strictness, project_root):\n"
+        "    return _build_analysis_index(paths, strictness, project_root)\n"
+    )
+    first = da._pattern_schema_snapshot_entries(
+        da._pattern_schema_matches(groups_by_path=groups_by_path, source=source)
+    )
+    second = da._pattern_schema_snapshot_entries(
+        da._pattern_schema_matches(groups_by_path=groups_by_path, source=source)
+    )
+    assert first == second
+
+
+def test_build_function_index_indexes_lambda_sites_deterministically(tmp_path: Path) -> None:
+    da = _load()
+    mod = tmp_path / "mod.py"
+    mod.write_text(
+        "def outer(x):\n"
+        "    f = lambda y: y\n"
+        "    return f(x), (lambda z: z)(x)\n"
+    )
+    args = dict(
+        paths=[mod],
+        project_root=tmp_path,
+        ignore_params=set(),
+        strictness="high",
+        parse_failure_witnesses=[],
+    )
+    by_name1, by_qual1 = da._build_function_index(**args)
+    by_name2, by_qual2 = da._build_function_index(**args)
+    assert "f" in by_name1
+    all_infos = [info for infos in by_name1.values() for info in infos]
+    assert any(info.name == "f" for info in all_infos)
+    assert any(info.name.startswith("<lambda@") for info in all_infos)
+    assert sorted(by_qual1) == sorted(by_qual2)

--- a/tests/test_visitors_edges.py
+++ b/tests/test_visitors_edges.py
@@ -569,3 +569,18 @@ def test_subscript_positional_slot_detection() -> None:
     tree, visitor, use_map, _ = _make_use_visitor(code, ["a"], strictness="low")
     visitor.visit(tree)
     assert ("sink", "arg[0]") in use_map["a"].direct_forward
+
+
+def test_subscript_name_bound_key_tracks_forward_and_unknown_key_state() -> None:
+    code = (
+        "def f(a):\n"
+        "    k = 'k'\n"
+        "    data = {}\n"
+        "    data[k] = a\n"
+        "    sink(data[k])\n"
+        "    sink(data[get_key()])\n"
+    )
+    tree, visitor, use_map, _ = _make_use_visitor(code, ["a"], strictness="low")
+    visitor.visit(tree)
+    assert ("sink", "arg[0]") in use_map["a"].direct_forward
+    assert use_map["a"].unknown_key_carrier is True


### PR DESCRIPTION
### Motivation
- Stabilize call/evidence semantics by classifying dynamic-dispatch call sites separately from unresolved static names so downstream reporting and CI can treat them distinctly.
- Materialize lambda/closure callables as deterministic function sites so call-resolution and bundle propagation include anonymous callables without guessing.
- Improve precision for dict-key-based carriers and dataclass constructor bundle extraction while keeping behavior conservative and additive (no removal of existing artifact keys).
- Provide deterministic fixtures asserting stable pattern/schema identity across repeated runs to avoid non-deterministic churn.

### Description
- Add `unknown_key_carrier: bool` to `ParamUse` and plumb it through serialization (`_serialize_param_use` / `_deserialize_param_use`).
- Extend `UseVisitor` to normalize recoverable dict keys (string literals, constant joined-strings, and name-bound constant aliases), persist name->constant aliases, mark unresolved key accesses with `unknown_key_carrier`, and propagate conservative non-forward behavior. (changes in `src/gabion/analysis/visitors.py`).
- Index lambdas as deterministic synthetic callable sites and include lambda callee naming for direct lambda call expressions, and add a helper to collect bound lambdas into the function index so lambdas appear in `by_name`/`by_qual`. (changes in `src/gabion/analysis/dataflow_audit.py`).
- Introduce dynamic-dispatch classification in call resolution by returning `status="unresolved_dynamic"` from `_resolve_callee_outcome` when the callee expression matches lightweight dynamic patterns, and emit `CallResolutionObligation` with `kind: "unresolved_dynamic_dispatch"` during materialization; preserved existing `resolved`, `ambiguous`, `unresolved_internal`, `unresolved_external` semantics. (changes in `src/gabion/analysis/dataflow_audit.py`).
- Enhance dataclass-call bundle discovery to conservatively accept literal starred forms (`*[...]`, `**{...}`) where determinable, and emit deterministic unresolved witnesses (`parse_failure_witnesses`) for undecidable/invalid starred payloads. (changes in `src/gabion/analysis/dataflow_audit.py`).
- Add tests and deterministic fixtures that assert stable output identity across repeated runs and cover the implemented slices (tests added/updated under `tests/` for visitors, dataclass bundles, dataflow audit helpers/edges).  

### Testing
- Ran the focused unit suites and fixtures with the repo interpreter using `PYTHONPATH=src` and the local test runner: `mise exec -- python -m pytest -o addopts='' tests/test_dataflow_audit_helpers.py -k "dynamic_dispatch or lambda_sites_deterministically or pattern_schema_matches_are_stable"`, `... tests/test_dataflow_audit_edges.py -k "dynamic_obligation_kind or materialize_call_candidates_covers_obligation_and_external_paths"`, `... tests/test_visitors_edges.py -k "name_bound_key_tracks_forward"`, and `... tests/test_dataclass_call_bundles.py` and full relevant slices.
- Results: the targeted tests and combined slice runs passed (focused runs passed; combined run across the modified suites returned: 199 passed for dataflow/audit/visitor/dataclass slices, and server execute-command slice passed 42 tests).
- All modified tests in `tests/` added for deterministic identity, dynamic-obligation-kind, lambda-site indexing, dict-key uncertainty, and starred-dataclass behavior succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ce4334dc83249251499662774652)