### PR TITLE
Enable default-on delta gates in staged dataflow pipeline

### DIFF
--- a/scripts/annotation_drift_orphaned_gate.py
+++ b/scripts/annotation_drift_orphaned_gate.py
@@ -10,8 +10,10 @@ ENV_FLAG = "GABION_GATE_ORPHANED_DELTA"
 
 def _enabled(value: str | None = None) -> bool:
     if value is None:
-        value = os.getenv(ENV_FLAG, "")
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+        value = os.getenv(ENV_FLAG)
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _delta_value(payload: Mapping[str, object]) -> int:
@@ -31,19 +33,22 @@ def check_gate(path: Path, *, enabled: bool | None = None) -> int:
     if enabled is None:
         enabled = _enabled()
     if not enabled:
-        print(f"Annotation drift gate disabled; set {ENV_FLAG}=1 to enable.")
+        print(
+            "Annotation drift gate disabled by override; "
+            f"set {ENV_FLAG}=1 to enforce."
+        )
         return 0
     if not path.exists():
-        print("Annotation drift delta missing; gate skipped.")
-        return 0
+        print("Annotation drift delta missing; gate failed.")
+        return 2
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Annotation drift delta unreadable; gate skipped: {exc}")
-        return 0
+        print(f"Annotation drift delta unreadable; gate failed: {exc}")
+        return 2
     if not isinstance(payload, Mapping):
-        print("Annotation drift delta unreadable; gate skipped.")
-        return 0
+        print("Annotation drift delta unreadable; gate failed.")
+        return 2
     delta_value = _delta_value(payload)
     if delta_value > 0:
         summary = payload.get("summary", {})

--- a/scripts/obsolescence_delta_gate.py
+++ b/scripts/obsolescence_delta_gate.py
@@ -1,29 +1,60 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from typing import Mapping
+
+ENV_FLAG = "GABION_GATE_OPAQUE_DELTA"
 
 
-def main() -> int:
-    path = Path("artifacts/out/test_obsolescence_delta.json")
-    if not path.exists():
-        print("Test obsolescence delta missing; gate skipped.")
+def _enabled(value: str | None = None) -> bool:
+    if value is None:
+        value = os.getenv(ENV_FLAG)
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _delta_value(payload: Mapping[str, object]) -> int:
+    summary = payload.get("summary", {})
+    if not isinstance(summary, Mapping):
         return 0
