### PR TITLE
Add non-mutating SPPF issue lifecycle validation and hook/CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,29 @@ jobs:
           .venv/bin/python scripts/policy_check.py --posture
       - name: Docflow audit
         run: .venv/bin/python -m gabion docflow-audit --root . --fail-on-violations
+      - name: SPPF issue lifecycle validation (non-mutating)
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "GH_TOKEN is unavailable; skipping SPPF issue lifecycle validation."
+            exit 0
+          fi
+          if [ -z "${BEFORE_SHA:-}" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            rev_range="HEAD~20..HEAD"
+          else
+            rev_range="$BEFORE_SHA..$AFTER_SHA"
+          fi
+          .venv/bin/python scripts/sppf_sync.py \
+            --validate \
+            --only-when-relevant \
+            --range "$rev_range" \
+            --require-state open \
+            --require-label done-on-stage \
+            --require-label status/pending-release
       - name: Test evidence index
         env:
           GABION_LSP_TIMEOUT_TICKS: "300000"

--- a/tests/test_sppf_sync.py
+++ b/tests/test_sppf_sync.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scripts import sppf_sync
+
+
+def test_is_sppf_relevant_push_detects_relevant_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sppf_sync, "_run_git", lambda args: "src/gabion/cli.py\nREADME.md")
+    assert sppf_sync._is_sppf_relevant_push("origin/stage..HEAD") is True
+
+
+def test_validate_issue_lifecycle_reports_missing_labels_and_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sppf_sync,
+        "_fetch_issue",
+        lambda issue_id: sppf_sync.IssueLifecycle(issue_id=issue_id, state="closed", labels=("done-on-stage",)),
+    )
+    violations = sppf_sync._validate_issue_lifecycle(
+        ["123"],
+        required_labels=["done-on-stage", "status/pending-release"],
+        expected_state="open",
+    )
+    assert len(violations) == 2
+    assert "expected state 'open'" in violations[0]
+    assert "missing required label(s): status/pending-release" in violations[1]
+    assert "scripts/sppf_sync.py --range <rev-range> --label status/pending-release" in violations[1]
+
+
+def test_main_validate_mode_fails_with_clear_remediation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sppf_sync, "_default_range", lambda: "origin/stage..HEAD")
+    monkeypatch.setattr(sppf_sync, "_is_sppf_relevant_push", lambda rev_range: True)
+    monkeypatch.setattr(
+        sppf_sync,
+        "_collect_commits",
+        lambda rev_range: [sppf_sync.CommitInfo(sha="abc", subject="SPPF: GH-123", body="")],
+    )
+    monkeypatch.setattr(sppf_sync, "_issue_ids_from_commits", lambda commits: {"123"})
+    monkeypatch.setattr(
+        sppf_sync,
+        "_fetch_issue",
+        lambda issue_id: sppf_sync.IssueLifecycle(issue_id=issue_id, state="open", labels=()),
+    )
+
+    monkeypatch.setattr(
+        sppf_sync.sys,
+        "argv",
+        [
+            "sppf_sync.py",
+            "--validate",
+            "--only-when-relevant",
+            "--require-label",
+            "done-on-stage",
+            "--require-label",
+            "status/pending-release",
+        ],
+    )
+    exit_code = sppf_sync.main()
+    captured = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "SPPF issue lifecycle validation failed" in captured
+    assert "GH-123: missing required label(s): done-on-stage, status/pending-release" in captured
+
+
+def test_fetch_issue_reports_missing_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=["gh"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    with pytest.raises(RuntimeError) as exc:
+        sppf_sync._fetch_issue("999")
+    assert "GH-999: issue lookup failed" in str(exc.value)


### PR DESCRIPTION
### Motivation
- Run SPPF sync in a dry/validation mode automatically on relevant pushes so CI can assert SPPF references without requesting write permissions.
- Detect and surface missing expected labels (`done-on-stage`, `status/pending-release`) and unexpected issue lifecycle state with clear remediation instructions.
- Provide a non-mutating CI check that verifies referenced issues exist and are in an expected lifecycle state before allowing a push to proceed.
- Preserve the existing permission model by keeping mutating actions (comments, closes, label writes) local-only and opt-in.

### Description
- Extended `scripts/sppf_sync.py` with `--validate`, `--only-when-relevant`, `--require-label`, and `--require-state` flags, added `SPPF_RELEVANT_PATHS`, and implemented `_fetch_issue` and `_validate_issue_lifecycle` to check issue existence, state, and labels and emit remediation text. 
- Made `--label` repeatable and kept mutating operations (`--comment`, `--close`, `--label`) as explicit local actions that cannot be combined with `--validate`.
- Wired the CI `checks` job in `.github/workflows/ci.yml` to run the non-mutating validation on `push` (read-only) using a computed revision range and `secrets.GITHUB_TOKEN`, and updated `scripts/install_hooks.sh` pre-push hook to run the same validation for `stage` while preserving optional local mutating sync when `GABION_SPPF_SYNC=1`.
- Documented one canonical SPPF “happy path” in `CONTRIBUTING.md` with exact command sequence and added focused unit tests in `tests/test_sppf_sync.py` covering relevance detection, lifecycle validation messaging, and error handling.

### Testing
- Ran the focused unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_sppf_sync.py` and all tests passed (4 passed).
- Executed the workflow policy verifier with `PYTHONPATH=src python scripts/policy_check.py --workflows` which completed successfully.
- Ran `PYTHONPATH=src python -m gabion docflow-audit --root . --fail-on-violations` which completed successfully (a local git warning about missing `origin/stage` ref is environmental and not a validation failure).
- Verified `scripts/sppf_sync.py` compiles with `py_compile` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995280c9f908324a52c840a87a0826b)