### PR TITLE
Improve refresh baselines timeout reporting and recovery behavior

### DIFF
--- a/tests/test_refresh_baselines.py
+++ b/tests/test_refresh_baselines.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import refresh_baselines
+
+
+def test_run_check_adds_timeout_progress_and_resume_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[refresh_baselines._RefreshCommand] = []
+
+    def _capture(run: refresh_baselines._RefreshCommand) -> None:
+        captured.append(run)
+
+    monkeypatch.setattr(refresh_baselines, "_run_refresh_command", _capture)
+    monkeypatch.setenv("GABION_LSP_TIMEOUT_TICKS", "77")
+
+    refresh_baselines._run_check("--emit-ambiguity-delta", timeout=3)
+
+    run = captured[0]
+    assert "--emit-timeout-progress-report" in run.cmd
+    assert "--resume-checkpoint" in run.cmd
+    assert "--resume-on-timeout" in run.cmd
+    checkpoint_index = run.cmd.index("--resume-checkpoint") + 1
+    assert run.cmd[checkpoint_index] == str(
+        refresh_baselines.RESUME_CHECKPOINT_DIR / "--emit-ambiguity-delta.json"
+    )
+
+
+def test_run_refresh_command_timeout_writes_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd=[sys.executable, "-m", "gabion"], timeout=9)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    run = refresh_baselines._RefreshCommand(
+        label="timeout-case",
+        cmd=[sys.executable, "-m", "gabion", "check"],
+        env={"GABION_LSP_TIMEOUT_MS": "9000", "GABION_DIRECT_RUN": "1"},
+        timeout=9,
+        expected_artifacts=["artifacts/out/test_obsolescence_delta.json"],
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        refresh_baselines._run_refresh_command(run)
+
+    payload = json.loads(refresh_baselines.FAILURE_ARTIFACT_PATH.read_text(encoding="utf-8"))
+    assert payload["failure_type"] == "TimeoutExpired"
+    assert payload["exit_code"] is None
+    assert payload["expected_artifact_paths"] == [
+        "artifacts/out/test_obsolescence_delta.json"
+    ]
+    stderr = capsys.readouterr().err
+    assert "Refresh baseline subprocess failed" in stderr
+    assert "GABION_DIRECT_RUN=1" in stderr
+
+
+def test_run_refresh_command_called_process_error_writes_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def _raise_called_process_error(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(returncode=21, cmd=["python", "-m", "gabion"])
+
+    monkeypatch.setattr(subprocess, "run", _raise_called_process_error)
+    run = refresh_baselines._RefreshCommand(
+        label="cpe-case",
+        cmd=["python", "-m", "gabion", "check"],
+        env={"GABION_DIRECT_RUN": "1", "GABION_LSP_TIMEOUT_SECONDS": "7"},
+        timeout=7,
+        expected_artifacts=["baselines/ambiguity_baseline.json"],
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        refresh_baselines._run_refresh_command(run)
+
+    payload = json.loads(refresh_baselines.FAILURE_ARTIFACT_PATH.read_text(encoding="utf-8"))
+    assert payload["failure_type"] == "CalledProcessError"
+    assert payload["exit_code"] == 21
+    assert payload["env_timeout_settings"]["GABION_LSP_TIMEOUT_SECONDS"] == "7"
+
+
+def test_run_refresh_command_success_clears_stale_failure_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    refresh_baselines.FAILURE_ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    refresh_baselines.FAILURE_ARTIFACT_PATH.write_text("stale", encoding="utf-8")
+
+    def _ok(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["python"], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _ok)
+    run = refresh_baselines._RefreshCommand(
+        label="ok-case",
+        cmd=["python", "-m", "gabion", "check"],
+        env={"GABION_DIRECT_RUN": "1"},
+        timeout=2,
+        expected_artifacts=[],
+    )
+
+    refresh_baselines._run_refresh_command(run)
+
+    assert not refresh_baselines.FAILURE_ARTIFACT_PATH.exists()


### PR DESCRIPTION
### Motivation
- Make `scripts/refresh_baselines.py` robust to subprocess timeouts and failures by emitting deterministic progress/resume flags for `gabion check` runs.
- Produce structured, machine-readable failure artifacts when subprocesses time out or return non-zero so CI/automation can inspect failure context.
- Provide direct remediation snippets on stderr to help operators retry/diagnose failures quickly.
- Ensure a successful run clears stale failure artifacts so old errors do not block subsequent runs.

### Description
- Added a `_RefreshCommand` dataclass and `_run_refresh_command` wrapper that executes subprocesses and centralizes handling of `TimeoutExpired` and `CalledProcessError`.
- Emits a structured failure artifact at `artifacts/out/refresh_baselines_failure.json` containing `failure_type`, `label`, `command`, `command_text`, `exit_code`, `timeout_seconds`, `env_timeout_settings`, and `expected_artifact_paths` when a run fails.
- Injects deterministic timeout progress/resume flags into `gabion check` invocations (`--emit-timeout-progress-report`, `--resume-checkpoint <path>`, `--resume-on-timeout 1`) with a stable checkpoint path derived from the invoked flag.
- Prints concise remediation command snippets to `stderr` when a subprocess fails, and clears any stale failure artifact on successful runs and at script startup.
- Updated docflow emitter invocation to use the same wrapper and record its expected artifact, and added `tests/test_refresh_baselines.py` covering timeout, `CalledProcessError`, resume-flag wiring, and stale artifact cleanup.

### Testing
- Ran the new unit tests: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_refresh_baselines.py -q` and all tests passed (`4 passed`).
- The test run exercised the `TimeoutExpired` and `CalledProcessError` branches and verified resume/timeout flag injection and stale artifact removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952817417083249676c3c84be0e720)