### PR TITLE
docs: add compact implementation ledgers for partial in-steps

### DIFF
--- a/docs/influence_index.md
+++ b/docs/influence_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 49
+doc_revision: 50
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: influence_index
 doc_role: index
@@ -127,10 +127,10 @@ Status legend:
 - in/in-27.md — **partial** (exception obligations emitted with deadness/handledness witnesses; exception-aware rewrite acceptance predicates implemented; remaining handledness refinement tracked; SPPF/GH-77, GH-80.)
 - in/in-28.md — **adopted** (in_step template discipline enforced; docflow structure and review requirements codified.)
 - in/in-29.md — **partial** (test evidence carrier + dominance/equivalence + obsolescence/suggestions projections implemented; dominance deltas pending.)
-- in/in-30.md — **partial** (SuiteSite carrier + loop-scoped deadlines design; implementation in progress; SPPF/GH-85.)
-- in/in-31.md — **partial** (projection carriers + meet-boundary ordering semantics; convergence in progress.)
+- in/in-30.md — **partial** (implemented: suite ambiguity projections + suite-order SpecFacet path + tick-budget deadline propagation; open: SuiteSite-native loop obligation enforcement; deferred: phase-3/4 decision-surface migration; SPPF/GH-85, GH-87, GH-88.)
+- in/in-31.md — **partial** (implemented: suite-order ProjectionSpec/SpecFacet quotient path; open: explicit quotient/internment regression harness; deferred: internal broad-type lint tightening impact; SPPF/GH-85, GH-89.)
 - in/in-32.md — **queued** (hypothetical/non-normative Gödel-numbering exploration; acknowledged, but not a controlling contract for implementation or CI at this time.)
