### PR TITLE
Enforce required SPPF GH-ref checks in docflow strict mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           fi
           .venv/bin/python scripts/policy_check.py --posture
       - name: Docflow audit
-        run: .venv/bin/python -m gabion docflow-audit --root . --fail-on-violations
+        run: .venv/bin/python -m gabion docflow-audit --root . --fail-on-violations --sppf-gh-ref-mode required
       - name: Test evidence index
         env:
           GABION_LSP_TIMEOUT_TICKS: "300000"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -5,6 +5,7 @@ run_docflow=true
 run_dataflow=true
 run_tests=true
 list_only=false
+docflow_mode="required"
 
 for arg in "$@"; do
   case "$arg" in
@@ -14,8 +15,9 @@ for arg in "$@"; do
     --tests-only) run_tests=true; run_dataflow=false; run_docflow=false ;;
     --dataflow-only) run_dataflow=true; run_docflow=false; run_tests=false ;;
     --list) list_only=true ;;
+    --docflow-advisory) docflow_mode="advisory" ;;
     -h|--help)
-      echo "Usage: scripts/checks.sh [--docflow|--no-docflow|--docflow-only|--dataflow-only|--tests-only|--list]" >&2
+      echo "Usage: scripts/checks.sh [--docflow|--no-docflow|--docflow-only|--dataflow-only|--tests-only|--docflow-advisory|--list]" >&2
       exit 0
       ;;
   esac
@@ -24,7 +26,7 @@ done
 if $list_only; then
   echo "Checks to run:" >&2
   $run_dataflow && echo "- dataflow (gabion check)" >&2
-  $run_docflow && echo "- docflow (gabion docflow-audit)" >&2
+  $run_docflow && echo "- docflow (gabion docflow-audit --fail-on-violations --sppf-gh-ref-mode $docflow_mode)" >&2
   $run_tests && echo "- tests (pytest)" >&2
   exit 0
 fi
@@ -42,7 +44,11 @@ if $run_dataflow; then
   mise exec -- python -m gabion check "${baseline_arg[@]}"
 fi
 if $run_docflow; then
-  mise exec -- python -m gabion docflow-audit
+  docflow_args=(--fail-on-violations --sppf-gh-ref-mode "$docflow_mode")
+  if [ "$docflow_mode" = "advisory" ]; then
+    echo "WARNING: running docflow in advisory GH-reference mode (local debugging only)." >&2
+  fi
+  mise exec -- python -m gabion docflow-audit "${docflow_args[@]}"
 fi
 if $run_tests; then
   test_dir="${TEST_ARTIFACTS_DIR:-artifacts/test_runs}"

--- a/scripts/docflow_audit.py
+++ b/scripts/docflow_audit.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution path
 
 
 if __name__ == "__main__":
