### PR TITLE
Add canonical merge layer for partial dataflow-audit worker outputs

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -13383,6 +13383,160 @@ _COLLECTION_PROGRESS_EMIT_INTERVAL = 8
 _ANALYSIS_INDEX_PROGRESS_EMIT_INTERVAL = 4
 
 
+@dataclass(frozen=True)
+class _PartialWorkerCarrierOutput:
+    violations: tuple[str, ...] = ()
+    witnesses: tuple[JSONObject, ...] = ()
+    deltas: tuple[JSONObject, ...] = ()
+    snapshots: tuple[JSONObject, ...] = ()
+
+
+def _canonical_json_bytes(value: JSONValue) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _path_key_from_violation(violation: str) -> str | None:
+    path_prefix, separator, _ = violation.partition(":")
+    if separator and path_prefix.endswith(".py"):
+        return path_prefix
+    return None
+
+
+def _path_key_from_payload(payload: Mapping[str, JSONValue]) -> str | None:
+    for key in ("path", "module_path", "file", "baseline_path", "current_path"):
+        raw_value = payload.get(key)
+        if isinstance(raw_value, str) and raw_value:
+            return raw_value
+    return None
+
+
+def _canonicalize_worker_violations(
+    violations: Iterable[str],
+    *,
+    source: str,
+) -> list[str]:
+    by_path: dict[str, dict[str, str]] = defaultdict(dict)
+    no_path: dict[str, str] = {}
+    for violation in violations:
+        check_deadline()
+        canonical = _canonical_json_bytes(violation)
+        path_key = _path_key_from_violation(violation)
+        if path_key is None:
+            no_path.setdefault(canonical, violation)
+            continue
+        by_path[path_key].setdefault(canonical, violation)
+    ordered_paths = _iter_monotonic_paths(
+        ordered_or_sorted(
+            (Path(path_key) for path_key in by_path),
+            source=f"{source}.paths",
+            key=str,
+        ),
+        source=f"{source}.paths_monotonic",
+    )
+    ordered: list[str] = []
+    for path in ordered_paths:
+        check_deadline()
+        path_key = str(path)
+        entries = by_path.get(path_key, {})
+        for canonical in ordered_or_sorted(
+            entries,
+            source=f"{source}.path_entries",
+        ):
+            check_deadline()
+            ordered.append(entries[canonical])
+    for canonical in ordered_or_sorted(
+        no_path,
+        source=f"{source}.no_path_entries",
+    ):
+        check_deadline()
+        ordered.append(no_path[canonical])
+    return ordered
+
+
+def _canonicalize_worker_structured_entries(
+    entries: Iterable[JSONObject],
+    *,
+    source: str,
+) -> list[JSONObject]:
+    by_path: dict[str, dict[str, JSONObject]] = defaultdict(dict)
+    no_path: dict[str, JSONObject] = {}
+    for entry in entries:
+        check_deadline()
+        canonical = _canonical_json_bytes(entry)
+        path_key = _path_key_from_payload(entry)
+        if path_key is None:
+            no_path.setdefault(canonical, entry)
+            continue
+        by_path[path_key].setdefault(canonical, entry)
+    ordered_paths = _iter_monotonic_paths(
+        ordered_or_sorted(
+            (Path(path_key) for path_key in by_path),
+            source=f"{source}.paths",
+            key=str,
+        ),
+        source=f"{source}.paths_monotonic",
+    )
+    ordered: list[JSONObject] = []
+    for path in ordered_paths:
+        check_deadline()
+        path_key = str(path)
+        path_entries = by_path.get(path_key, {})
+        for canonical in ordered_or_sorted(
+            path_entries,
+            source=f"{source}.path_entries",
+        ):
+            check_deadline()
+            ordered.append(path_entries[canonical])
+    for canonical in ordered_or_sorted(
+        no_path,
+        source=f"{source}.no_path_entries",
+    ):
+        check_deadline()
+        ordered.append(no_path[canonical])
+    return ordered
+
+
+def _merge_worker_carriers(
+    partials: Sequence[_PartialWorkerCarrierOutput],
+) -> _PartialWorkerCarrierOutput:
+    combined_violations: list[str] = []
+    combined_witnesses: list[JSONObject] = []
+    combined_deltas: list[JSONObject] = []
+    combined_snapshots: list[JSONObject] = []
+    for partial in partials:
+        check_deadline()
+        combined_violations.extend(partial.violations)
+        combined_witnesses.extend(partial.witnesses)
+        combined_deltas.extend(partial.deltas)
+        combined_snapshots.extend(partial.snapshots)
+    return _PartialWorkerCarrierOutput(
+        violations=tuple(
+            _canonicalize_worker_violations(
+                combined_violations,
+                source="_merge_worker_carriers.violations",
+            )
+        ),
+        witnesses=tuple(
+            _canonicalize_worker_structured_entries(
+                combined_witnesses,
+                source="_merge_worker_carriers.witnesses",
+            )
+        ),
+        deltas=tuple(
+            _canonicalize_worker_structured_entries(
+                combined_deltas,
+                source="_merge_worker_carriers.deltas",
+            )
+        ),
+        snapshots=tuple(
+            _canonicalize_worker_structured_entries(
+                combined_snapshots,
+                source="_merge_worker_carriers.snapshots",
+            )
+        ),
+    )
+
+
 def _analysis_collection_resume_path_key(path: Path) -> str:
     return str(path)
 

