### PR TITLE
Add SPPF status drift audit and wire it into CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
           .venv/bin/python scripts/policy_check.py --posture
       - name: Docflow audit
         run: .venv/bin/python -m gabion docflow-audit --root . --fail-on-violations
+      - name: SPPF status drift audit
+        run: .venv/bin/python scripts/sppf_status_audit.py --root .
       - name: Test evidence index
         env:
           GABION_LSP_TIMEOUT_TICKS: "300000"

--- a/in/in-34.md
+++ b/in/in-34.md
@@ -99,7 +99,7 @@ Promote lambda/closure callables to first-class executable sites so call-resolut
 - No attempt to fully model metaprogramming or eval/exec.
 
 ### Status
-Planned refactor step; additive behavior with conservative fallbacks.
+Implemented in part; additive behavior with conservative fallbacks remains.
 
 Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#suite_site](glossary.md#suite_site), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
 

--- a/in/in-35.md
+++ b/in/in-35.md
@@ -78,7 +78,7 @@ Increase dataflow precision for dict-based carriers by extending beyond strict `
 - No inference from arbitrary runtime-computed keys.
 
 ### Status
-Planned refinement of alias/forward-use modeling in the AST visitor layer.
+Implemented in part; alias/forward-use modeling refinement is partially adopted.
 
 Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
 

--- a/in/in-36.md
+++ b/in/in-36.md
@@ -78,7 +78,7 @@ Improve dataclass-call bundle detection for simple starred constructor calls (`*
 - No broad inference beyond statically enumerable literals.
 
 ### Status
-Planned enhancement to dataclass constructor bundle extraction.
+Done; dataclass constructor bundle extraction enhancement is adopted.
 
 Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
 

--- a/in/in-37.md
+++ b/in/in-37.md
@@ -87,7 +87,7 @@ Distinguish unresolved calls caused by dynamic dispatch patterns from unresolved
 - No attempt to fully resolve monkeypatch/metaclass runtime behavior.
 
 ### Status
-Planned call-resolution classification refinement.
+Done; call-resolution classification refinement is adopted.
 
 Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#ambiguity_set](glossary.md#ambiguity_set), [in/in-30.md#in_in_30](in/in-30.md#in_in_30).
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -43,6 +43,7 @@ if $run_dataflow; then
 fi
 if $run_docflow; then
   mise exec -- python -m gabion docflow-audit
+  mise exec -- python scripts/sppf_status_audit.py --root .
 fi
 if $run_tests; then
   test_dir="${TEST_ARTIFACTS_DIR:-artifacts/test_runs}"

