### PR TITLE
docs: classify in-33..in-37 and link checklist nodes

### DIFF
--- a/docs/influence_index.md
+++ b/docs/influence_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 48
+doc_revision: 49
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: influence_index
 doc_role: index
@@ -130,8 +130,8 @@ Status legend:
 - in/in-30.md — **partial** (SuiteSite carrier + loop-scoped deadlines design; implementation in progress; SPPF/GH-85.)
 - in/in-31.md — **partial** (projection carriers + meet-boundary ordering semantics; convergence in progress.)
 - in/in-32.md — **queued** (hypothetical/non-normative Gödel-numbering exploration; acknowledged, but not a controlling contract for implementation or CI at this time.)
-- in/in-33.md — **untriaged** (new inbox entry; pending review and classification.)
-- in/in-34.md — **untriaged** (new inbox entry; pending review and classification.)
-- in/in-35.md — **untriaged** (new inbox entry; pending review and classification.)
-- in/in-36.md — **untriaged** (new inbox entry; pending review and classification.)
-- in/in-37.md — **untriaged** (new inbox entry; pending review and classification.)
+- in/in-33.md — [**partial**](docs/sppf_checklist.md#in-33-pattern-schema-unification) (PatternSchema carriers exist for both dataflow and execution pattern instances with shared residue reporting, but execution-pattern coverage is intentionally narrow and metafactory reification remains open.)
+- in/in-34.md — [**partial**](docs/sppf_checklist.md#in-34-lambda-callable-sites) (synthetic lambda function sites are indexed and used for direct/bound lambda call resolution, while broader closure/alias cases still fall back conservatively.)
+- in/in-35.md — [**partial**](docs/sppf_checklist.md#in-35-dict-key-carrier-tracking) (dict key normalization now supports name-bound constants and records explicit unknown-key carrier evidence for non-recoverable keys; supported key grammar remains deliberately conservative.)
+- in/in-36.md — [**adopted**](docs/sppf_checklist.md#in-36-starred-dataclass-call-bundles) (dataclass call-bundle extraction now decodes deterministic starred literals for `*` and `**` and emits unresolved-starred witnesses for dynamic payloads.)
+- in/in-37.md — [**adopted**](docs/sppf_checklist.md#in-37-dynamic-dispatch-uncertainty) (callee resolution now distinguishes `unresolved_dynamic` from unresolved internal/external states and emits a dedicated `unresolved_dynamic_callee` obligation kind.)

--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 148
+doc_revision: 149
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -205,6 +205,11 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [~] SuiteSite carriers + loop-scoped deadline obligations. (in-30, GH-85) sppf{doc=partial; impl=partial; doc_ref=in-30@24}
 - [~] Deadline propagation as gas (ticks-based carriers across LSP/CLI/server). (in-30, GH-87) sppf{doc=partial; impl=done; doc_ref=in-30@24}
 - [~] Structural ambiguity as CallCandidate alts (SuiteSite) with virtual AmbiguitySet. (in-30, GH-88) sppf{doc=partial; impl=done; doc_ref=in-30@24}
+- <a id="in-33-pattern-schema-unification"></a>[~] PatternSchema unification for dataflow bundles + execution patterns (shared schema IDs + residue reporting; execution rules still narrow). (in-33) sppf{doc=partial; impl=partial; doc_ref=in-33@1}
+- <a id="in-34-lambda-callable-sites"></a>[~] Lambda/closure callable indexing as first-class function sites (synthetic lambda identities + direct/bound lambda call resolution; conservative fallback retained). (in-34) sppf{doc=partial; impl=partial; doc_ref=in-34@1}
+- <a id="in-35-dict-key-carrier-tracking"></a>[~] Dict carrier tracking beyond literal subscript aliases (name-bound constant keys + unknown-key carrier evidence). (in-35) sppf{doc=partial; impl=done; doc_ref=in-35@1}
+- <a id="in-36-starred-dataclass-call-bundles"></a>[x] Conservative starred dataclass constructor argument handling (`*` list/tuple/set, `**` dict literal) with unresolved-starred witnesses for dynamic payloads. (in-36) sppf{doc=done; impl=done; doc_ref=in-36@1}
+- <a id="in-37-dynamic-dispatch-uncertainty"></a>[x] Dynamic-dispatch uncertainty classification in call resolution (`unresolved_dynamic`) plus dedicated call-resolution obligation kind. (in-37) sppf{doc=done; impl=done; doc_ref=in-37@1}
 
 ## Reporting & visualization nodes
 - [x] Component isolation (connected components in bundle graph).


### PR DESCRIPTION
### Motivation
- Bring the influence index and SPPF checklist in line with the actual analysis behavior implemented in `src/gabion/analysis/dataflow_audit.py` by assigning explicit statuses and short implementation notes to `in/in-33.md` through `in/in-37.md` and by linking each status to a checklist node.
- Ensure the docs are actionable: add checklist anchors so each indexed inbox entry has a concrete SPPF checklist target for planning and GH linkage.

### Description
- Updated `docs/influence_index.md` to replace the five `untriaged` entries for `in-33`..`in-37` with explicit `[partial]`/`[adopted]` statuses and concise implementation notes reflecting current code (PatternSchema/dataflow-pattern instances, synthetic lambda sites, dict key normalization and unknown-key evidence, conservative starred dataclass decoding, and `unresolved_dynamic` call-resolution classification).
- Added corresponding anchored checklist nodes in `docs/sppf_checklist.md` (with sppf metadata anchors and brief summaries) and bumped `doc_revision` values in both edited docs.

### Testing
- Ran the repo docflow audit with the local interpreter via `PYTHONPATH=src python -m gabion docflow-audit`, which completed successfully and emitted the SPPF dependency graph while reporting an unrelated existing `sppf_sync` GH-reference violation in the recent commit range.
- Attempted the repository-preferred `mise exec -- python -m gabion docflow-audit` path but encountered tool-resolution/trust issues in this environment; fallback local invocation above was used for validation.
- Verified changes were staged and committed (`git commit`), and the branch head is `f04996a`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994844d6b7883249e64d357f140d0ba)