### PR TITLE
Add failure artifact reporting for refresh_baselines subprocess errors

### DIFF
--- a/tests/test_refresh_baselines_failure_report.py
+++ b/tests/test_refresh_baselines_failure_report.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import refresh_baselines
+
+
+def test_refresh_baselines_writes_failure_artifact_on_check_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(refresh_baselines.sys, "argv", ["refresh_baselines.py", "--docflow"])
+    monkeypatch.setenv("GABION_LSP_TIMEOUT_SECONDS", "17")
+
+    failing_command: list[str] = []
+
+    def _failing_run(
+        cmd: list[str],
+        *,
+        check: bool,
+        timeout: int | None,
+        env: dict[str, str],
+    ) -> None:
+        del check, timeout, env
+        nonlocal failing_command
+        failing_command = cmd
+        raise subprocess.CalledProcessError(returncode=9, cmd=cmd)
+
+    monkeypatch.setattr(refresh_baselines.subprocess, "run", _failing_run)
+
+    with pytest.raises(refresh_baselines.RefreshBaselinesSubprocessFailure) as failure_info:
+        refresh_baselines.main()
+
+    artifact_path = refresh_baselines._write_failure_artifact(failure_info.value)
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+    assert artifact_path == refresh_baselines.FAILURE_ARTIFACT_PATH
+    assert payload["attempted_command"] == failing_command
+    assert payload["attempted_flags"] == []
+    assert payload["exit_code"] == 9
+    assert payload["timeout_settings"]["cli_timeout_seconds"] is None
+    assert payload["timeout_settings"]["env"]["GABION_LSP_TIMEOUT_SECONDS"] == "17"
+    assert payload["expected_artifacts"][str(refresh_baselines.DOCFLOW_DELTA_PATH)] is False
+    assert payload["expected_artifacts"][str(refresh_baselines.DOCFLOW_CURRENT_PATH)] is False
+
+
+def test_refresh_baselines_clears_stale_failure_artifact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(refresh_baselines.sys, "argv", ["refresh_baselines.py", "--docflow"])
+    stale_artifact = refresh_baselines.FAILURE_ARTIFACT_PATH
+    stale_artifact.parent.mkdir(parents=True, exist_ok=True)
+    stale_artifact.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(refresh_baselines, "_guard_obsolescence_delta", lambda timeout: None)
+    monkeypatch.setattr(refresh_baselines, "_guard_annotation_drift_delta", lambda timeout: None)
+    monkeypatch.setattr(refresh_baselines, "_guard_ambiguity_delta", lambda timeout: None)
+
+    def _guard_docflow_with_current(timeout: int | None) -> None:
+        del timeout
+        refresh_baselines.DOCFLOW_CURRENT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        refresh_baselines.DOCFLOW_CURRENT_PATH.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        refresh_baselines,
+        "_guard_docflow_delta",
+        _guard_docflow_with_current,
+    )
+
+    exit_code = refresh_baselines.main()
+
+    assert exit_code == 0
+    assert not stale_artifact.exists()


### PR DESCRIPTION
### Motivation

- Make `scripts/refresh_baselines.py` robust in CI by persisting structured failure information when `gabion check` or docflow subprocesses fail so debugging is easier.  
- Avoid confusing leftover failure state by clearing stale failure artifacts on startup and after successful runs.  

### Description

- Add a failure artifact at `artifacts/out/refresh_baselines_failure.json` and helper functions `_write_failure_artifact` and `_clear_failure_artifact` to produce and manage it.  
- Introduce `RefreshBaselinesSubprocessFailure` to carry `command`, `timeout_seconds`, `exit_code`, and `expected_artifacts`, and capture env timeout settings via `_timeout_env_settings`.  
- Wrap subprocess calls in `_run_check` and `_run_docflow_delta_emit` to convert `CalledProcessError` into the structured exception and record which diagnostic artifacts were expected to be produced.  
- On top-level failure the script now writes the JSON failure artifact, prints the artifact path to `stderr`, and exits non-zero, and successful runs clear any stale failure artifact at startup and on normal completion.  

### Testing

- Added `tests/test_refresh_baselines_failure_report.py` which simulates a `subprocess.CalledProcessError` and asserts the failure artifact contents and that stale artifacts are removed on success.  
- Ran the new tests and a related scope-binding test with: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_refresh_baselines_failure_report.py` and `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_script_scope_bindings.py`, and both test files passed.  
- `mise` emitted a transient warning while resolving tool versions, but the interpreter executed the tests and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699525061e588324ad7dc4c647a783bf)