+    opaque = summary.get("opaque_evidence", {})
+    if not isinstance(opaque, Mapping):
+        return 0
+    try:
+        return int(opaque.get("delta", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def check_gate(path: Path, *, enabled: bool | None = None) -> int:
+    if enabled is None:
+        enabled = _enabled()
+    if not enabled:
+        print(
+            "Opaque obsolescence gate disabled by override; "
+            f"set {ENV_FLAG}=1 to enforce."
+        )
+        return 0
+    if not path.exists():
+        print("Test obsolescence delta missing; gate failed.")
+        return 2
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Test obsolescence delta unreadable; gate skipped: {exc}")
-        return 0
-    summary = payload.get("summary", {})
-    opaque = summary.get("opaque_evidence", {}) if isinstance(summary, dict) else {}
-    delta = opaque.get("delta", 0)
-    try:
-        delta_value = int(delta)
-    except (TypeError, ValueError):
-        delta_value = 0
+        print(f"Test obsolescence delta unreadable; gate failed: {exc}")
+        return 2
+    if not isinstance(payload, Mapping):
+        print("Test obsolescence delta unreadable; gate failed.")
+        return 2
+    delta_value = _delta_value(payload)
     if delta_value > 0:
-        baseline = opaque.get("baseline", 0)
-        current = opaque.get("current", 0)
+        summary = payload.get("summary", {})
+        opaque = summary.get("opaque_evidence", {}) if isinstance(summary, Mapping) else {}
+        baseline = opaque.get("baseline", 0) if isinstance(opaque, Mapping) else 0
+        current = opaque.get("current", 0) if isinstance(opaque, Mapping) else 0
         print(
             "Opaque evidence delta increased: "
             f"{baseline} -> {current} (+{delta_value})."
@@ -31,6 +62,10 @@ def main() -> int:
         return 1
     print(f"Opaque evidence delta OK ({delta_value}).")
     return 0
+
+
+def main() -> int:
+    return check_gate(Path("artifacts/out/test_obsolescence_delta.json"))
 
 
 if __name__ == "__main__":

--- a/scripts/obsolescence_delta_unmapped_gate.py
+++ b/scripts/obsolescence_delta_unmapped_gate.py
@@ -3,46 +3,74 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-
+from typing import Mapping
 
 ENV_FLAG = "GABION_GATE_UNMAPPED_DELTA"
 
 
-def _enabled() -> bool:
-    value = os.getenv(ENV_FLAG, "").strip().lower()
-    return value in {"1", "true", "yes", "on"}
+def _enabled(value: str | None = None) -> bool:
+    if value is None:
+        value = os.getenv(ENV_FLAG)
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
-def main() -> int:
-    if not _enabled():
-        print(f"Unmapped delta gate disabled; set {ENV_FLAG}=1 to enable.")
+def _delta_value(payload: Mapping[str, object]) -> int:
+    summary = payload.get("summary", {})
+    if not isinstance(summary, Mapping):
         return 0
-    path = Path("artifacts/out/test_obsolescence_delta.json")
+    counts = summary.get("counts", {})
+    if not isinstance(counts, Mapping):
+        return 0
+    delta = counts.get("delta", {})
+    if not isinstance(delta, Mapping):
+        return 0
+    try:
+        return int(delta.get("unmapped", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def check_gate(path: Path, *, enabled: bool | None = None) -> int:
+    if enabled is None:
+        enabled = _enabled()
+    if not enabled:
+        print(
+            "Unmapped delta gate disabled by override; "
+            f"set {ENV_FLAG}=1 to enforce."
+        )
+        return 0
     if not path.exists():
-        print("Test obsolescence delta missing; gate skipped.")
-        return 0
+        print("Test obsolescence delta missing; gate failed.")
+        return 2
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Test obsolescence delta unreadable; gate skipped: {exc}")
-        return 0
-    summary = payload.get("summary", {})
-    counts = summary.get("counts", {}) if isinstance(summary, dict) else {}
-    delta = counts.get("delta", {}) if isinstance(counts, dict) else {}
-    try:
-        delta_value = int(delta.get("unmapped", 0))
-    except (TypeError, ValueError):
-        delta_value = 0
+        print(f"Test obsolescence delta unreadable; gate failed: {exc}")
+        return 2
+    if not isinstance(payload, Mapping):
+        print("Test obsolescence delta unreadable; gate failed.")
+        return 2
+    delta_value = _delta_value(payload)
     if delta_value > 0:
-        baseline = counts.get("baseline", {}).get("unmapped", 0)
-        current = counts.get("current", {}).get("unmapped", 0)
+        summary = payload.get("summary", {})
+        counts = summary.get("counts", {}) if isinstance(summary, Mapping) else {}
+        baseline = counts.get("baseline", {}) if isinstance(counts, Mapping) else {}
+        current = counts.get("current", {}) if isinstance(counts, Mapping) else {}
+        before = baseline.get("unmapped", 0) if isinstance(baseline, Mapping) else 0
+        after = current.get("unmapped", 0) if isinstance(current, Mapping) else 0
         print(
             "Unmapped evidence delta increased: "
-            f"{baseline} -> {current} (+{delta_value})."
+            f"{before} -> {after} (+{delta_value})."
         )
         return 1
     print(f"Unmapped evidence delta OK ({delta_value}).")
     return 0
+
+
+def main() -> int:
+    return check_gate(Path("artifacts/out/test_obsolescence_delta.json"))
 
 
 if __name__ == "__main__":

--- a/tests/test_delta_gates.py
+++ b/tests/test_delta_gates.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from scripts import ambiguity_delta_gate
+from scripts import annotation_drift_orphaned_gate
+from scripts import obsolescence_delta_gate
+from scripts import obsolescence_delta_unmapped_gate
+
+
+@pytest.mark.parametrize(
+    ("gate_fn", "payload"),
+    [
+        (ambiguity_delta_gate.check_gate, {"summary": {"total": {"delta": 1}}}),
+        (
+            annotation_drift_orphaned_gate.check_gate,
+            {"summary": {"delta": {"orphaned": 1}}},
+        ),
+        (obsolescence_delta_gate.check_gate, {"summary": {"opaque_evidence": {"delta": 1}}}),
+        (
+            obsolescence_delta_unmapped_gate.check_gate,
+            {"summary": {"counts": {"delta": {"unmapped": 1}}}},
+        ),
+    ],
+)
+def test_gate_detects_positive_delta(
+    tmp_path: Path,
+    gate_fn: Callable[..., int],
+    payload: dict[str, object],
+) -> None:
+    delta_path = tmp_path / "delta.json"
+    delta_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert gate_fn(delta_path, enabled=True) == 1
+
+
+@pytest.mark.parametrize(
+    "gate_fn",
+    [
+        ambiguity_delta_gate.check_gate,
+        annotation_drift_orphaned_gate.check_gate,
+        obsolescence_delta_gate.check_gate,
+        obsolescence_delta_unmapped_gate.check_gate,
+    ],
+)
+def test_gate_fails_when_payload_missing(tmp_path: Path, gate_fn: Callable[..., int]) -> None:
+    delta_path = tmp_path / "missing.json"
+    assert gate_fn(delta_path, enabled=True) == 2
+
+
+@pytest.mark.parametrize(
+    "gate_fn",
+    [
+        ambiguity_delta_gate.check_gate,
+        annotation_drift_orphaned_gate.check_gate,
+        obsolescence_delta_gate.check_gate,
+        obsolescence_delta_unmapped_gate.check_gate,
+    ],
+)
+def test_gate_fails_when_payload_malformed(tmp_path: Path, gate_fn: Callable[..., int]) -> None:
+    delta_path = tmp_path / "delta.json"
+    delta_path.write_text("{not-json", encoding="utf-8")
+    assert gate_fn(delta_path, enabled=True) == 2
+
+
+@pytest.mark.parametrize(
+    "enabled_fn",
+    [
+        ambiguity_delta_gate._enabled,
+        annotation_drift_orphaned_gate._enabled,
+        obsolescence_delta_gate._enabled,
+        obsolescence_delta_unmapped_gate._enabled,
+    ],
+)
+def test_gate_default_is_enabled(enabled_fn: Callable[[str | None], bool]) -> None:
+    assert enabled_fn(None) is True
+    assert enabled_fn("0") is False


### PR DESCRIPTION
### Motivation

- Ensure protected-class delta gates (ambiguity total, annotation orphaned, obsolescence unmapped/opaque) are enforced by default during staged dataflow CI so regressions are visible in one pass. 
- Narrow gate semantics so they only fail on positive deltas for protected classes and surface missing/malformed payloads as infra failures instead of silently skipping. 
- Wire gates into the staged audit flow so a stage that otherwise succeeds will still fail when a protected delta gate trips. 

### Description

- Promoted gate default semantics: each gate now treats the env var as an explicit override and is enabled by default when the env var is absent, and disabled only when set to a falsey value (`0/false/no/off`). (Files changed: `scripts/ambiguity_delta_gate.py`, `scripts/annotation_drift_orphaned_gate.py`, `scripts/obsolescence_delta_unmapped_gate.py`, `scripts/obsolescence_delta_gate.py`.)
- Tightened payload handling: missing or malformed delta payloads now cause an infra-style non-zero failure exit (`2`) instead of being silently skipped; gates still only return a failing status (`1`) when the protected-class delta is positive. (See the updated `check_gate` implementations.)
- Added an opaque-obsolescence gate helper and reworked obsolescence gate functions to mirror the same `check_gate` pattern and return codes. (`scripts/obsolescence_delta_gate.py` and `scripts/obsolescence_delta_unmapped_gate.py`.)
- Integrated delta gates into the staged pipeline: `scripts/run_dataflow_stage.py` gains a `_DELTA_GATE_SCRIPTS` list and `_run_delta_gates` runner that is executed after a successful stage run, and a failing gate converts the stage outcome into a hard failure with `analysis_state="delta_gate_failure"`; the gate runner is injectable for tests. 
- Tests: added `tests/test_delta_gates.py` to cover positive-delta detection, missing/malformed payload handling, and default-on env parsing; updated `tests/test_run_dataflow_stage.py` to exercise gate-runner injection and assert that a delta gate failure converts a successful audit into a staged failure.

### Testing

- Ran targeted pytest smoke: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_delta_gates.py tests/test_annotation_drift_gate.py tests/test_run_dataflow_stage.py`, which completed with all tests passing (`24 passed`).
- Compiled modified modules to check syntax with `python -m compileall ...` which succeeded for the edited scripts and tests.
- Note: an earlier attempt to run the suite via `mise` was blocked by local `mise` trust/tool resolution constraints, so tests were validated using the `PYTHONPATH`-based pytest invocation above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950f3156dc832482272927b1b72549)