-    status = run_docflow_cli()
+    status = run_docflow_cli(["--fail-on-violations", "--sppf-gh-ref-mode", "required"])
     if status == 0:
         try:
             run_sppf_graph_cli([])

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -1636,6 +1636,7 @@ def _run_docflow_audit(
     *,
     root: Path,
     fail_on_violations: bool,
+    sppf_gh_ref_mode: str,
     audit_tools_path: Path | None = None,
     spec_from_file_location_fn: Callable[..., object | None] = importlib.util.spec_from_file_location,
     module_from_spec_fn: Callable[..., object] = importlib.util.module_from_spec,
@@ -1689,6 +1690,7 @@ def _run_docflow_audit(
             args = ["--root", str(root)]
             if fail_on_violations:
                 args.append("--fail-on-violations")
+            args.extend(["--sppf-gh-ref-mode", sppf_gh_ref_mode])
             status = int(module.run_docflow_cli(args))
             if status == 0:
                 try:
@@ -1714,11 +1716,20 @@ def _run_docflow_audit(
 def docflow_audit(
     root: Path = typer.Option(Path("."), "--root"),
     fail_on_violations: bool = typer.Option(
-        False, "--fail-on-violations/--no-fail-on-violations"
+        True, "--fail-on-violations/--no-fail-on-violations"
+    ),
+    sppf_gh_ref_mode: str = typer.Option(
+        "required",
+        "--sppf-gh-ref-mode",
+        help="SPPF GH-reference enforcement mode (required|advisory).",
     ),
 ) -> None:
     """Run the docflow audit (governance docs only)."""
-    exit_code = _run_docflow_audit(root=root, fail_on_violations=fail_on_violations)
+    exit_code = _run_docflow_audit(
+        root=root,
+        fail_on_violations=fail_on_violations,
+        sppf_gh_ref_mode=sppf_gh_ref_mode,
+    )
     raise typer.Exit(code=exit_code)
 
 

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -457,6 +457,7 @@ def test_run_docflow_audit_missing_script(tmp_path: Path) -> None:
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=missing,
     )
     assert exit_code == 2
@@ -481,11 +482,12 @@ def test_run_docflow_audit_passes_flags(tmp_path: Path) -> None:
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=True,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
     )
     assert exit_code == 0
     lines = calls_path.read_text(encoding="utf-8").splitlines()
-    assert lines[0] == f"docflow:--root|{tmp_path}|--fail-on-violations"
+    assert lines[0] == f"docflow:--root|{tmp_path}|--fail-on-violations|--sppf-gh-ref-mode|required"
     assert lines[1] == "sppf:"
 
 
@@ -507,6 +509,7 @@ def test_run_docflow_audit_cleans_import_state(tmp_path: Path) -> None:
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
         sys_path_list=sys_path_list,
         sys_modules_map=sys_modules_map,
@@ -531,6 +534,7 @@ def test_run_docflow_audit_restores_previous_module(tmp_path: Path) -> None:
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
         sys_modules_map=sys_modules_map,
     )
@@ -556,6 +560,7 @@ def test_run_docflow_audit_cleanup_ignores_missing_sys_path(tmp_path: Path) -> N
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
         sys_path_list=sys_path_list,
     )
@@ -576,6 +581,7 @@ def test_run_docflow_audit_keeps_existing_sys_path_entry(tmp_path: Path) -> None
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
         sys_path_list=sys_path_list,
     )
@@ -596,6 +602,7 @@ def test_run_docflow_audit_returns_one_when_sppf_graph_fails(
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
     )
     assert exit_code == 1
@@ -615,6 +622,7 @@ def test_run_docflow_audit_returns_nonzero_docflow_status_without_sppf(
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
     )
     assert exit_code == 7
