### PR TITLE
Enforce order contracts in analysis/server pipelines

### DIFF
--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -96,6 +96,11 @@ def canonical_type_key(hint: str) -> str:
             source="canonical_type_key.union_parts",
             policy=OrderPolicy.SORT,
         )
+        normalized = ordered_or_sorted(
+            normalized,
+            source="canonical_type_key.union_parts.enforce",
+            policy=OrderPolicy.ENFORCE,
+        )
         return f"Union[{', '.join(normalized)}]"
     if raw.startswith("Optional[") and raw.endswith("]"):
         inner = raw[len("Optional[") : -1]
@@ -107,6 +112,11 @@ def canonical_type_key(hint: str) -> str:
             source="canonical_type_key.optional_parts",
             policy=OrderPolicy.SORT,
         )
+        normalized = ordered_or_sorted(
+            normalized,
+            source="canonical_type_key.optional_parts.enforce",
+            policy=OrderPolicy.ENFORCE,
+        )
         return f"Union[{', '.join(normalized)}]"
     if raw.startswith("Union[") and raw.endswith("]"):
         inner = raw[len("Union[") : -1]
@@ -115,6 +125,11 @@ def canonical_type_key(hint: str) -> str:
             (part for part in (canonical_type_key(p) for p in parts) if part),
             source="canonical_type_key.union_bracket_parts",
             policy=OrderPolicy.SORT,
+        )
+        normalized = ordered_or_sorted(
+            normalized,
+            source="canonical_type_key.union_bracket_parts.enforce",
+            policy=OrderPolicy.ENFORCE,
         )
         return f"Union[{', '.join(normalized)}]"
     if "[" in raw and raw.endswith("]"):

--- a/tests/test_dataflow_report_helpers.py
+++ b/tests/test_dataflow_report_helpers.py
@@ -479,3 +479,27 @@ def test_merge_counts_by_knobs_merges_subset() -> None:
     counts = {("a", "b"): 1, ("a", "b", "k"): 2}
     merged = da._merge_counts_by_knobs(counts, {"k"})
     assert merged == {("a", "b", "k"): 3}
+
+
+# gabion:evidence E:function_site::dataflow_audit.py::gabion.analysis.dataflow_audit._topologically_order_report_projection_specs
+def test_report_projection_topological_order_is_stable_for_shuffled_dep_order() -> None:
+    da = _load()
+    spec_a = da._report_section_spec(section_id="a", phase="collection")
+    spec_b = da._report_section_spec(
+        section_id="b",
+        phase="post",
+        deps=("c", "a"),
+    )
+    spec_b_shuffled = da._report_section_spec(
+        section_id="b",
+        phase="post",
+        deps=("a", "c"),
+    )
+    spec_c = da._report_section_spec(section_id="c", phase="edge", deps=("a",))
+
+    ordered = da._topologically_order_report_projection_specs((spec_a, spec_b, spec_c))
+    ordered_shuffled = da._topologically_order_report_projection_specs(
+        (spec_a, spec_b_shuffled, spec_c)
+    )
+
+    assert [spec.section_id for spec in ordered] == [spec.section_id for spec in ordered_shuffled]

--- a/tests/test_type_fingerprints.py
+++ b/tests/test_type_fingerprints.py
@@ -754,3 +754,9 @@ def test_build_fingerprint_registry_seed_is_stable_under_reordered_inputs() -> N
     assert reg_a.bit_positions == reg_b.bit_positions
     assert reg_a.prime_for("int") == 2
     assert reg_a.prime_for("ctor:list") == 13
+
+
+# gabion:evidence E:function_site::type_fingerprints.py::gabion.analysis.type_fingerprints.canonical_type_key
+def test_canonical_type_key_is_stable_for_shuffled_union_order() -> None:
+    tf = _load()
+    assert tf.canonical_type_key("str | int | None") == tf.canonical_type_key("None | str | int")


### PR DESCRIPTION
### Motivation

- Reduce ad-hoc `sorted(...)` use in internal pipeline code and make ordering decisions explicit via the existing `ordered_or_sorted` contract. 
- Treat `_RAW_SORTED_BASELINE_COUNTS` as the ordered-debt baseline and lower allowances incrementally after each targeted module pass. 
- Preserve caller-order invariants inside analysis/server internals and keep explicit sorting only at outward serialization/report boundaries. 
- Add focused invariants that prove stability of selected module outputs under shuffled upstream insertion order.

### Description

- Imported `OrderPolicy` alongside `ordered_or_sorted` and replaced internal `sorted(...)` call sites in targeted code paths with `ordered_or_sorted(..., source=...)` in `src/gabion/server.py`, `src/gabion/analysis/type_fingerprints.py`, and `src/gabion/analysis/dataflow_audit.py`. 
- Enforced caller-order invariants at internal handoffs by using `policy=OrderPolicy.ENFORCE` where caller-order should be canonical (server bundle linting and other internal loops). 
- Kept canonicalization/serialization sorting at outward boundaries while adding ENFORCE re-checks after sort-based normalization in type fingerprint union/optional normalization paths. 
- Lowered raw-sorted baseline allowances in `_RAW_SORTED_BASELINE_COUNTS` for the touched modules (`src/gabion/analysis/dataflow_audit.py`, `src/gabion/server.py`, `src/gabion/analysis/type_fingerprints.py`) to reflect the module passes. 
- Added focused invariant tests to prove stable output under shuffled upstream insertion order: a dataflow report projection topological-order stability test, a server diagnostics stability test for shuffled bundle insertion order, and a canonical type-key stability test for shuffled union order.

### Testing

- Ran the targeted test subset via `PYTHONPATH=src python -m pytest -o addopts='' tests/test_server_helpers.py tests/test_type_fingerprints.py tests/test_dataflow_report_helpers.py -q` and received a green run (`84 passed`).
- Executed an AST-based sanity check comparing raw `sorted()` callsite counts against `_RAW_SORTED_BASELINE_COUNTS` for the touched modules and updated baseline entries accordingly. 
- All added stability tests passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995109257d88324b5ca951abbd01bf2)