### PR TITLE
docs(in-32): emphasize non-normative status and add current implementation boundary

### DIFF
--- a/in/in-32.md
+++ b/in/in-32.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 5
+doc_revision: 6
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: in_32
 doc_role: in_step
@@ -43,7 +43,7 @@ doc_erasure:
   - spelling/formatting only
   - reflow without semantic edits
 doc_sections:
-  in_in_32: 5
+  in_in_32: 6
 doc_section_requires:
   in_in_32:
     - POLICY_SEED.md#policy_seed
@@ -55,27 +55,27 @@ doc_section_reviews:
   in_in_32:
     POLICY_SEED.md#policy_seed:
       dep_version: 1
-      self_version_at_review: 5
+      self_version_at_review: 6
       outcome: no_change
       note: "Reviewed POLICY_SEED.md rev1; no conflicts."
     glossary.md#aspf:
       dep_version: 1
-      self_version_at_review: 5
+      self_version_at_review: 6
       outcome: no_change
       note: "Gödel numbering is an implementation refinement of ASPF, not a semantic break."
     glossary.md#forest:
       dep_version: 1
-      self_version_at_review: 5
+      self_version_at_review: 6
       outcome: no_change
       note: "Decoration lineages extend Forest structure but preserve interning contract."
     glossary.md#hash_consing:
       dep_version: 1
-      self_version_at_review: 5
+      self_version_at_review: 6
       outcome: no_change
       note: "Bitmask NodeID is hash-consing applied to Gödel-numbered atoms."
     in/in-30.md#in_in_30:
       dep_version: 1
-      self_version_at_review: 5
+      self_version_at_review: 6
       outcome: no_change
       note: "SuiteSite carrier is the base for all phases; Gödel numbering is orthogonal."
 ---
@@ -111,13 +111,37 @@ the migration is a refinement of representation and execution, not a redesign of
 
 ## Status
 
-Hypothetical and non-normative workstream. This document is acknowledged as a
-forward-looking exploration and does not control implementation, policy, or CI.
+**Hypothetical and non-normative workstream (prominent):** this document is
+forward-looking theory and does not control implementation scope, execution policy,
+or CI requirements.
+
+`in/in-32.md` is directional architecture guidance only. Any execution/CI obligations
+remain governed by [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), the
+normative semantic contract in [glossary.md#contract](glossary.md#contract), and
+active checklist nodes in [docs/sppf_checklist.md](docs/sppf_checklist.md).
+
 Target architecture has a six-phase migration plan. Phases 1–3 are foundational;
 Phases 4–6 build capability layers. Each phase has validation criteria; migration
 is incremental and reversible at phase boundaries.
 
-Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#hash_consing](glossary.md#hash_consing), [CONTRIBUTING.md#contributing_contract](CONTRIBUTING.md#contributing_contract), [README.md#repo_contract](README.md#repo_contract), [AGENTS.md#agent_obligations](AGENTS.md#agent_obligations), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#hash_consing](glossary.md#hash_consing), [glossary.md#contract](glossary.md#contract), [CONTRIBUTING.md#contributing_contract](CONTRIBUTING.md#contributing_contract), [README.md#repo_contract](README.md#repo_contract), [AGENTS.md#agent_obligations](AGENTS.md#agent_obligations), [docs/sppf_checklist.md](docs/sppf_checklist.md), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+
+## Current implementation boundary
+
+Active implementation and delivery are currently tracked in:
+
+- [in/in-22.md](in/in-22.md)
+- [in/in-30.md](in/in-30.md)
+- [in/in-33.md](in/in-33.md)
+- [in/in-34.md](in/in-34.md)
+- [in/in-35.md](in/in-35.md)
+- [in/in-36.md](in/in-36.md)
+- [in/in-37.md](in/in-37.md)
+- [docs/sppf_checklist.md](docs/sppf_checklist.md)
+
+These documents define what is currently being implemented and validated. If any
+statement in `in/in-32.md` appears to conflict with those active documents, treat
+`in/in-32.md` as non-normative theory and follow the active implementation sources.
 
 ## Definitions
 


### PR DESCRIPTION
### Motivation
- Make the theoretical nature of `in/in-32.md` explicit and prevent accidental interpretation as normative or executable guidance.
- Provide a clear pointer to the active implementation artifacts so readers can resolve conflicts between theory and practice.

### Description
- Prominently mark `in/in-32.md` as a non-normative, directional architecture guidance document and state that it does not control implementation, execution policy, or CI requirements.
- Add explicit language that execution and CI obligations remain governed by `POLICY_SEED.md`, the normative semantic contract in `glossary.md#contract`, and active checklist nodes in `docs/sppf_checklist.md`.
- Add a new “Current implementation boundary” section that points to active implementation and delivery documents: `in/in-22.md`, `in/in-30.md`, `in/in-33.md` through `in/in-37.md`, and `docs/sppf_checklist.md`.
- Bump document metadata (`doc_revision`, `doc_sections.in_in_32`, and `self_version_at_review` entries) to reflect the conceptual documentation change.

### Testing
- Ran `git diff --check` to validate no whitespace or index issues and it completed successfully.
- Ran `python -m compileall -q in` to ensure repository docs/scripts in `in/` do not produce syntax errors and it returned exit status 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699484074898832485c2c532cae39085)