### PR TITLE
Add sparse exponent sidecars for fingerprint decode hot paths

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -73,7 +73,6 @@ from gabion.analysis.type_fingerprints import (
     bundle_fingerprint_dimensional,
     format_fingerprint,
     fingerprint_carrier_soundness,
-    fingerprint_to_type_keys_with_remainder,
     synth_registry_payload,
 )
 from .forest_signature import (
@@ -2949,12 +2948,8 @@ def _compute_fingerprint_warnings(
                 soundness_issues = _fingerprint_soundness_issues(fingerprint)
                 names = index.get(fingerprint)
 
-                base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.base.product, registry
-                )
-                ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.ctor.product, registry
-                )
+                base_keys, base_remaining = fingerprint.base.keys_with_remainder(registry)
+                ctor_keys, ctor_remaining = fingerprint.ctor.keys_with_remainder(registry)
                 ctor_keys = [
                     key[len("ctor:") :] if key.startswith("ctor:") else key
                     for key in ctor_keys
@@ -3028,12 +3023,8 @@ def _compute_fingerprint_matches(
                 names = index.get(fingerprint)
                 if not names:
                     continue
-                base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.base.product, registry
-                )
-                ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.ctor.product, registry
-                )
+                base_keys, base_remaining = fingerprint.base.keys_with_remainder(registry)
+                ctor_keys, ctor_remaining = fingerprint.ctor.keys_with_remainder(registry)
                 ctor_keys = [
                     key[len("ctor:") :] if key.startswith("ctor:") else key
                     for key in ctor_keys
@@ -3129,12 +3120,8 @@ def _compute_fingerprint_provenance(
                     ctor_registry,
                 )
                 soundness_issues = _fingerprint_soundness_issues(fingerprint)
-                base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.base.product, registry
-                )
-                ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-                    fingerprint.ctor.product, registry
-                )
+                base_keys, base_remaining = fingerprint.base.keys_with_remainder(registry)
+                ctor_keys, ctor_remaining = fingerprint.ctor.keys_with_remainder(registry)
                 ctor_keys = [
                     key[len("ctor:") :] if key.startswith("ctor:") else key
                     for key in ctor_keys
@@ -8939,12 +8926,8 @@ def _build_synth_registry_payload(
     entries: list[JSONObject] = []
     for prime, tail in sorted(synth_registry.tails.items()):
         check_deadline()
-        base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.base.product, registry
-        )
-        ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.ctor.product, registry
-        )
+        base_keys, base_remaining = tail.base.keys_with_remainder(registry)
+        ctor_keys, ctor_remaining = tail.ctor.keys_with_remainder(registry)
         ctor_keys = [
             key[len("ctor:") :] if key.startswith("ctor:") else key
             for key in ctor_keys

--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -167,9 +167,43 @@ class PrimeRegistry:
 class FingerprintDimension:
     product: int = 1
     mask: int = 0
+    # Sparse exponent-vector sidecar keyed by normalized registry key.
+    # Kept out of equality/hash for compatibility with persisted payloads that
+    # may not carry sidecars yet.
+    exponents: tuple[tuple[str, int], ...] = field(
+        default_factory=tuple,
+        compare=False,
+    )
 
     def is_empty(self) -> bool:
         return self.product in (0, 1) and self.mask == 0
+
+    def keys_with_remainder(
+        self,
+        registry: PrimeRegistry,
+    ) -> tuple[list[str], int]:
+        """Decode this dimension, preferring the sparse exponent sidecar."""
+        check_deadline()
+        if not self.exponents:
+            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+        keys: list[str] = []
+        for key, exponent in self.exponents:
+            check_deadline()
+            if exponent <= 0:
+                continue
+            keys.extend([key] * exponent)
+        sidecar_product = 1
+        for key in keys:
+            check_deadline()
+            prime = registry.prime_for(key)
+            if prime is None:
+                # Incomplete registry basis: preserve soundness by falling back.
+                return fingerprint_to_type_keys_with_remainder(self.product, registry)
+            sidecar_product *= prime
+        if sidecar_product != self.product:
+            # Product remains source-of-truth; sidecar is an optimization.
+            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+        return keys, 1
 
 
 @dataclass(frozen=True)
@@ -397,16 +431,28 @@ def _dimension_from_keys(keys: Iterable[str], registry: PrimeRegistry) -> Finger
     check_deadline()
     product = 1
     mask = 0
+    exponents: dict[str, int] = {}
     for key in keys:
         check_deadline()
         if not key:
             continue
         prime = registry.get_or_assign(key)
         product *= prime
+        exponents[key] = exponents.get(key, 0) + 1
         bit = registry.bit_for(key)
         if bit is not None:
             mask |= 1 << bit
-    return FingerprintDimension(product=product, mask=mask)
+    return FingerprintDimension(
+        product=product,
+        mask=mask,
+        exponents=tuple(
+            ordered_or_sorted(
+                exponents.items(),
+                source="_dimension_from_keys.exponents",
+                policy=OrderPolicy.SORT,
+            )
+        ),
+    )
 
 
 def _ctor_dimension_from_names(
@@ -416,6 +462,7 @@ def _ctor_dimension_from_names(
     check_deadline()
     product = 1
     mask = 0
+    exponents: dict[str, int] = {}
     for name in names:
         check_deadline()
         if not name:
@@ -423,10 +470,21 @@ def _ctor_dimension_from_names(
         key = f"ctor:{_normalize_base(name)}"
         prime = registry.get_or_assign(key)
         product *= prime
+        exponents[key] = exponents.get(key, 0) + 1
         bit = registry.bit_for(key)
         if bit is not None:
             mask |= 1 << bit
-    return FingerprintDimension(product=product, mask=mask)
+    return FingerprintDimension(
+        product=product,
+        mask=mask,
+        exponents=tuple(
+            ordered_or_sorted(
+                exponents.items(),
+                source="_ctor_dimension_from_names.exponents",
+                policy=OrderPolicy.SORT,
+            )
+        ),
+    )
 
 
 def format_fingerprint(fingerprint: Fingerprint) -> str:
@@ -473,7 +531,7 @@ class SynthRegistry:
         key = _synth_key(self.version, fingerprint)
         bit = self.registry.bit_for(key)
         mask = 0 if bit is None else 1 << bit
-        return FingerprintDimension(product=prime, mask=mask)
+        return FingerprintDimension(product=prime, mask=mask, exponents=((key, 1),))
 
 
 def build_synth_registry(

--- a/tests/test_type_fingerprints_sidecar.py
+++ b/tests/test_type_fingerprints_sidecar.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+from gabion.analysis.dataflow_audit import (
+    _compute_fingerprint_matches,
+    _compute_fingerprint_provenance,
+)
+from gabion.analysis.type_fingerprints import (
+    PrimeRegistry,
+    TypeConstructorRegistry,
+    bundle_fingerprint_dimensional,
+    fingerprint_to_type_keys_with_remainder,
+    format_fingerprint,
+)
+
+
+def _legacy_decode(fingerprint, registry: PrimeRegistry) -> tuple[list[str], int, list[str], int]:
+    base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
+        fingerprint.base.product,
+        registry,
+    )
+    ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
+        fingerprint.ctor.product,
+        registry,
+    )
+    ctor_keys = [
+        key[len("ctor:") :] if key.startswith("ctor:") else key
+        for key in ctor_keys
+    ]
+    return base_keys, base_remaining, ctor_keys, ctor_remaining
+
+
+def test_dimension_sidecar_decode_matches_legacy_division() -> None:
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+    fingerprint = bundle_fingerprint_dimensional(
+        ["list[int]", "dict[str, int]"],
+        registry,
+        ctor_registry,
+    )
+
+    expected_base = fingerprint_to_type_keys_with_remainder(fingerprint.base.product, registry)
+    expected_ctor = fingerprint_to_type_keys_with_remainder(fingerprint.ctor.product, registry)
+
+    base_keys, base_remaining = fingerprint.base.keys_with_remainder(registry)
+    ctor_keys, ctor_remaining = fingerprint.ctor.keys_with_remainder(registry)
+    assert (sorted(base_keys), base_remaining) == (sorted(expected_base[0]), expected_base[1])
+    assert (sorted(ctor_keys), ctor_remaining) == (sorted(expected_ctor[0]), expected_ctor[1])
+
+
+def test_dimension_sidecar_falls_back_to_product_when_inconsistent() -> None:
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+    fingerprint = bundle_fingerprint_dimensional(["list[int]"], registry, ctor_registry)
+
+    inconsistent = type(fingerprint.base)(
+        product=fingerprint.base.product,
+        mask=fingerprint.base.mask,
+        exponents=(("list", 4),),
+    )
+
+    assert inconsistent.keys_with_remainder(registry) == fingerprint_to_type_keys_with_remainder(
+        fingerprint.base.product,
+        registry,
+    )
+
+
+def test_dataflow_fingerprint_reporting_parity_with_legacy_decode() -> None:
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+
+    path = Path("pkg/mod.py")
+    groups_by_path = {path: {"fn": [{"left", "right"}]}}
+    annotations_by_path = {
+        path: {
+            "fn": {
+                "left": "list[int]",
+                "right": "dict[str, int]",
+            }
+        }
+    }
+
+    fingerprint = bundle_fingerprint_dimensional(
+        ["list[int]", "dict[str, int]"],
+        registry,
+        ctor_registry,
+    )
+    index = {fingerprint: {"bundle.shape"}}
+    legacy_base, legacy_base_remaining, legacy_ctor, legacy_ctor_remaining = _legacy_decode(
+        fingerprint,
+        registry,
+    )
+    legacy_base_sorted = sorted(legacy_base)
+    legacy_ctor_sorted = sorted(legacy_ctor)
+
+    matches = _compute_fingerprint_matches(
+        groups_by_path,
+        annotations_by_path,
+        registry=registry,
+        index=index,
+        ctor_registry=ctor_registry,
+    )
+    expected_detail = (
+        f"mod.py:fn bundle ['left', 'right'] fingerprint {format_fingerprint(fingerprint)} "
+        "matches: bundle.shape "
+        f"base={legacy_base_sorted} ctor={legacy_ctor_sorted}"
+    )
+    if legacy_base_remaining not in (0, 1) or legacy_ctor_remaining not in (0, 1):
+        expected_detail += f" remainder=({legacy_base_remaining},{legacy_ctor_remaining})"
+    assert expected_detail in matches
+
+    provenance = _compute_fingerprint_provenance(
+        groups_by_path,
+        annotations_by_path,
+        registry=registry,
+        project_root=None,
+        index=index,
+        ctor_registry=ctor_registry,
+    )
+    assert len(provenance) == 1
+    entry = provenance[0]
+    assert entry["base_keys"] == legacy_base_sorted
+    assert entry["ctor_keys"] == legacy_ctor_sorted
+    assert entry["remainder"] == {
+        "base": legacy_base_remaining,
+        "ctor": legacy_ctor_remaining,
+    }


### PR DESCRIPTION
### Motivation
- Decode of dimensional fingerprints frequently factors products to recover type keys which is a hot path and can be optimized by carrying a sparse exponent-vector sidecar during construction.
- Preserve existing `product`/`mask` carriers for compatibility and soundness while routing reverse-mapping through a faster, sidecar-first path when available.

### Description
- Augment `FingerprintDimension` with an `exponents: tuple[tuple[str,int], ...]` sidecar and add `keys_with_remainder(registry)` which prefers the sidecar and falls back to legacy prime-division when the sidecar is missing or inconsistent.
- Populate `exponents` during dimensional construction in `_dimension_from_keys` and `_ctor_dimension_from_names`, and include a synth-sidecar for synth-dimensions returned by `SynthRegistry.synth_dimension_for`.
- Replace repeated calls to `fingerprint_to_type_keys_with_remainder(...)` in `src/gabion/analysis/dataflow_audit.py` with the new `FingerprintDimension.keys_with_remainder(...)` in warnings/matches/provenance/synth reporting paths.
- Add parity tests `tests/test_type_fingerprints_sidecar.py` that assert sidecar decoding matches legacy decode and that the sidecar correctly falls back on inconsistent data.

### Testing
- Ran the new parity tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_type_fingerprints_sidecar.py` and observed `3 passed`.
- Attempted CI-style `mise exec -- pytest ...` but execution was environment-blocked due to local `mise.toml` trust checks, so the focused pytest invocation above was used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948014fb7c8324aee2fdab3efdeb14)