### PR TITLE
Add fingerprint-backed node interning and dual forest signature payloads

### DIFF
--- a/tests/test_aspf.py
+++ b/tests/test_aspf.py
@@ -135,3 +135,16 @@ def test_add_alt_requires_deadline_clock_scope() -> None:
 
     with pytest.raises(NeverThrown):
         Context().run(_run)
+
+
+def test_node_intern_uses_fingerprint_identity_with_legacy_keys() -> None:
+    forest = Forest()
+
+    first = forest.add_node("Sentinel", (1, True, "1"))
+    second = forest.add_node("Sentinel", (1, True, "1"))
+
+    assert first == second
+    assert len(forest.nodes) == 1
+    assert forest.has_node("Sentinel", (1, True, "1"))
+
+

--- a/tests/test_forest_signature.py
+++ b/tests/test_forest_signature.py
@@ -6,6 +6,7 @@ from gabion.analysis.aspf import Forest
 from gabion.analysis.forest_signature import (
     build_forest_signature,
     build_forest_signature_from_groups,
+    build_forest_signature_payload,
     _path_name,
     _normalize_key,
 )
@@ -32,6 +33,22 @@ def test_forest_signature_from_groups() -> None:
     signature = build_forest_signature_from_groups(groups_by_path)
     assert signature["nodes"]["count"] > 0
     assert signature["alts"]["count"] > 0
+
+
+def test_forest_signature_can_emit_legacy_and_fingerprint_intern_payloads() -> None:
+    forest = Forest()
+    forest.add_site("a.py", "f")
+
+    signature = build_forest_signature_payload(
+        forest,
+        include_legacy_intern=True,
+        include_fingerprint_intern=True,
+    )
+
+    assert "intern" in signature["nodes"]
+    assert "intern_fingerprint" in signature["nodes"]
+    assert signature["nodes"]["count"] == len(signature["nodes"]["intern"])
+    assert signature["nodes"]["count"] == len(signature["nodes"]["intern_fingerprint"])
 
 
 def test_forest_signature_from_groups_rejects_path_order_regression() -> None:


### PR DESCRIPTION
### Motivation
- Provide a stable, fingerprint-backed identity for node interning to support migration and indexing while preserving the existing tuple-based `NodeId(kind, key)` projection for serializers and compatibility.
- Allow forest signature emission to include both legacy intern payloads and new fingerprint intern payloads so migration validation can run without breaking consumers.

### Description
- Introduced typed fingerprint tokenization and an adapter via `fingerprint_identity(...)`, `_canonicalize_intern_identity(...)`, and `NodeId.fingerprint()` so `(kind, key)` can be canonicalized into a stable `NodeFingerprint` for storage and lookups.
- Made `Forest._intern_node(...)` fingerprint-backed and added `_nodes_by_fingerprint` and `has_node(...)` so intern lookups and existence checks use canonical fingerprints while keeping `NodeId` entries as the compatibility projection in `Forest.nodes`.
- Updated `add_site(...)` and `add_suite_site(...)` to use fingerprint-based existence checks so duplicates are detected via the canonical identity.
- Added `build_forest_signature_payload(...)` with flags `include_legacy_intern` and `include_fingerprint_intern` and kept `build_forest_signature(...)` delegating to the new payload API to emit legacy `nodes.intern` and optional `nodes.intern_fingerprint` together for migration validation.
- Added tests `test_node_intern_uses_fingerprint_identity_with_legacy_keys` and `test_forest_signature_can_emit_legacy_and_fingerprint_intern_payloads` to validate interning behavior and dual-payload emission.

### Testing
- Ran the targeted test suite with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf.py tests/test_forest_signature.py`, and all tests passed (`17 passed`).
- An attempt to run tests via the repo-local `mise exec` tool was blocked by local `mise.toml` trust / resolver issues, so the targeted `PYTHONPATH` invocation was used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948006382c8324bdb405b5ee79826a)