--- a/scripts/sppf_status_audit.py
+++ b/scripts/sppf_status_audit.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Audit SPPF status consistency across in/, checklist, and influence index."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+IN_FILE_RE = re.compile(r"in-(\d+)\.md$")
+INFLUENCE_ROW_RE = re.compile(r"^-\s+in/in-(\d+)\.md\s+—\s+\*\*(\w+)\*\*", re.MULTILINE)
+CHECKLIST_TAG_RE = re.compile(
+    r"^(?P<line>.*?sppf\{[^\n]*doc=(?P<doc>\w+);\s*impl=(?P<impl>\w+);\s*doc_ref=(?P<refs>[^}]+)\}.*?)$",
+    re.MULTILINE,
+)
+CHECKLIST_STATUS_NODE_RE = re.compile(r"<a\s+id=\"in-(\d+)")
+DOC_REF_IN_RE = re.compile(r"in-(\d+)@")
+STATUS_HEADING_RE = re.compile(r"^###\s+Status\s*$", re.MULTILINE)
+OVERRIDE_RE = re.compile(r"sppf-status-override\s*:\s*(in-\d+|all)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class StatusRecord:
+    category: str
+    source: str
+    detail: str
+
+
+def _normalize_in_status(text: str) -> str | None:
+    lowered = text.lower()
+    if "implemented in part" in lowered or "partially implemented" in lowered:
+        return "implemented-in-part"
+    if "partial" in lowered or "in progress" in lowered:
+        return "implemented-in-part"
+    if any(token in lowered for token in ("planned", "plan", "queued", "todo")):
+        return "planned"
+    if any(token in lowered for token in ("done", "completed", "adopted", "implemented and active")):
+        return "done"
+    return None
+
+
+def _normalize_influence_status(token: str) -> str | None:
+    token = token.lower().strip()
+    mapping = {
+        "adopted": "done",
+        "partial": "implemented-in-part",
+        "queued": "planned",
+        "untriaged": "planned",
+        "rejected": "rejected",
+    }
+    return mapping.get(token)
+
+
+def _normalize_checklist_pair(doc: str, impl: str) -> str:
+    doc = doc.lower().strip()
+    impl = impl.lower().strip()
+    if doc == "done" and impl == "done":
+        return "done"
+    if impl == "planned":
+        return "planned"
+    return "implemented-in-part"
+
+
+def _extract_in_status(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    match = STATUS_HEADING_RE.search(text)
+    if not match:
+        return None
+    tail = text[match.end() :]
+    for line in tail.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            return None
+        return _normalize_in_status(line)
+    return None
+
+
+def _collect_overrides(*texts: str) -> set[str]:
+    overrides: set[str] = set()
+    for text in texts:
+        for match in OVERRIDE_RE.finditer(text):
+            overrides.add(match.group(1).lower())
+    return overrides
+
+
+def run_audit(root: Path) -> tuple[int, list[str]]:
+    in_dir = root / "in"
+    checklist_path = root / "docs" / "sppf_checklist.md"
+    influence_path = root / "docs" / "influence_index.md"
+
+    checklist_text = checklist_path.read_text(encoding="utf-8")
+    influence_text = influence_path.read_text(encoding="utf-8")
+
+    overrides = _collect_overrides(checklist_text, influence_text)
+
+    records: dict[str, list[StatusRecord]] = {}
+
+    for in_file in sorted(in_dir.glob("in-*.md")):
+        if not IN_FILE_RE.search(in_file.name):
+            continue
+        in_id = in_file.stem
+        in_text = in_file.read_text(encoding="utf-8")
+        overrides.update(_collect_overrides(in_text))
+        category = _extract_in_status(in_file)
+        if category:
+            records.setdefault(in_id, []).append(
+                StatusRecord(category=category, source="in", detail=f"{in_file.as_posix()}")
+            )
+
+    for in_num, token in INFLUENCE_ROW_RE.findall(influence_text):
+        in_id = f"in-{in_num}"
+        category = _normalize_influence_status(token)
+        if category:
+            records.setdefault(in_id, []).append(
+                StatusRecord(
+                    category=category,
+                    source="influence_index",
+                    detail=f"{influence_path.as_posix()}:**{token}**",
+                )
+            )
+
+    checklist_rows: dict[str, list[str]] = {}
+    for match in CHECKLIST_TAG_RE.finditer(checklist_text):
+        line = match.group("line")
+        if "sppf-status-node" not in line and not CHECKLIST_STATUS_NODE_RE.search(line):
+            continue
+        category = _normalize_checklist_pair(match.group("doc"), match.group("impl"))
+        refs = match.group("refs")
+        for in_num in DOC_REF_IN_RE.findall(refs):
+            checklist_rows.setdefault(f"in-{in_num}", []).append(category)
+
+    for in_id, categories in checklist_rows.items():
+        uniq = set(categories)
+        if uniq == {"done"}:
+            aggregate = "done"
+        elif uniq == {"planned"}:
+            aggregate = "planned"
+        else:
+            aggregate = "implemented-in-part"
+        records.setdefault(in_id, []).append(
+            StatusRecord(
+                category=aggregate,
+                source="sppf_checklist",
+                detail=f"{checklist_path.as_posix()}:{sorted(uniq)}",
+            )
+        )
+
+    errors: list[str] = []
+    for in_id, row in sorted(records.items()):
+        categories = {item.category for item in row}
+        if len(categories) <= 1:
+            continue
+        if "all" in overrides or in_id in overrides:
+            continue
+        errors.append(f"{in_id}: status drift detected")
+        for item in row:
+            errors.append(f"  - {item.source}: {item.category} ({item.detail})")
+
+    if errors:
+        return 1, errors
+    return 0, ["sppf-status-audit: no drift detected"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root")
+    args = parser.parse_args(argv)
+    code, lines = run_audit(args.root.resolve())
+    stream = sys.stderr if code else sys.stdout
+    for line in lines:
+        print(line, file=stream)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sppf_status_audit.py
+++ b/tests/test_sppf_status_audit.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.sppf_status_audit import run_audit
+
+
+def _write_fixture(root: Path, *, in_status: str, checklist_status: str, influence_status: str) -> None:
+    (root / "in").mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+
+    (root / "in" / "in-1.md").write_text(
+        f"""---
+doc_revision: 1
+---
+
+### Status
+{in_status}
+""",
+        encoding="utf-8",
+    )
+    (root / "docs" / "sppf_checklist.md").write_text(
+        f"""- <a id=\"in-1-test\"></a>[x] Example node. sppf{{doc={checklist_status}; impl={checklist_status}; doc_ref=in-1@1}}
+""",
+        encoding="utf-8",
+    )
+    (root / "docs" / "influence_index.md").write_text(
+        f"""## Inbox entries
+
+- in/in-1.md — **{influence_status}**
+""",
+        encoding="utf-8",
+    )
+
+
+def test_sppf_status_audit_passes_for_matching_statuses(tmp_path: Path) -> None:
+    _write_fixture(
+        tmp_path,
+        in_status="Done and adopted.",
+        checklist_status="done",
+        influence_status="adopted",
+    )
+
+    code, lines = run_audit(tmp_path)
+
+    assert code == 0
+    assert lines == ["sppf-status-audit: no drift detected"]
+
+
+def test_sppf_status_audit_fails_for_stale_in_doc_status(tmp_path: Path) -> None:
+    _write_fixture(
+        tmp_path,
+        in_status="Planned refinement.",
+        checklist_status="done",
+        influence_status="adopted",
+    )
+
+    code, lines = run_audit(tmp_path)
+
+    assert code == 1
+    assert any("in-1: status drift detected" in line for line in lines)
+    assert any("in: planned" in line for line in lines)
+
+
+def test_sppf_status_audit_fails_for_stale_influence_row(tmp_path: Path) -> None:
+    _write_fixture(
+        tmp_path,
+        in_status="Done and adopted.",
+        checklist_status="done",
+        influence_status="partial",
+    )
+
+    code, lines = run_audit(tmp_path)
+
+    assert code == 1
+    assert any("in-1: status drift detected" in line for line in lines)
+    assert any("influence_index: implemented-in-part" in line for line in lines)


### PR DESCRIPTION
### Motivation
- Provide an automated, lightweight audit to detect status drift between `in/in-XX.md`, `docs/sppf_checklist.md` status nodes, and the `docs/influence_index.md` summary so governance/docflow drift is caught early. 
- Fail CI when semantic status categories contradict (e.g. `planned` vs `done`) unless an explicit override marker is present, to keep the SPPF convergence surface consistent. 
- Integrate the check into existing docflow/policy pipelines so drift becomes a CI gate. 

### Description
- Add `scripts/sppf_status_audit.py`, a small scanner that: parses `### Status` blocks in `in/in-XX.md`, extracts `sppf{doc=...; impl=...; doc_ref=...}` status nodes from `docs/sppf_checklist.md`, reads summary rows in `docs/influence_index.md`, normalizes statuses into shared categories (`planned`, `implemented-in-part`, `done`), and reports/fails on conflicts unless `sppf-status-override: in-XX` or `all` appears. 
- Hook the audit into local checks by updating `scripts/checks.sh` to run the audit after the docflow step. 
- Add a CI gate by inserting a `SPPF status drift audit` step into the `.github/workflows/ci.yml` `checks` job immediately after the docflow audit. 
- Add unit tests in `tests/test_sppf_status_audit.py` covering matching statuses (pass), stale in-doc status (fail), and stale influence row (fail). 
- Update `in/in-34.md` through `in/in-37.md` status text to reflect current adopted/partial states so the repository baseline is consistent with the new check. 

### Testing
- `python -m py_compile scripts/sppf_status_audit.py tests/test_sppf_status_audit.py` succeeded. 
- Executing the audit via `mise exec -- python scripts/sppf_status_audit.py --root .` produced `sppf-status-audit: no drift detected` in this environment (mise emitted a non-fatal python-version resolution warning in this environment). 
- `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_sppf_status_audit.py` ran the new unit tests and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995271ba9888324ba7448deb4e0b913)