### PR TITLE
docs(in): refresh status and evidence for in-34 through in-37

### DIFF
--- a/in/in-34.md
+++ b/in/in-34.md
@@ -99,9 +99,13 @@ Promote lambda/closure callables to first-class executable sites so call-resolut
 - No attempt to fully model metaprogramming or eval/exec.
 
 ### Status
-Planned refactor step; additive behavior with conservative fallbacks.
+partial — additive behavior is implemented in part, with conservative fallbacks retained.
 
-Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#suite_site](glossary.md#suite_site), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#suite_site](glossary.md#suite_site), [in/in-30.md#in_in_30](in/in-30.md#in_in_30), [docs/sppf_checklist.md#in-34-lambda-callable-sites](docs/sppf_checklist.md#in-34-lambda-callable-sites).
+
+### Implemented evidence
+- Key functions (`src/gabion/analysis/dataflow_audit.py`): `_collect_functions`, `_accumulate_function_index_for_tree`, `_resolve_callee`, `_resolve_callee_outcome`.
+- Representative tests (`tests/`): `tests/test_dataflow_audit_helpers.py::test_build_function_index_indexes_lambda_sites_deterministically`, `tests/test_dataflow_resolve_callee.py::test_resolve_callee_bound_lambda_call`.
 
 ---
 

--- a/in/in-35.md
+++ b/in/in-35.md
@@ -78,9 +78,13 @@ Increase dataflow precision for dict-based carriers by extending beyond strict `
 - No inference from arbitrary runtime-computed keys.
 
 ### Status
-Planned refinement of alias/forward-use modeling in the AST visitor layer.
+partial — alias/forward-use modeling is implemented with remaining refinements tracked.
 
-Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30), [docs/sppf_checklist.md#in-35-dict-key-carrier-tracking](docs/sppf_checklist.md#in-35-dict-key-carrier-tracking).
+
+### Implemented evidence
+- Key functions (`src/gabion/analysis/dataflow_audit.py`): `_accumulate_function_index_for_tree`, `_unused_params`, `_analyze_unused_arg_flow_indexed`.
+- Representative tests (`tests/`): `tests/test_unused_arg_audit.py::test_unused_arg_reports_unknown_key_carrier_category`, `tests/test_dataflow_audit_helpers.py::test_deserialize_param_use_filters_malformed_values`.
 
 ---
 

--- a/in/in-36.md
+++ b/in/in-36.md
@@ -78,9 +78,13 @@ Improve dataclass-call bundle detection for simple starred constructor calls (`*
 - No broad inference beyond statically enumerable literals.
 
 ### Status
-Planned enhancement to dataclass constructor bundle extraction.
+done — conservative starred dataclass constructor handling is implemented.
 
-Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30), [docs/sppf_checklist.md#in-36-starred-dataclass-call-bundles](docs/sppf_checklist.md#in-36-starred-dataclass-call-bundles).
+
+### Implemented evidence
+- Key functions (`src/gabion/analysis/dataflow_audit.py`): `_iter_dataclass_call_bundles`, `_unresolved_starred_witness` (local helper within `_iter_dataclass_call_bundles`).
+- Representative tests (`tests/`): `tests/test_dataflow_audit_edges.py::test_iter_dataclass_call_bundles_dynamic_starred_records_unresolved`, `tests/test_dataflow_audit_edges.py::test_iter_dataclass_call_bundles`.
 
 ---
 

--- a/in/in-37.md
+++ b/in/in-37.md
@@ -87,9 +87,13 @@ Distinguish unresolved calls caused by dynamic dispatch patterns from unresolved
 - No attempt to fully resolve monkeypatch/metaclass runtime behavior.
 
 ### Status
-Planned call-resolution classification refinement.
+done — dynamic-dispatch uncertainty classification is implemented in call resolution.
 
-Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#ambiguity_set](glossary.md#ambiguity_set), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
+Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#ambiguity_set](glossary.md#ambiguity_set), [in/in-30.md#in_in_30](in/in-30.md#in_in_30), [docs/sppf_checklist.md#in-37-dynamic-dispatch-uncertainty](docs/sppf_checklist.md#in-37-dynamic-dispatch-uncertainty).
+
+### Implemented evidence
+- Key functions (`src/gabion/analysis/dataflow_audit.py`): `_resolve_callee_outcome`, `_materialize_call_candidates`, `_collect_call_resolution_obligations_from_forest`.
+- Representative tests (`tests/`): `tests/test_dataflow_resolve_callee.py::test_resolve_callee_outcome_unresolved_internal_and_dynamic`, `tests/test_dataflow_audit_edges.py::test_materialize_call_candidates_emits_dynamic_obligation_kind`.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Bring the in/ planning documents into sync with the current implementation state so the SPPF checklist and in/ guidance reflect actual behavior.
- Provide concrete, machine-friendly anchors (implementation evidence) so CI/consumers and reviewers can quickly map doc nodes to code and test artifacts.
- Ensure each in/ node references the corresponding checklist anchor in `docs/sppf_checklist.md` for bidirectional traceability.

### Description
- Updated the `### Status` section in `in/in-34.md` and `in/in-35.md` from “Planned” to `partial`, and in `in/in-36.md` and `in/in-37.md` from “Planned” to `done` to reflect current implementation state.
- Added an `### Implemented evidence` subsection to each of the four files linking to the concrete key functions in `src/gabion/analysis/dataflow_audit.py` and representative tests under `tests/`.
- Added checklist anchor references in each file’s normative pointers to the matching anchors in `docs/sppf_checklist.md` (`#in-34-lambda-callable-sites`, `#in-35-dict-key-carrier-tracking`, `#in-36-starred-dataclass-call-bundles`, `#in-37-dynamic-dispatch-uncertainty`).
- Kept front-matter `doc_revision` and dependency review fields unchanged because edits were status/evidence bookkeeping without conceptual contract changes.

### Testing
- Verified presence of updated status strings, the new `### Implemented evidence` sections, and the checklist anchor links using repository searches (e.g. `rg`), which succeeded.
- Confirmed the representative test symbols referenced in the new evidence paragraphs exist in `tests/` via pattern searches (e.g. `rg`), which returned matching test definitions.
- Performed basic repository status verification to ensure the four `in/` files were modified as intended, which showed the expected diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699526fc492483248e3a449949fec500)