-- in/in-33.md — [**partial**](docs/sppf_checklist.md#in-33-pattern-schema-unification) (PatternSchema carriers exist for both dataflow and execution pattern instances with shared residue reporting, but execution-pattern coverage is intentionally narrow and metafactory reification remains open.)
+- in/in-33.md — [**partial**](docs/sppf_checklist.md#in-33-pattern-schema-unification) (implemented: PatternSchema/PatternInstance/PatternResidue carriers + unified schema suggestion/residue pipeline; open: execution-rule coverage breadth; deferred: Tier-2 residue ratchet/metafactory reification gate.)
 - in/in-34.md — [**partial**](docs/sppf_checklist.md#in-34-lambda-callable-sites) (synthetic lambda function sites are indexed and used for direct/bound lambda call resolution, while broader closure/alias cases still fall back conservatively.)
 - in/in-35.md — [**partial**](docs/sppf_checklist.md#in-35-dict-key-carrier-tracking) (dict key normalization now supports name-bound constants and records explicit unknown-key carrier evidence for non-recoverable keys; supported key grammar remains deliberately conservative.)
 - in/in-36.md — [**adopted**](docs/sppf_checklist.md#in-36-starred-dataclass-call-bundles) (dataclass call-bundle extraction now decodes deterministic starred literals for `*` and `**` and emits unresolved-starred witnesses for dynamic payloads.)

--- a/in/in-30.md
+++ b/in/in-30.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 24
+doc_revision: 25
 reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
 doc_id: in_30
 doc_role: in_step
@@ -173,6 +173,16 @@ and aligns the Forest/ProjectionSpec stack with Python's suite semantics.
 Target design with a phased migration plan; implementation starts with loop
 suites and deadline obligations. Phase 1 now migrates ambiguity to call suites
 with an aggregation spec for legacy stability.
+
+### Compact implementation ledger
+- **Implemented**
+  - `src/gabion/analysis/dataflow_audit.py::_materialize_ambiguity_suite_agg_spec` and `_materialize_ambiguity_virtual_set_spec` now materialize suite-scoped ambiguity projections (`ambiguity_suite_agg`, `ambiguity_virtual_set`) for legacy-compatible reporting (SPPF: in-30 checklist row, GH-88).
+  - `src/gabion/analysis/dataflow_audit.py::_materialize_suite_order_spec` plus `src/gabion/analysis/projection_registry.py` (`name="suite_order"`) provide suite-order SpecFacet materialization used by projection reports (SPPF: in-30 checklist row, GH-85).
+  - `src/gabion/server.py::_analysis_timeout_total_ticks` and `gabion.analysis.timeout_context.deadline_loop_iter` wire tick-budget deadline propagation across server/analysis paths (SPPF: in-30 checklist row, GH-87).
+- **Open**
+  - `src/gabion/analysis/dataflow_audit.py::_collect_deadline_obligations` still enforces obligations through function-root traversal (`config.deadline_roots`) rather than SuiteSite-native loop obligations, so loop-local precision remains incomplete (SPPF: in-30 checklist row, GH-85).
+- **Blocked/Deferred**
+  - Full migration of decision-surface and never-invariant facets to SuiteSite (documented as Phases 3-4 in this step) remains staged behind current ambiguity/deadline convergence work (SPPF: in-30 checklist row, GH-85).
 
 Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#suite_site](glossary.md#suite_site), [glossary.md#hash_consing](glossary.md#hash_consing), [glossary.md#decision_surface](glossary.md#decision_surface), [glossary.md#ambiguity_set](glossary.md#ambiguity_set), [glossary.md#partition_witness](glossary.md#partition_witness), [CONTRIBUTING.md#contributing_contract](CONTRIBUTING.md#contributing_contract), [README.md#repo_contract](README.md#repo_contract), [AGENTS.md#agent_obligations](AGENTS.md#agent_obligations), [in/in-28.md#in_in_28](in/in-28.md#in_in_28), [in/in-23.md#in_in_23](in/in-23.md#in_in_23), [in/in-29.md#in_in_29](in/in-29.md#in_in_29).
 

--- a/in/in-31.md
+++ b/in/in-31.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 3
+doc_revision: 4
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: in_31
 doc_role: in_step
@@ -143,6 +143,15 @@ Formalize the relationship between **ProjectionSpec**, **internment**, **ASPF/Fo
 - Formalization of existing behavior and intended invariants.
 - Aligns ProjectionSpec-as-carrier with SuiteSite and hash-consing semantics.
 - Proof-of-concept: suite-order projection materialized as SpecFacet.
+
+### Compact implementation ledger
+- **Implemented**
+  - `src/gabion/analysis/dataflow_audit.py::_materialize_suite_order_spec` reifies suite-order quotient rows into SpecFacet-compatible projection rows, grounding the proof-of-concept carrier path (SPPF: in-30 checklist row, GH-85).
+  - `src/gabion/analysis/projection_registry.py` registers `ProjectionSpec(name="suite_order", domain="suite_order")`, making suite-order quotient output addressable from report projection plumbing (SPPF: in-30 checklist row, GH-85).
+- **Open**
+  - A dedicated quotient/internment regression harness for the `suite_order` carrier path is still not codified as a named test contract in `tests/` (SPPF: in-30 checklist row, GH-85).
+- **Blocked/Deferred**
+  - Internal broad-type lint tightening on non-boundary surfaces is tracked separately and may constrain final carrier proof shape once enforced repo-wide (`src/gabion/analysis/dataflow_audit.py::_internal_broad_type_lint_lines`) (SPPF: checklist internal broad-type lint row, GH-89).
 
 Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#suite_site](glossary.md#suite_site), [glossary.md#hash_consing](glossary.md#hash_consing), [glossary.md#evidence_surface](glossary.md#evidence_surface), [CONTRIBUTING.md#contributing_contract](CONTRIBUTING.md#contributing_contract), [README.md#repo_contract](README.md#repo_contract), [AGENTS.md#agent_obligations](AGENTS.md#agent_obligations), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
 

--- a/in/in-33.md
+++ b/in/in-33.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: in_33
 doc_role: in_step
@@ -153,6 +153,15 @@ patterns) into a single schema calculus with dual projections.
 
 Target design. Implementation is incremental: introduce the schema type, unify
 mining/reporting, then ratchet residue to reification.
+
+### Compact implementation ledger
+- **Implemented**
+  - `src/gabion/analysis/pattern_schema.py::PatternSchema` / `PatternInstance` / `PatternResidue` provide the shared schema carrier and residue types for unified pattern reporting (SPPF: `docs/sppf_checklist.md#in-33-pattern-schema-unification`).
+  - `src/gabion/analysis/dataflow_audit.py::_pattern_schema_matches`, `_pattern_schema_suggestions`, and `_pattern_schema_residue_entries` bridge execution-pattern mining into schema instances with residue-aware output (SPPF: `docs/sppf_checklist.md#in-33-pattern-schema-unification`).
+- **Open**
+  - Execution-pattern rule coverage remains intentionally narrow in `src/gabion/analysis/dataflow_audit.py::_EXECUTION_PATTERN_RULES`, so many callable/dataflow shapes still bypass PatternSchema unification (SPPF: `docs/sppf_checklist.md#in-33-pattern-schema-unification`).
+- **Blocked/Deferred**
+  - Tier-2 residue ratchet to CI-failing enforcement (metafactory/protocol reification gate) is deferred to later phases to preserve staged rollout (SPPF: `docs/sppf_checklist.md#in-33-pattern-schema-unification`).
 
 Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed),
 [glossary.md#contract](glossary.md#contract), [glossary.md#bundle](glossary.md#bundle),


### PR DESCRIPTION
### Motivation
- Make planning agents and reviewers find current implementation status quickly by adding a machine-friendly ledger near each `Status` heading that summarizes concrete progress, open work, and blocked/ deferred items.
- Ensure each ledger bullet includes a concrete locator (`module/path::symbol`) and a tracking reference (SPPF anchor or GH id) so automation can link docs to issues and checklist rows.

### Description
- Added a compact `Implemented` / `Open` / `Blocked/Deferred` ledger under `Status` in `in/in-30.md` that cites `src/gabion/analysis/dataflow_audit.py::_materialize_ambiguity_suite_agg_spec`, `_materialize_ambiguity_virtual_set_spec`, `_materialize_suite_order_spec`, `src/gabion/analysis/projection_registry.py::ProjectionSpec(name="suite_order")`, and `src/gabion/server.py::_analysis_timeout_total_ticks` with SPPF/GH tracking (SPPF/ GH-85/87/88).
- Added the same ledger structure to `in/in-31.md` citing `src/gabion/analysis/dataflow_audit.py::_materialize_suite_order_spec` and `src/gabion/analysis/projection_registry.py` and noting open/test-harness and lint interactions (SPPF/ GH-85/89).
- Added the same ledger structure to `in/in-33.md` citing `src/gabion/analysis/pattern_schema.py::PatternSchema` / `PatternInstance` / `PatternResidue` and `src/gabion/analysis/dataflow_audit.py::_pattern_schema_matches`, `_pattern_schema_suggestions`, and `_pattern_schema_residue_entries` with SPPF tracking and staged reification notes.
- Updated `docs/influence_index.md` to mirror the new per-file ledgers for `in-30`, `in-31`, and `in-33`, and bumped `doc_revision` values in the modified docs to reflect the conceptual documentation updates.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues and it succeeded with no warnings.
- Ran `python -m compileall -q src/gabion/analysis/pattern_schema.py` to ensure the changed referenced module is syntactically valid and it succeeded with no output/errors.
- No runtime or behavior changes were introduced; this PR is documentation-only and focused on planning/traceability updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952714441c8324a6361a4ad8640c6a)