--- a/tests/test_dataflow_audit_merge_canonicalization.py
+++ b/tests/test_dataflow_audit_merge_canonicalization.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import itertools
+import json
+
+from gabion.analysis import dataflow_audit as da
+
+
+def _payload_bytes(output: da._PartialWorkerCarrierOutput) -> bytes:
+    payload = {
+        "violations": list(output.violations),
+        "witnesses": list(output.witnesses),
+        "deltas": list(output.deltas),
+        "snapshots": list(output.snapshots),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sample_partials() -> tuple[da._PartialWorkerCarrierOutput, ...]:
+    return (
+        da._PartialWorkerCarrierOutput(
+            violations=(
+                "src/zeta.py:9 violation z",
+                "orphan violation",
+            ),
+            witnesses=(
+                {"path": "src/beta.py", "kind": "witness", "value": 2},
+                {"kind": "witness", "value": 99},
+            ),
+            deltas=(
+                {"path": "src/gamma.py", "bundle": ["b", "a"], "delta": 1},
+            ),
+            snapshots=(
+                {"path": "src/beta.py", "hash": "b"},
+            ),
+        ),
+        da._PartialWorkerCarrierOutput(
+            violations=(
+                "src/alpha.py:1 violation a",
+                "src/beta.py:3 violation b",
+            ),
+            witnesses=(
+                {"path": "src/alpha.py", "kind": "witness", "value": 1},
+                {"path": "src/beta.py", "kind": "witness", "value": 2},
+            ),
+            deltas=(
+                {"path": "src/alpha.py", "bundle": ["a"], "delta": -1},
+            ),
+            snapshots=(
+                {"path": "src/alpha.py", "hash": "a"},
+            ),
+        ),
+    )
+
+
+def test_merge_worker_carriers_is_byte_stable_across_partial_orders() -> None:
+    partials = _sample_partials()
+    merged_bytes = {
+        _payload_bytes(da._merge_worker_carriers(ordering))
+        for ordering in itertools.permutations(partials)
+    }
+    assert len(merged_bytes) == 1
+
+
+def test_merge_worker_carriers_global_order_is_path_anchored() -> None:
+    merged = da._merge_worker_carriers(tuple(reversed(_sample_partials())))
+    assert list(merged.violations) == [
+        "src/alpha.py:1 violation a",
+        "src/beta.py:3 violation b",
+        "src/zeta.py:9 violation z",
+        "orphan violation",
+    ]
+    assert [entry["path"] for entry in merged.witnesses if "path" in entry] == [
+        "src/alpha.py",
+        "src/beta.py",
+    ]
+    assert [entry["path"] for entry in merged.deltas] == [
+        "src/alpha.py",
+        "src/gamma.py",
+    ]
+    assert [entry["path"] for entry in merged.snapshots] == [
+        "src/alpha.py",
+        "src/beta.py",
+    ]


### PR DESCRIPTION
### Motivation
- Worker stages produce partial carriers (violations, witnesses, deltas, snapshots) that must be combined into a single, globally ordered carrier for reporting and downstream consumers.  
- Merge ordering must respect existing monotonic/path ordering and the repo's order-contract semantics (`_iter_monotonic_paths` + `ordered_or_sorted`).  
- The merge must be deterministic (byte-stable) regardless of partial merge order to make baselines and fingerprints stable.

### Description
- Added a frozen dataclass `_PartialWorkerCarrierOutput` to represent partial worker carrier outputs and a canonical merge layer in `src/gabion/analysis/dataflow_audit.py`.  
- Implemented canonicalization helpers: `_canonical_json_bytes`, `_path_key_from_violation`, `_path_key_from_payload`, `_canonicalize_worker_violations`, and `_canonicalize_worker_structured_entries` to deduplicate by canonical JSON bytes and bucket entries by path.  
- Implemented `_merge_worker_carriers` that composes path-monotonic ordering (`_iter_monotonic_paths`) with `ordered_or_sorted(...)` for deterministic ordering within buckets and for entries without path anchors.  
- Added tests `tests/test_dataflow_audit_merge_canonicalization.py` that assert byte-stable output across permutations of partial inputs and that global ordering is anchored to path keys.

### Testing
- Ran the new test directly with `PYTHONPATH=src python -m pytest -c /dev/null tests/test_dataflow_audit_merge_canonicalization.py` and it passed (`2 passed`).  
- Attempts to run the suite via the pinned toolchain wrapper (`mise exec -- python -m pytest ...`) failed in this environment due to external tool-resolution/network issues; those failures are environmental and not related to the deterministic logic added.  
- The added unit tests exercise permutations of partial inputs and verify both byte-stability and path-anchored ordering (both assertions succeeded in the executed run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d256f60083249aa33518aa2c9931)