@@ -629,6 +637,7 @@ def test_run_docflow_audit_returns_two_when_loader_creation_fails(
     exit_code = cli._run_docflow_audit(
         root=tmp_path,
         fail_on_violations=False,
+        sppf_gh_ref_mode="required",
         audit_tools_path=module_path,
         spec_from_file_location_fn=lambda *_a, **_k: None,
     )

--- a/tests/test_docflow_sppf_gh_refs.py
+++ b/tests/test_docflow_sppf_gh_refs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+def _load_audit_tools():
+    from scripts import audit_tools
+
+    return audit_tools
+
+
+def _install_fake_sppf_sync(monkeypatch, *, rev_range: str, commits: list[str], issue_ids: set[str]) -> None:
+    module = types.SimpleNamespace(
+        _default_range=lambda: rev_range,
+        _collect_commits=lambda _range: commits,
+        _issue_ids_from_commits=lambda _commits: issue_ids,
+    )
+    monkeypatch.setitem(sys.modules, "scripts.sppf_sync", module)
+
+
+def test_sppf_gh_refs_required_mode_reports_violation(monkeypatch, tmp_path: Path) -> None:
+    audit_tools = _load_audit_tools()
+    _install_fake_sppf_sync(
+        monkeypatch,
+        rev_range="HEAD~1..HEAD",
+        commits=["abc123"],
+        issue_ids=set(),
+    )
+    monkeypatch.setattr(audit_tools, "_git_diff_paths", lambda _rev: ["src/gabion/cli.py"])
+
+    violations, warnings = audit_tools._sppf_sync_check(tmp_path, mode="required")
+
+    assert len(violations) == 1
+    assert "no GH references found" in violations[0]
+    assert warnings == []
+
+
+def test_sppf_gh_refs_advisory_mode_reports_warning(monkeypatch, tmp_path: Path) -> None:
+    audit_tools = _load_audit_tools()
+    _install_fake_sppf_sync(
+        monkeypatch,
+        rev_range="HEAD~1..HEAD",
+        commits=["abc123"],
+        issue_ids=set(),
+    )
+    monkeypatch.setattr(audit_tools, "_git_diff_paths", lambda _rev: ["in/in-30.md"])
+
+    violations, warnings = audit_tools._sppf_sync_check(tmp_path, mode="advisory")
+
+    assert violations == []
+    assert len(warnings) == 1
+    assert "no GH references found" in warnings[0]
+
+
+def test_sppf_gh_refs_required_mode_ignores_irrelevant_paths(monkeypatch, tmp_path: Path) -> None:
+    audit_tools = _load_audit_tools()
+    _install_fake_sppf_sync(
+        monkeypatch,
+        rev_range="HEAD~1..HEAD",
+        commits=["abc123"],
+        issue_ids=set(),
+    )
+    monkeypatch.setattr(audit_tools, "_git_diff_paths", lambda _rev: ["docs/notes.md"])
+
+    violations, warnings = audit_tools._sppf_sync_check(tmp_path, mode="required")
+
+    assert violations == []
+    assert warnings == []
+
+
+def test_sppf_gh_refs_required_mode_passes_when_refs_present(monkeypatch, tmp_path: Path) -> None:
+    audit_tools = _load_audit_tools()
+    _install_fake_sppf_sync(
+        monkeypatch,
+        rev_range="HEAD~1..HEAD",
+        commits=["abc123"],
+        issue_ids={"GH-123"},
+    )
+    monkeypatch.setattr(audit_tools, "_git_diff_paths", lambda _rev: ["docs/sppf_checklist.md"])
+
+    violations, warnings = audit_tools._sppf_sync_check(tmp_path, mode="required")
+
+    assert violations == []
+    assert warnings == []


### PR DESCRIPTION
### Motivation
- Make SPPF GH-reference checking explicit and enforceable by splitting advisory vs required behavior to avoid silent regressions when SPPF-relevant paths change without issue references. 
- Ensure all docflow entrypoints run the same strict mode by default so CI and local checks behave consistently. 
- Provide a minimal escape hatch for local debugging while preventing accidental opt-outs in CI and automated runs.

### Description
- Split the SPPF commit GH-reference check into two modes in `scripts/audit_tools.py`: `required` and `advisory`, implemented as `_sppf_sync_check(..., mode=...)` with a `SppfGhRefMode` resolver. 
- Make `required` mode append a docflow violation when commits touching SPPF-relevant paths (`src/`, `in/`, `docs/sppf_checklist.md`) lack GH references, while `advisory` emits a warning only. 
- Thread the GH-ref mode through the docflow call path: added `--sppf-gh-ref-mode` CLI argument to `scripts/audit_tools.py`, forwarded from `src/gabion/cli.py` and included by `python -m gabion docflow-audit`, with `docflow` defaulting to `required` + `--fail-on-violations`. 
- Update entrypoints and orchestration: `scripts/docflow_audit.py` now invokes docflow with `--fail-on-violations --sppf-gh-ref-mode required`, CI (`.github/workflows/ci.yml`) explicitly passes `--sppf-gh-ref-mode required`, and `scripts/checks.sh` runs docflow in required mode by default while adding a `--docflow-advisory` flag for local opt-out and a short advisory warning. 
- Add regression tests `tests/test_docflow_sppf_gh_refs.py` covering required/advisory outcomes and relevant/irrelevant path combinations, and update `tests/test_cli_helpers.py` to reflect forwarded args.

### Testing
- Ran the updated test subset with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_cli_helpers.py tests/test_docflow_sppf_gh_refs.py tests/test_cli_commands.py -q`, and all tests passed (`96 passed`).
- Attempted `mise exec -- python -m pytest ...` but `mise` required trust in this environment and was skipped; the equivalent direct invocation above validated the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699527f706608324b9f8682718fa2647)