### PR TITLE
Intern structural alts and add compact evidence fingerprints

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -6840,13 +6840,22 @@ def _lint_rows_from_lines(
     return rows
 
 
+def _add_interned_alt(
+    *,
+    forest: Forest,
+    kind: str,
+    inputs: Iterable[NodeId],
+    evidence: dict[str, object] | None = None,
+) -> Alt:
+    return forest.add_alt(kind, inputs, evidence=evidence)
+
+
 def _materialize_lint_rows(
     *,
     forest: Forest,
     rows: Iterable[Mapping[str, JSONValue]],
 ) -> None:
     check_deadline()
-    seen: set[tuple[NodeId, NodeId, str]] = set()
     for row in rows:
         check_deadline()
         path = str(row.get("path", "") or "")
@@ -6880,11 +6889,12 @@ def _materialize_lint_rows(
             },
         )
         file_node = forest.add_file_site(path)
-        dedupe_key = (file_node, lint_node, source)
-        if dedupe_key in seen:
-            continue
-        seen.add(dedupe_key)
-        forest.add_alt("LintFinding", (file_node, lint_node), evidence={"source": source})
+        _add_interned_alt(
+            forest=forest,
+            kind="LintFinding",
+            inputs=(file_node, lint_node),
+            evidence={"source": source},
+        )
 
 
 def _lint_relation_from_forest(forest: Forest) -> list[dict[str, JSONValue]]:
@@ -6979,9 +6989,10 @@ def _materialize_report_section_lines(
                 "text": text_value,
             },
         )
