### PR TITLE
Stabilize projection output ordering in normalization and count aggregation

### DIFF
--- a/src/gabion/analysis/projection_normalize.py
+++ b/src/gabion/analysis/projection_normalize.py
@@ -120,7 +120,17 @@ def _extract_predicates(params: Mapping[str, JSONValue]) -> list[str]:
 
 
 def _normalize_predicates(values: Iterable[str]) -> list[str]:
-    cleaned = {value.strip() for value in values if value and value.strip()}
+    # ordered internally; explicit sort only at edge.
+    # We deduplicate with an insertion-preserving dict carrier, then hand the
+    # keys to ordered_or_sorted(...) for canonical edge ordering.
+    cleaned: dict[str, None] = {}
+    for value in values:
+        if not value:
+            continue
+        stripped = value.strip()
+        if not stripped:
+            continue
+        cleaned.setdefault(stripped, None)
     return ordered_or_sorted(
         cleaned,
         source="_normalize_predicates.cleaned",


### PR DESCRIPTION
### Motivation
- Ensure projection normalization and aggregation emit stable, deterministic output that does not depend on input/discovery iteration order. 
- Preserve internal insertion order where appropriate but guarantee canonical ordering at boundaries to satisfy ordering contracts for downstream consumers.

### Description
- Replace predicate deduplication in `_normalize_predicates` (projection_normalize) from a set-based comprehension to an insertion-preserving dict carrier and add an order-contract comment documenting the boundary behavior. 
- Make `apply_spec(..., count_by ...)` (projection_exec) aggregate into a dict keyed by the group tuple and then emit group rows via `ordered_or_sorted(...)` with an explicit stable key function, and add a boundary comment explaining intent. 
- Add `cast` import to `projection_exec.py` to support the stable sort key construction. 
- Add two focused regression tests to `tests/test_projection_spec.py` that assert stable normalized select predicates and stable `count_by` outputs under permuted input/discovery orders.

### Testing
- Ran the targeted tests with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_projection_spec.py tests/test_projection_exec_edges.py` and all collected tests passed (`22 passed`).
- `mise` printed a non-fatal remote-version warning in this environment but the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699500cd95c083248c5e2f7ccd9c10a5)