### PR TITLE
Default-on burn-down delta gates and deterministic artifact failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,8 @@ jobs:
             --log-file-level=INFO
       - name: Delta state emit
         run: .venv/bin/python scripts/delta_state_emit.py
-      - name: Delta triplets
+      - name: Delta triplets (default-on burn-down gates)
         run: .venv/bin/python scripts/delta_triplets.py
-        env:
-          GABION_GATE_UNMAPPED_DELTA: "1"
-          GABION_GATE_ORPHANED_DELTA: "1"
-          GABION_GATE_AMBIGUITY_DELTA: "1"
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/scripts/annotation_drift_orphaned_gate.py
+++ b/scripts/annotation_drift_orphaned_gate.py
@@ -10,7 +10,9 @@ ENV_FLAG = "GABION_GATE_ORPHANED_DELTA"
 
 def _enabled(value: str | None = None) -> bool:
     if value is None:
-        value = os.getenv(ENV_FLAG, "")
+        value = os.getenv(ENV_FLAG)
+    if value is None or not value.strip():
+        return True
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
@@ -31,19 +33,22 @@ def check_gate(path: Path, *, enabled: bool | None = None) -> int:
     if enabled is None:
         enabled = _enabled()
     if not enabled:
-        print(f"Annotation drift gate disabled; set {ENV_FLAG}=1 to enable.")
+        print(
+            "Annotation drift gate disabled via emergency override "
+            f"({ENV_FLAG})."
+        )
         return 0
     if not path.exists():
-        print("Annotation drift delta missing; gate skipped.")
-        return 0
+        print(f"Annotation drift delta artifact missing: {path}")
+        return 1
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Annotation drift delta unreadable; gate skipped: {exc}")
-        return 0
+        print(f"Annotation drift delta artifact malformed ({path}): {exc}")
+        return 1
     if not isinstance(payload, Mapping):
-        print("Annotation drift delta unreadable; gate skipped.")
-        return 0
+        print(f"Annotation drift delta artifact must be an object: {path}")
+        return 1
     delta_value = _delta_value(payload)
     if delta_value > 0:
         summary = payload.get("summary", {})
@@ -60,8 +65,8 @@ def check_gate(path: Path, *, enabled: bool | None = None) -> int:
             current.get("orphaned", 0) if isinstance(current, Mapping) else 0
         )
         print(
-            "Orphaned annotation delta increased: "
-            f"{before} -> {after} (+{delta_value})."
+            "Orphaned annotation delta increased "
+            f"(before={before}, current={after}, delta=+{delta_value})."
         )
         return 1
     print(f"Orphaned annotation delta OK ({delta_value}).")

--- a/scripts/obsolescence_delta_gate.py
+++ b/scripts/obsolescence_delta_gate.py
@@ -1,19 +1,41 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 
-def main() -> int:
-    path = Path("artifacts/out/test_obsolescence_delta.json")
-    if not path.exists():
-        print("Test obsolescence delta missing; gate skipped.")
+ENV_FLAG = "GABION_GATE_OBSOLESCENCE_DELTA"
+
+
+def _enabled(value: str | None = None) -> bool:
+    if value is None:
+        value = os.getenv(ENV_FLAG)
+    if value is None or not value.strip():
+        return True
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def check_gate(path: Path, *, enabled: bool | None = None) -> int:
+    if enabled is None:
+        enabled = _enabled()
+    if not enabled:
+        print(
+            "Test obsolescence gate disabled via emergency override "
+            f"({ENV_FLAG})."
+        )
         return 0
+    if not path.exists():
+        print(f"Test obsolescence delta artifact missing: {path}")
+        return 1
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Test obsolescence delta unreadable; gate skipped: {exc}")
-        return 0
+        print(f"Test obsolescence delta artifact malformed ({path}): {exc}")
+        return 1
+    if not isinstance(payload, dict):
+        print(f"Test obsolescence delta artifact must be an object: {path}")
+        return 1
     summary = payload.get("summary", {})
     opaque = summary.get("opaque_evidence", {}) if isinstance(summary, dict) else {}
     delta = opaque.get("delta", 0)
