### PR TITLE
Retarget stale return-alias evidence markers in helper tests

### DIFF
--- a/tests/test_dataflow_helpers.py
+++ b/tests/test_dataflow_helpers.py
@@ -381,7 +381,7 @@ def test_resolve_star_external_filtered() -> None:
     table.internal_roots.add("pkg")
     assert table.resolve_star("pkg.mod", "Foo") is None
 
-# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases._alias_from_expr::expr E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_defaults::fn,ignore_params E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
+# gabion:evidence E:function_site::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_defaults::fn,ignore_params E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
 def test_param_defaults_and_return_aliases() -> None:
     da = _load()
     tree = ast.parse(
@@ -402,7 +402,7 @@ def test_param_defaults_and_return_aliases() -> None:
     alias = da._return_aliases(fn)
     assert alias == ["a"]
 
-# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases._alias_from_expr::expr E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
+# gabion:evidence E:function_site::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
 def test_return_aliases_tuple_and_conflict() -> None:
     da = _load()
     tree = ast.parse(
@@ -440,7 +440,7 @@ def test_collect_return_aliases_conflict() -> None:
     aliases = da._collect_return_aliases(funcs, parents, ignore_params=None)
     assert "foo" not in aliases
 
-# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases._alias_from_expr::expr E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
+# gabion:evidence E:function_site::dataflow_audit.py::gabion.analysis.dataflow_audit._return_aliases E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._param_names::fn,ignore_params
 def test_return_aliases_bare_return() -> None:
     da = _load()
     tree = ast.parse(


### PR DESCRIPTION
### Motivation
- Tests referenced a nested helper evidence surface that no longer resolves, causing obsolescence evidence mapping to be stale; retarget to the canonical function-site surface to keep test-to-evidence mapping accurate.

### Description
- Updated `gabion:evidence` tags in `tests/test_dataflow_helpers.py` to replace `gabion.analysis.dataflow_audit._return_aliases._alias_from_expr::expr` with the canonical function-site surface `gabion.analysis.dataflow_audit._return_aliases` in three return-alias related tests.
- This change only adjusts evidence markers and does not alter any test logic or assertions.

### Testing
- Ran the focused pytest selection with `PYTHONPATH=src pytest -q -o addopts='' tests/test_dataflow_helpers.py -k 'param_defaults_and_return_aliases or return_aliases_tuple_and_conflict or return_aliases_bare_return'` and received `3 passed, 15 deselected`.
- Attempted to run the obsolescence/coverage emitter with `PYTHONPATH=src python -m gabion check --emit-test-obsolescence-state` but `gabion check` did not complete in this environment (deadline/profile artifacts were produced but full delta/baseline emission did not finish).
- Attempted `scripts/refresh_baselines.py --obsolescence --timeout 300` to update the obsolescence baseline, but the run invoked `gabion check` and exited non-zero / timed out in this execution environment, so the baseline was not refreshed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995245834a08324857e0b022fe1bd4d)