### PR TITLE
Reify projection operation bundles with dataclass carriers

### DIFF
--- a/src/gabion/analysis/projection_exec.py
+++ b/src/gabion/analysis/projection_exec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 from typing import Callable, Iterable, Mapping, cast
 
@@ -10,6 +11,47 @@ from gabion.analysis.timeout_context import check_deadline
 from gabion.order_contract import OrderPolicy, ordered_or_sorted
 
 Relation = list[dict[str, JSONValue]]
+
+
+@dataclass(frozen=True)
+class SelectParams:
+    predicates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProjectParams:
+    fields: tuple[JSONValue, ...]
+
+
+@dataclass(frozen=True)
+class CountByParams:
+    fields: tuple[JSONValue, ...]
+
+
+@dataclass(frozen=True)
+class TraverseParams:
+    field: str
+    merge: bool = True
+    keep: bool = False
+    prefix: str = ""
+    as_field: str = ""
+    index_field: str = ""
+
+
+@dataclass(frozen=True)
+class SortKey:
+    field: str
+    order: str = "asc"
+
+
+@dataclass(frozen=True)
+class SortParams:
+    keys: tuple[SortKey, ...]
+
+
+@dataclass(frozen=True)
+class LimitParams:
+    count: int | None
 
 
 def apply_spec(
@@ -44,157 +86,51 @@ def apply_spec(
             params_map = {}
 
         if op_name == "select":
-            predicates = params_map.get("predicates", [])
-            if isinstance(predicates, str):
-                predicates = [predicates]
-            if not isinstance(predicates, list):
-                predicates = []
-            for predicate_name in predicates:
-                check_deadline()
-                if not isinstance(predicate_name, str):
-                    continue
-                predicate = op_registry.get(predicate_name)
-                if predicate is None:
-                    continue
-                current = [row for row in current if predicate(row, params)]
+            select_params = _select_params_from_map(params_map)
+            current = _apply_select(current, select_params, op_registry=op_registry, runtime_params=params)
             continue
 
         if op_name == "project":
-            fields = params_map.get("fields", [])
-            if isinstance(fields, str):
-                fields = [fields]
-            if not isinstance(fields, list):
+            project_params = _project_params_from_map(params_map)
+            if project_params is None:
                 continue
-            projected: Relation = []
-            for row in current:
-                check_deadline()
-                projected.append({field: row.get(field) for field in fields})
-            current = projected
+            current = _apply_project(current, project_params)
             continue
 
         if op_name == "count_by":
-            fields = params_map.get("fields", params_map.get("field"))
-            if isinstance(fields, str):
-                fields = [fields]
-            if not isinstance(fields, list) or not fields:
+            count_params = _count_by_params_from_map(params_map)
+            if count_params is None:
                 continue
-            # ordered internally; explicit sort only at edge.
-            # Keep aggregation in a dict keyed by hashable group tuple, then
-            # emit a deterministic edge order so projections are stable even
-            # when discovery/input row order changes.
-            counts: dict[tuple[object, ...], dict[str, JSONValue]] = {}
-            for row in current:
-                check_deadline()
-                key_parts: list[object] = []
-                for field in fields:
-                    check_deadline()
-                    if not isinstance(field, str):
-                        key_parts.append("")
-                        continue
-                    value = row.get(field)
-                    key_parts.append(_hashable(value))
-                key = tuple(key_parts)
-                record = counts.get(key)
-                if record is None:
-                    record = {str(field): row.get(field) for field in fields if isinstance(field, str)}
-                    record["count"] = 0
-                    counts[key] = record
-                record["count"] = int(record.get("count", 0)) + 1
-            ordered_group_keys = ordered_or_sorted(
-                counts,
-                source="apply_spec.count_by.group_keys",
-                policy=OrderPolicy.SORT,
-                key=lambda key: tuple(_sort_value(cast(JSONValue, part)) for part in key),
-            )
-            current = [counts[key] for key in ordered_group_keys]
+            current = _apply_count_by(current, count_params)
             continue
 
         if op_name == "traverse":
-            field = params_map.get("field")
-            if not isinstance(field, str) or not field.strip():
+            traverse_params = _traverse_params_from_map(params_map)
+            if traverse_params is None:
                 continue
-            field = field.strip()
-            merge = params_map.get("merge", True)
-            if not isinstance(merge, bool):
-                merge = True
-            keep = params_map.get("keep", False)
-            if not isinstance(keep, bool):
-                keep = False
-            prefix = params_map.get("prefix", "")
-            if not isinstance(prefix, str):
-                prefix = ""
-            as_field = params_map.get("as", field)
-            if not isinstance(as_field, str) or not as_field.strip():
-                as_field = field
-            index_field = params_map.get("index")
-            if not isinstance(index_field, str) or not index_field.strip():
-                index_field = ""
-            traversed: Relation = []
-            for row in current:
-                check_deadline()
-                seq = row.get(field)
-                if not isinstance(seq, list):
-                    continue
-                base = dict(row)
-                if not keep:
-                    base.pop(field, None)
-                for idx, element in enumerate(seq):
-                    check_deadline()
-                    out = dict(base)
-                    if index_field:
-                        out[index_field] = idx
-                    if merge and isinstance(element, Mapping):
-                        for key, value in element.items():
-                            check_deadline()
-                            if not isinstance(key, str):
-                                key = str(key)
-                            merged_key = f"{prefix}{key}" if prefix else key
-                            out[merged_key] = value
-                    else:
-                        out[as_field] = element
-                    traversed.append(out)
-            current = traversed
+            current = _apply_traverse(current, traverse_params)
             continue
 
         if op_name == "sort":
-            by = params_map.get("by", [])
-            if isinstance(by, Mapping):
-                by = [by]
-            if not isinstance(by, list):
+            sort_params = _sort_params_from_map(params_map)
+            if sort_params is None:
                 continue
-            sort_keys: list[tuple[str, str]] = []
-            for entry in by:
-                check_deadline()
-                if not isinstance(entry, Mapping):
-                    continue
-                field = entry.get("field")
-                order = entry.get("order", "asc")
-                if not isinstance(field, str):
-                    continue
-                if not isinstance(order, str):
-                    order = "asc"
-                order_norm = order.strip().lower() or "asc"
-                sort_keys.append((field, order_norm))
-            for field, order in reversed(sort_keys):
+            for key in reversed(sort_params.keys):
                 check_deadline()
                 current = ordered_or_sorted(
                     current,
-                    source=f"apply_spec.sort[{field}]",
+                    source=f"apply_spec.sort[{key.field}]",
                     policy=OrderPolicy.SORT,
-                    key=lambda row, name=field: _sort_value(row.get(name)),
-                    reverse=order == "desc",
+                    key=lambda row, name=key.field: _sort_value(row.get(name)),
+                    reverse=key.order == "desc",
                 )
             continue
 
         if op_name == "limit":
-            count = params_map.get("count")
-            try:
-                limit = int(count) if count is not None else None
-            except (TypeError, ValueError):
-                limit = None
-            if limit is None or limit < 0:
+            limit_params = _limit_params_from_map(params_map)
+            if limit_params is None or limit_params.count is None or limit_params.count < 0:
                 continue
-            current = current[:limit]
+            current = current[: limit_params.count]
             continue
 
     return current
@@ -214,3 +150,169 @@ def _hashable(value: JSONValue) -> object:
     except TypeError:
         return json.dumps(value, sort_keys=True, separators=(",", ":"))
     return value
+
+
+def _select_params_from_map(params_map: Mapping[str, JSONValue]) -> SelectParams:
+    predicates = params_map.get("predicates", [])
+    if isinstance(predicates, str):
+        predicates = [predicates]
+    if not isinstance(predicates, list):
+        predicates = []
+    names = tuple(name for name in predicates if isinstance(name, str))
+    return SelectParams(predicates=names)
+
+
+def _apply_select(
+    rows: Relation,
+    select_params: SelectParams,
+    *,
+    op_registry: Mapping[str, Callable[[Mapping[str, JSONValue], Mapping[str, JSONValue]], bool]],
+    runtime_params: Mapping[str, JSONValue],
+) -> Relation:
+    selected = rows
+    for predicate_name in select_params.predicates:
+        check_deadline()
+        predicate = op_registry.get(predicate_name)
+        if predicate is None:
+            continue
+        selected = [row for row in selected if predicate(row, runtime_params)]
+    return selected
+
+
+def _project_params_from_map(params_map: Mapping[str, JSONValue]) -> ProjectParams | None:
+    fields = params_map.get("fields", [])
+    if isinstance(fields, str):
+        fields = [fields]
+    if not isinstance(fields, list):
+        return None
+    return ProjectParams(fields=tuple(cast(JSONValue, field) for field in fields))
+
+
+def _apply_project(rows: Relation, params: ProjectParams) -> Relation:
+    projected: Relation = []
+    for row in rows:
+        check_deadline()
+        projected.append({field: row.get(field) for field in params.fields})
+    return projected
+
+
+def _count_by_params_from_map(params_map: Mapping[str, JSONValue]) -> CountByParams | None:
+    fields = params_map.get("fields", params_map.get("field"))
+    if isinstance(fields, str):
+        fields = [fields]
+    if not isinstance(fields, list) or not fields:
+        return None
+    return CountByParams(fields=tuple(cast(JSONValue, field) for field in fields))
+
+
+def _apply_count_by(rows: Relation, params: CountByParams) -> Relation:
+    counts: dict[tuple[object, ...], dict[str, JSONValue]] = {}
+    for row in rows:
+        check_deadline()
+        key_parts: list[object] = []
+        for field in params.fields:
+            check_deadline()
+            if not isinstance(field, str):
+                key_parts.append("")
+                continue
+            key_parts.append(_hashable(row.get(field)))
+        key = tuple(key_parts)
+        record = counts.get(key)
+        if record is None:
+            record = {str(field): row.get(field) for field in params.fields if isinstance(field, str)}
+            record["count"] = 0
+            counts[key] = record
+        record["count"] = int(record.get("count", 0)) + 1
+    ordered_group_keys = ordered_or_sorted(
+        counts,
+        source="apply_spec.count_by.group_keys",
+        policy=OrderPolicy.SORT,
+        key=lambda key: tuple(_sort_value(cast(JSONValue, part)) for part in key),
+    )
+    return [counts[key] for key in ordered_group_keys]
+
+
+def _traverse_params_from_map(params_map: Mapping[str, JSONValue]) -> TraverseParams | None:
+    field = params_map.get("field")
+    if not isinstance(field, str) or not field.strip():
+        return None
+    field = field.strip()
+    merge = params_map.get("merge", True)
+    if not isinstance(merge, bool):
+        merge = True
+    keep = params_map.get("keep", False)
+    if not isinstance(keep, bool):
+        keep = False
+    prefix = params_map.get("prefix", "")
+    if not isinstance(prefix, str):
+        prefix = ""
+    as_field = params_map.get("as", field)
+    if not isinstance(as_field, str) or not as_field.strip():
+        as_field = field
+    index_field = params_map.get("index")
+    if not isinstance(index_field, str) or not index_field.strip():
+        index_field = ""
+    return TraverseParams(
+        field=field,
+        merge=merge,
+        keep=keep,
+        prefix=prefix,
+        as_field=as_field,
+        index_field=index_field,
+    )
+
+
+def _apply_traverse(rows: Relation, params: TraverseParams) -> Relation:
+    traversed: Relation = []
+    for row in rows:
+        check_deadline()
+        seq = row.get(params.field)
+        if not isinstance(seq, list):
+            continue
+        base = dict(row)
+        if not params.keep:
+            base.pop(params.field, None)
+        for idx, element in enumerate(seq):
+            check_deadline()
+            out = dict(base)
+            if params.index_field:
+                out[params.index_field] = idx
+            if params.merge and isinstance(element, Mapping):
+                for key, value in element.items():
+                    check_deadline()
+                    merged_key = f"{params.prefix}{key}" if params.prefix else key
+                    out[str(merged_key)] = value
+            else:
+                out[params.as_field] = element
+            traversed.append(out)
+    return traversed
+
+
+def _sort_params_from_map(params_map: Mapping[str, JSONValue]) -> SortParams | None:
+    by = params_map.get("by", [])
+    if isinstance(by, Mapping):
+        by = [by]
+    if not isinstance(by, list):
+        return None
+    keys: list[SortKey] = []
+    for entry in by:
+        check_deadline()
+        if not isinstance(entry, Mapping):
+            continue
+        field = entry.get("field")
+        order = entry.get("order", "asc")
+        if not isinstance(field, str):
+            continue
+        if not isinstance(order, str):
+            order = "asc"
+        keys.append(SortKey(field=field, order=order.strip().lower() or "asc"))
+    return SortParams(keys=tuple(keys))
+
+
+def _limit_params_from_map(params_map: Mapping[str, JSONValue]) -> LimitParams | None:
+    count = params_map.get("count")
+    try:
+        limit = int(count) if count is not None else None
+    except (TypeError, ValueError):
+        limit = None
+    return LimitParams(count=limit)

--- a/tests/test_projection_spec.py
+++ b/tests/test_projection_spec.py
@@ -253,6 +253,38 @@ def test_count_by_output_stable_under_permuted_discovery_order() -> None:
     ]
 
 
+
+
+def test_count_by_accepts_legacy_single_field_param() -> None:
+    spec = ProjectionSpec(
+        spec_version=1,
+        name="count-field",
+        domain="tests",
+        pipeline=(ProjectionOp("count_by", {"field": "class"}),),
+    )
+    rows = [{"class": "b"}, {"class": "a"}, {"class": "b"}]
+    assert apply_spec(spec, rows) == [
+        {"class": "a", "count": 1},
+        {"class": "b", "count": 2},
+    ]
+
+
+def test_traverse_stringifies_merged_non_string_keys() -> None:
+    spec = ProjectionSpec(
+        spec_version=1,
+        name="traverse",
+        domain="tests",
+        pipeline=(
+            ProjectionOp(
+                "traverse",
+                {"field": "items", "merge": True, "prefix": "item_", "index": "idx"},
+            ),
+        ),
+    )
+    rows = [{"items": [{1: "x", "name": "first"}]}]
+    assert apply_spec(spec, rows) == [{"idx": 0, "item_1": "x", "item_name": "first"}]
+
+
 def test_apply_spec_params_override_replaces_normalized_params() -> None:
     rows = [{"value": 1}, {"value": 3}, {"value": 5}]
 


### PR DESCRIPTION
### Motivation
- The projection pipeline repeatedly accessed ad-hoc dict payloads (`op`, `params`, nested keys) across stages which violated the repo dataflow grammar invariant for recurring bundles. 
- Promote recurring op-parameter clusters to typed carriers so pipeline stages receive structured data instead of raw dicts, reducing parsing duplication and making Tier-2 bundles explicit.

### Description
- Introduced `ProjectionOpPayload` and centralized pipeline parsing in `spec_from_dict` via `_op_payloads_from_pipeline` and `_op_payload_from_entry` in `src/gabion/analysis/projection_spec.py` to extract op payloads once. 
- Added frozen dataclass carriers in `src/gabion/analysis/projection_exec.py` for operation parameter bundles: `SelectParams`, `ProjectParams`, `CountByParams`, `TraverseParams`, `SortKey`/`SortParams`, and `LimitParams` and corresponding typed adapters (`_*_params_from_map`). 
- Refactored `apply_spec` to use typed helpers that parse params once and call focused implementation helpers (`_apply_select`, `_apply_project`, `_apply_count_by`, `_apply_traverse`, sort/limit helpers), preserving original semantics and ordering determinism. 
- Added focused tests in `tests/test_projection_spec.py` to validate legacy `count_by` single-field payload compatibility and `traverse` merge behavior that stringifies non-string keys, and adjusted existing tests to exercise the refactor.

### Testing
- Ran Python compile checks with `python -m py_compile src/gabion/analysis/projection_exec.py src/gabion/analysis/projection_spec.py` and they succeeded. 
- Executed unit tests for the projection spec with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_projection_spec.py` and all tests passed (`17 passed`). 
- Attempted to run repo-local tooling via `mise exec -- python -m pytest ...` but the pinned toolchain resolution failed in this environment, so I used the `PYTHONPATH=src` pytest fallback for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995043ec28c8324ab519af8920f7743)