### PR TITLE
Tighten projection ordering regression coverage and raw-sorted baselines

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -201,8 +201,6 @@ _RAW_SORTED_BASELINE_COUNTS: dict[str, int] = {
     "src/gabion/analysis/evidence_keys.py": 2,
     "src/gabion/analysis/forest_signature.py": 4,
     "src/gabion/analysis/forest_spec.py": 5,
-    "src/gabion/analysis/projection_exec.py": 1,
-    "src/gabion/analysis/projection_normalize.py": 3,
     "src/gabion/analysis/schema_audit.py": 1,
     "src/gabion/analysis/test_annotation_drift_delta.py": 2,
     "src/gabion/analysis/test_evidence.py": 6,

--- a/tests/test_projection_exec_edges.py
+++ b/tests/test_projection_exec_edges.py
@@ -84,6 +84,19 @@ def test_normalize_helpers_cover_branches() -> None:
     assert _normalize_value([{"b": 2, "a": 1}]) == [{"a": 1, "b": 2}]
 
 
+def test_normalize_pipeline_stable_under_shuffled_upstream_order() -> None:
+    pipeline_a = (
+        ProjectionOp("select", {"predicates": ["beta", "alpha", "beta"]}),
+        ProjectionOp("count_by", {"fields": ["group_b", "group_a", "group_b"]}),
+    )
+    pipeline_b = (
+        ProjectionOp("select", {"predicates": ["alpha", "beta"]}),
+        ProjectionOp("count_by", {"fields": ["group_a", "group_b"]}),
+    )
+
+    assert _normalize_pipeline(pipeline_a) == _normalize_pipeline(pipeline_b)
+
+
 # gabion:evidence E:decision_surface/direct::projection_exec.py::gabion.analysis.projection_exec.apply_spec::params_override E:decision_surface/direct::projection_exec.py::gabion.analysis.projection_exec._sort_value::value
 def test_apply_spec_with_custom_normalizer_handles_invalid_ops() -> None:
     rows = [


### PR DESCRIPTION
### Motivation
- Prefer `ordered_or_sorted(...)` at outward-facing projection code paths, reduce legacy raw-`sorted()` baseline allowances for projection modules, and add a small regression to ensure projection normalization is stable when upstream insertion order is shuffled.

### Description
- Removed the `_RAW_SORTED_BASELINE_COUNTS` entries for `src/gabion/analysis/projection_exec.py` and `src/gabion/analysis/projection_normalize.py` in `src/gabion/analysis/dataflow_audit.py` and added `test_normalize_pipeline_stable_under_shuffled_upstream_order` to `tests/test_projection_exec_edges.py` to cover shuffled upstream predicate/field order.

### Testing
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_projection_exec_edges.py tests/test_projection_spec.py tests/test_report_markdown_module.py tests/test_dataflow_audit_helpers.py -k 'projection or report_markdown or raw_sorted_contract_violations_strict_and_baseline'` which completed successfully with `40 passed, 128 deselected`; an earlier `mise exec` attempt failed in this environment due to tool resolution/network metadata but is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995245f5a6c8324a178aab8de2d21e9)