### PR TITLE
Add timeout diagnostics and resume controls to refresh_baselines checks

### DIFF
--- a/tests/test_refresh_baselines_run_check.py
+++ b/tests/test_refresh_baselines_run_check.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import refresh_baselines
+
+
+def test_run_check_includes_timeout_diagnostics_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, *, check, timeout, env):
+        captured["cmd"] = cmd
+        captured["check"] = check
+        captured["timeout"] = timeout
+        captured["env"] = env
+
+    monkeypatch.setattr(refresh_baselines.subprocess, "run", _fake_run)
+
+    refresh_baselines._run_check(
+        "--emit-test-obsolescence-delta",
+        timeout=17,
+        resume_on_timeout=1,
+        resume_checkpoint=Path("artifacts/out/refresh_baselines_resume.json"),
+        extra=["--foo", "bar"],
+    )
+
+    assert captured["check"] is True
+    assert captured["timeout"] == 17
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GABION_DIRECT_RUN"] == "1"
+
+    cmd = captured["cmd"]
+    assert cmd[:5] == [sys.executable, "-m", "gabion", "check", "--no-fail-on-violations"]
+    assert "--emit-timeout-progress-report" in cmd
+    resume_idx = cmd.index("--resume-on-timeout")
+    assert cmd[resume_idx + 1] == "1"
+    checkpoint_idx = cmd.index("--resume-checkpoint")
+    assert cmd[checkpoint_idx + 1] == "artifacts/out/refresh_baselines_resume.json"
+    assert cmd[-2:] == ["--foo", "bar"]
+
+
+def test_run_check_formats_called_process_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_run(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(returncode=2, cmd=["gabion", "check"])
+
+    monkeypatch.setattr(refresh_baselines.subprocess, "run", _raise_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        refresh_baselines._run_check(
+            "--write-ambiguity-baseline",
+            timeout=None,
+            resume_on_timeout=2,
+            resume_checkpoint=None,
+        )
+
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert notes
+    message = "\n".join(notes)
+    assert "Command:" in message
+    assert "Exit code: 2" in message
+    assert str(refresh_baselines.DEFAULT_TIMEOUT_PROGRESS_PATH) in message
+    assert str(refresh_baselines.DEFAULT_DEADLINE_PROFILE_PATH) in message
+    assert str(refresh_baselines.DEFAULT_CHECK_REPORT_PATH) in message


### PR DESCRIPTION
### Motivation

- Ensure `gabion check` invocations from `refresh_baselines.py` always emit timeout diagnostics and support resuming so CI and local runs produce useful artifacts on deadline expiries.
- Make retry/resume behavior configurable from the CLI and propagate those knobs through the delta-guard helpers so baseline refreshes behave consistently.
- Provide richer diagnostic context on `CalledProcessError` so callers and CI logs show the failing command, exit code, and expected artifact locations instead of an opaque exit code.

### Description

- Added default artifact path constants (`DEFAULT_CHECK_REPORT_PATH`, `DEFAULT_TIMEOUT_PROGRESS_PATH`, `DEFAULT_DEADLINE_PROFILE_PATH`, `DEFAULT_RESUME_CHECKPOINT_PATH`).
- Introduced resume defaults and helpers: `_default_resume_on_timeout()`, `_default_resume_checkpoint()`, and `_format_run_check_failure()`.
- Updated `_run_check` to always append `--emit-timeout-progress-report` and `--resume-on-timeout <n>` and optionally `--resume-checkpoint <path>`, to keep `check=True`, and to catch `subprocess.CalledProcessError` and attach an enriched diagnostic note before re-raising.
- Added CLI arguments `--resume-on-timeout` and `--resume-checkpoint` to `main()` and threaded these options through `_guard_*` and `_ensure_delta` helpers so all delta/emission invocations use the configured resume behavior.
- Added unit tests `tests/test_refresh_baselines_run_check.py` that mock `subprocess.run` to validate command construction and the presence of enriched failure notes when `CalledProcessError` is raised.

### Testing

- Ran the new unit tests with: `mise exec -- env PYTHONPATH=src python -m pytest -o addopts='' tests/test_refresh_baselines_run_check.py` and the suite reported `2 passed`.
- The added tests specifically verify that the `gabion check` command includes `--emit-timeout-progress-report`, `--resume-on-timeout`, and `--resume-checkpoint` when provided, and that a `CalledProcessError` carries diagnostic notes containing the command, exit code, and expected artifact paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699524e9a7ac83249d19785d8b4b5177)