@@ -25,12 +47,16 @@ def main() -> int:
         baseline = opaque.get("baseline", 0)
         current = opaque.get("current", 0)
         print(
-            "Opaque evidence delta increased: "
-            f"{baseline} -> {current} (+{delta_value})."
+            "Opaque evidence delta increased "
+            f"(before={baseline}, current={current}, delta=+{delta_value})."
         )
         return 1
     print(f"Opaque evidence delta OK ({delta_value}).")
     return 0
+
+
+def main() -> int:
+    return check_gate(Path("artifacts/out/test_obsolescence_delta.json"))
 
 
 if __name__ == "__main__":

--- a/scripts/obsolescence_delta_unmapped_gate.py
+++ b/scripts/obsolescence_delta_unmapped_gate.py
@@ -8,24 +8,34 @@ from pathlib import Path
 ENV_FLAG = "GABION_GATE_UNMAPPED_DELTA"
 
 
-def _enabled() -> bool:
-    value = os.getenv(ENV_FLAG, "").strip().lower()
-    return value in {"1", "true", "yes", "on"}
+def _enabled(value: str | None = None) -> bool:
+    if value is None:
+        value = os.getenv(ENV_FLAG)
+    if value is None or not value.strip():
+        return True
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def main() -> int:
-    if not _enabled():
-        print(f"Unmapped delta gate disabled; set {ENV_FLAG}=1 to enable.")
+def check_gate(path: Path, *, enabled: bool | None = None) -> int:
+    if enabled is None:
+        enabled = _enabled()
+    if not enabled:
+        print(
+            "Unmapped delta gate disabled via emergency override "
+            f"({ENV_FLAG})."
+        )
         return 0
-    path = Path("artifacts/out/test_obsolescence_delta.json")
     if not path.exists():
-        print("Test obsolescence delta missing; gate skipped.")
-        return 0
+        print(f"Test obsolescence delta artifact missing: {path}")
+        return 1
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"Test obsolescence delta unreadable; gate skipped: {exc}")
-        return 0
+        print(f"Test obsolescence delta artifact malformed ({path}): {exc}")
+        return 1
+    if not isinstance(payload, dict):
+        print(f"Test obsolescence delta artifact must be an object: {path}")
+        return 1
     summary = payload.get("summary", {})
     counts = summary.get("counts", {}) if isinstance(summary, dict) else {}
     delta = counts.get("delta", {}) if isinstance(counts, dict) else {}
@@ -37,12 +47,16 @@ def main() -> int:
         baseline = counts.get("baseline", {}).get("unmapped", 0)
         current = counts.get("current", {}).get("unmapped", 0)
         print(
-            "Unmapped evidence delta increased: "
-            f"{baseline} -> {current} (+{delta_value})."
+            "Unmapped evidence delta increased "
+            f"(before={baseline}, current={current}, delta=+{delta_value})."
         )
         return 1
     print(f"Unmapped evidence delta OK ({delta_value}).")
     return 0
+
+
+def main() -> int:
+    return check_gate(Path("artifacts/out/test_obsolescence_delta.json"))
 
 
 if __name__ == "__main__":