-        forest.add_alt(
-            "ReportSectionLine",
-            (report_file, line_node),
+        _add_interned_alt(
+            forest=forest,
+            kind="ReportSectionLine",
+            inputs=(report_file, line_node),
             evidence={
                 "run_id": section_key.run_id,
                 "section": section_key.section,
@@ -7953,9 +7964,10 @@ def _emit_call_ambiguities(
                 forest=forest,
                 candidate=candidate,
             )
-            forest.add_alt(
-                "CallCandidate",
-                (suite_id, candidate_id),
+            _add_interned_alt(
+                forest=forest,
+                kind="CallCandidate",
+                inputs=(suite_id, candidate_id),
                 evidence={
                     "kind": entry.kind,
                     "phase": entry.phase,
@@ -7981,9 +7993,10 @@ def _emit_call_ambiguities(
             (witness_identity,),
             meta={"evidence_key": witness_key},
         )
-        forest.add_alt(
-            "PartitionWitness",
-            (suite_id, witness_node),
+        _add_interned_alt(
+            forest=forest,
+            kind="PartitionWitness",
+            inputs=(suite_id, witness_node),
             evidence={
                 "kind": entry.kind,
                 "phase": entry.phase,
@@ -8486,19 +8499,12 @@ def _populate_bundle_forest(
             parse_failure_witnesses=parse_failure_witnesses,
             analysis_index=index,
         )
-    seen: set[tuple[str, tuple[NodeId, ...], tuple[tuple[str, str], ...]]] = set()
-
     def _add_alt(
         kind: str,
         inputs: Iterable[NodeId],
         evidence: dict[str, object] | None = None,
     ) -> None:
-        items = tuple(sorted((k, str(v)) for k, v in (evidence or {}).items()))
-        key = (kind, tuple(inputs), items)
-        if key in seen:
-            return
-        seen.add(key)
-        forest.add_alt(kind, inputs, evidence)
+        _add_interned_alt(forest=forest, kind=kind, inputs=inputs, evidence=evidence)
 
     progress_since_emit = 0
 

--- a/src/gabion/analysis/evidence_keys.py
+++ b/src/gabion/analysis/evidence_keys.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Callable, Iterable, Mapping, Sequence
 from gabion.analysis.timeout_context import check_deadline
@@ -349,6 +350,18 @@ def normalize_key(key: Mapping[str, object]) -> dict[str, object]:
 def key_identity(key: Mapping[str, object]) -> str:
     normalized = normalize_key(key)
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def normalized_fingerprint_identity(normalized: Mapping[str, object]) -> str:
+    payload = json.dumps(dict(normalized), sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    digest = hashlib.blake2s(payload, digest_size=12).hexdigest()
+    return f"ekf:{digest}"
+
+
+def key_fingerprint_identity(key: Mapping[str, object]) -> str:
+    return normalized_fingerprint_identity(normalize_key(key))
 
 
 def render_display(

--- a/tests/test_aspf.py
+++ b/tests/test_aspf.py
@@ -135,3 +135,16 @@ def test_add_alt_requires_deadline_clock_scope() -> None:
 
     with pytest.raises(NeverThrown):
         Context().run(_run)
+
+
+def test_add_alt_interns_structural_duplicates() -> None:
+    forest = Forest()
+    left = forest.add_site("mod.py", "mod.left")
+    right = forest.add_site("mod.py", "mod.right")
+    with forest_scope(forest):
+        with deadline_scope(Deadline.from_timeout_ms(1_000)):
+            with deadline_clock_scope(GasMeter(limit=32)):
+                first = forest.add_alt("Edge", (left, right), evidence={"b": 2, "a": 1})
+                second = forest.add_alt(" Edge ", (left, right), evidence={"a": 1, "b": 2})
+    assert first is second
+    assert len([alt for alt in forest.alts if alt.kind == "Edge"]) == 1

--- a/tests/test_evidence_keys.py
+++ b/tests/test_evidence_keys.py
@@ -356,3 +356,16 @@ def test_ambiguity_span_normalization_edges() -> None:
     assert evidence_keys.parse_display("E:ambiguity_set::{") is None
     assert evidence_keys.parse_display("E:partition_witness::") is None
     assert evidence_keys.parse_display("E:partition_witness::{") is None
+
+
+def test_fingerprint_identity_is_compact_and_stable() -> None:
+    key_a = evidence_keys.make_call_cluster_key(targets=[("a.py", "mod.f")])
+    key_b = {"targets": [{"qual": "mod.f", "path": "a.py"}], "k": "call_cluster"}
+
+    assert evidence_keys.key_fingerprint_identity(key_a) == evidence_keys.key_fingerprint_identity(
+        key_b
+    )
+    assert evidence_keys.key_fingerprint_identity(key_a).startswith("ekf:")
+    assert len(evidence_keys.key_fingerprint_identity(key_a)) < len(
+        evidence_keys.key_identity(key_a)
+    )


### PR DESCRIPTION
### Motivation
- Prevent duplicate structural alternatives (alts) from being emitted at high volume by interning alts keyed on a normalized `(alt_kind, inputs, evidence_identity)` tuple. 
- Provide a compact, stable canonical identity for evidence keys to make large evidence payloads cheaper to index and compare.

### Description
- Add an `_alt_index` to `Forest` and change `Forest.add_alt` to normalize `kind` whitespace, inputs, and an evidence JSON identity and return an existing `Alt` when a structural match is found instead of appending a duplicate. 
- Add `normalized_fingerprint_identity` and `key_fingerprint_identity` in `src/gabion/analysis/evidence_keys.py` that produce compact BLAKE2s-based `ekf:*` fingerprints while preserving the existing JSON `key_identity`. 
- Refactor high-volume emission sites in `src/gabion/analysis/dataflow_audit.py` to go through a small helper (`_add_interned_alt`) that routes to the interned path and remove local dedupe bookkeeping where appropriate (lint row materialization, report section lines, ambiguity emission, and bundle forest population). 

### Testing
- Added unit tests `test_add_alt_interns_structural_duplicates` (in `tests/test_aspf.py`) and `test_fingerprint_identity_is_compact_and_stable` (in `tests/test_evidence_keys.py`).
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf.py tests/test_evidence_keys.py tests/test_ambiguity_helpers.py`, which succeeded with `35 passed`.
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_dataflow_report_helpers.py tests/test_dataflow_audit_coverage_gaps.py -k 'lint or ambiguity or coherence or rewrite'`, which succeeded with `17 passed, 108 deselected`.
- An attempt to run via the repo `mise` wrapper (`mise exec -- pytest ...`) failed in this environment due to the pinned runtime resolution, so validation used `PYTHONPATH=src` pytest runs instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994801bcf3c8324a94b81d23abb8642)