--- a/tests/test_delta_gates.py
+++ b/tests/test_delta_gates.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import (
+    ambiguity_delta_gate,
+    annotation_drift_orphaned_gate,
+    obsolescence_delta_gate,
+    obsolescence_delta_unmapped_gate,
+)
+
+
+@pytest.mark.parametrize(
+    ("gate", "name"),
+    [
+        (ambiguity_delta_gate.check_gate, "Ambiguity delta artifact missing"),
+        (
+            annotation_drift_orphaned_gate.check_gate,
+            "Annotation drift delta artifact missing",
+        ),
+        (
+            obsolescence_delta_gate.check_gate,
+            "Test obsolescence delta artifact missing",
+        ),
+        (
+            obsolescence_delta_unmapped_gate.check_gate,
+            "Test obsolescence delta artifact missing",
+        ),
+    ],
+)
+def test_delta_gates_fail_for_missing_artifact(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], gate, name: str
+) -> None:
+    missing = tmp_path / "missing.json"
+    assert gate(missing, enabled=True) == 1
+    assert name in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        ambiguity_delta_gate.check_gate,
+        annotation_drift_orphaned_gate.check_gate,
+        obsolescence_delta_gate.check_gate,
+        obsolescence_delta_unmapped_gate.check_gate,
+    ],
+)
+def test_delta_gates_fail_for_malformed_artifact(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], gate
+) -> None:
+    payload_path = tmp_path / "delta.json"
+    payload_path.write_text("not-json")
+    assert gate(payload_path, enabled=True) == 1
+    assert "artifact malformed" in capsys.readouterr().out
+
+
+def test_ambiguity_gate_failure_output_has_before_current_delta(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload_path = tmp_path / "ambiguity.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "total": {
+                        "baseline": 3,
+                        "current": 5,
+                        "delta": 2,
+                    }
+                }
+            }
+        )
+    )
+    assert ambiguity_delta_gate.check_gate(payload_path, enabled=True) == 1
+    out = capsys.readouterr().out
+    assert "before=3" in out
+    assert "current=5" in out
+    assert "delta=+2" in out
+
+
+def test_annotation_drift_gate_failure_output_has_before_current_delta(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload_path = tmp_path / "annotation.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "baseline": {"orphaned": 1},
+                    "current": {"orphaned": 2},
+                    "delta": {"orphaned": 1},
+                }
+            }
+        )
+    )
+    assert annotation_drift_orphaned_gate.check_gate(payload_path, enabled=True) == 1
+    out = capsys.readouterr().out
+    assert "before=1" in out
+    assert "current=2" in out
+    assert "delta=+1" in out
+
+
+def test_obsolescence_gates_failure_output_has_before_current_delta(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload_path = tmp_path / "obsolescence.json"
+    payload = {
+        "summary": {
+            "opaque_evidence": {"baseline": 2, "current": 4, "delta": 2},
+            "counts": {
+                "baseline": {"unmapped": 1},
+                "current": {"unmapped": 2},
+                "delta": {"unmapped": 1},
+            },
+        }
+    }
+    payload_path.write_text(json.dumps(payload))
+
+    assert obsolescence_delta_gate.check_gate(payload_path, enabled=True) == 1
+    out = capsys.readouterr().out
+    assert "before=2" in out
+    assert "current=4" in out
+    assert "delta=+2" in out
+
+    assert obsolescence_delta_unmapped_gate.check_gate(payload_path, enabled=True) == 1
+    out = capsys.readouterr().out
+    assert "before=1" in out
+    assert "current=2" in out
+    assert "delta=+1" in out
+
+
+@pytest.mark.parametrize(
+    ("enabled_fn", "false_value"),
+    [
+        (ambiguity_delta_gate._enabled, "0"),
+        (annotation_drift_orphaned_gate._enabled, "false"),
+        (obsolescence_delta_gate._enabled, "no"),
+        (obsolescence_delta_unmapped_gate._enabled, "off"),
+    ],
+)
+def test_gate_enabled_defaults_on_and_can_be_disabled(enabled_fn, false_value: str) -> None:
+    assert enabled_fn(None) is True
+    assert enabled_fn("") is True
+    assert enabled_fn(false_value) is False


### PR DESCRIPTION
### Motivation
- Make the delta burn-down gates part of the normal dataflow CI path instead of opt-in so regressions are caught by default.
- Ensure gate failures are deterministic and noisy when required artifacts are missing or malformed so CI does not silently pass on bad inputs.
- Keep the existing env flags as explicit emergency overrides rather than the normal enable mechanism.

### Description
- Default-enabled the ambiguity, annotation-drift-orphaned, obsolescence (opaque) and obsolescence unmapped gates and removed the per-step env flags in the CI `checks` stage so delta triplets run in normal mode.
- Hardened gate logic to treat missing artifact files, malformed JSON, and non-object payloads as deterministic failures (return `1`) and emit clear messages mentioning the artifact path.
- Normalized failure output to include explicit `before`, `current`, and `delta` values for failing classes and added `check_gate(...)` entry points to obsolescence gate scripts for testability.
- Added focused unit tests in `tests/test_delta_gates.py` to cover missing/malformed artifact behavior, output formatting, and default-on vs explicit-disable semantics.

### Testing
- Attempted `mise exec -- python -m pytest tests/test_delta_gates.py tests/test_annotation_drift_gate.py` which failed in this environment due to untrusted `mise` config / network/tool resolution. (Expected in offline CI intervention scenarios.)
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_delta_gates.py tests/test_annotation_drift_gate.py` which executed the new and existing gate tests and passed (17 passed). 
- Verified the CI workflow change to run `scripts/delta_triplets.py` without per-step enable env flags so the gates run by default during `checks`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951ef862588324bd15a89beade41d1)