### PR TITLE
Add `gabion sppf-sync` CLI command with compatibility shim and tests

### DIFF
--- a/scripts/sppf_sync.py
+++ b/scripts/sppf_sync.py
@@ -1,28 +1,16 @@
 #!/usr/bin/env python3
-"""Sync SPPF checklist-linked issues from commit messages.
-
-This is a local helper to avoid CI write scopes. It parses commit messages for
-references like "GH-17" or "Closes #17" and comments/closes/labels issues
-via the GitHub CLI.
-"""
+"""Compatibility shim for `gabion sppf-sync`."""
 from __future__ import annotations
 
-import argparse
-import re
-import subprocess
 import sys
-from dataclasses import dataclass
 
 try:  # pragma: no cover - import form depends on invocation mode
     from scripts.deadline_runtime import DeadlineBudget, deadline_scope_from_lsp_env
 except ModuleNotFoundError:  # pragma: no cover - direct script execution path
     from deadline_runtime import DeadlineBudget, deadline_scope_from_lsp_env
-from gabion.analysis.timeout_context import check_deadline
-from gabion.order_contract import ordered_or_sorted
 
+from gabion.cli import run_sppf_sync_compat
 
-GH_REF_RE = re.compile(r"\bGH-(\d+)\b", re.IGNORECASE)
-KEYWORD_REF_RE = re.compile(r"\b(?:Closes|Fixes|Resolves|Refs)\s+#(\d+)\b", re.IGNORECASE)
 _DEFAULT_TIMEOUT_TICKS = 120_000
 _DEFAULT_TIMEOUT_TICK_NS = 1_000_000
 _DEFAULT_TIMEOUT_BUDGET = DeadlineBudget(
@@ -37,132 +25,9 @@ def _deadline_scope():
     )
 
 
-@dataclass(frozen=True)
-class CommitInfo:
-    sha: str
-    subject: str
-    body: str
-
-
-def _run_git(args: list[str]) -> str:
-    return subprocess.check_output(["git", *args], text=True).strip()
-
-
-def _default_range() -> str:
-    try:
-        _run_git(["rev-parse", "origin/stage"])
-        return "origin/stage..HEAD"
-    except Exception:
-        return "HEAD~20..HEAD"
-
-
-def _collect_commits(rev_range: str) -> list[CommitInfo]:
-    try:
-        raw = subprocess.check_output(
-            [
-                "git",
-                "log",
-                "--format=%H%x1f%s%x1f%B%x1e",
-                rev_range,
-            ],
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        raise SystemExit(f"git log failed for range {rev_range}: {exc}")
-
-    commits: list[CommitInfo] = []
-    for record in raw.split("\x1e"):
-        check_deadline()
-        if not record.strip():
-            continue
-        parts = record.split("\x1f")
-        if len(parts) < 3:
-            continue
-        sha, subject, body = parts[0].strip(), parts[1].strip(), parts[2].strip()
-        commits.append(CommitInfo(sha=sha, subject=subject, body=body))
-    return commits
-
-
-def _extract_issue_ids(text: str) -> set[str]:
-    issues = set(match.group(1) for match in GH_REF_RE.finditer(text))
-    issues.update(match.group(1) for match in KEYWORD_REF_RE.finditer(text))
-    return issues
-
-
-def _issue_ids_from_commits(commits: list[CommitInfo]) -> set[str]:
-    issues: set[str] = set()
-    for commit in commits:
-        check_deadline()
-        issues.update(_extract_issue_ids(commit.subject))
-        issues.update(_extract_issue_ids(commit.body))
-    return issues
-
-
-def _build_comment(rev_range: str, commits: list[CommitInfo]) -> str:
-    lines = [f"SPPF sync from `{rev_range}`:"]
-    for commit in commits:
-        check_deadline()
-        lines.append(f"- {commit.sha[:8]} {commit.subject}")
-    return "\n".join(lines)
-
-
-def _run_gh(args: list[str], dry_run: bool) -> None:
-    if dry_run:
-        print("DRY RUN:", " ".join(["gh", *args]))
-        return
-    subprocess.run(["gh", *args], check=True)
-
-
 def main() -> int:
     with _deadline_scope():
-        parser = argparse.ArgumentParser(description="Sync SPPF-linked issues from commit messages.")
-        parser.add_argument(
-            "--range",
-            dest="rev_range",
-            default=None,
-            help="Git revision range (default: origin/stage..HEAD if available).")
-        parser.add_argument(
-            "--comment",
-            action="store_true",
-            help="Comment on each referenced issue with commit summary.")
-        parser.add_argument(
-            "--close",
-            action="store_true",
-            help="Close each referenced issue with a summary comment.")
-        parser.add_argument(
-            "--label",
-            default=None,
-            help="Apply a label to each referenced issue.")
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Print gh commands without executing.")
-        args = parser.parse_args()
-
-        rev_range = args.rev_range or _default_range()
-        commits = _collect_commits(rev_range)
-        if not commits:
-            print("No commits in range; nothing to sync.")
-            return 0
-
-        issue_ids = ordered_or_sorted(
-            _issue_ids_from_commits(commits),
-            source="scripts.sppf_sync.issue_ids",
-        )
-        if not issue_ids:
-            print("No issue references found in commit messages.")
-            return 0
-
-        comment = _build_comment(rev_range, commits)
-        for issue_id in issue_ids:
-            check_deadline()
-            if args.close:
-                _run_gh(["issue", "close", issue_id, "-c", comment], args.dry_run)
-            elif args.comment:
-                _run_gh(["issue", "comment", issue_id, "-b", comment], args.dry_run)
-            if args.label:
-                _run_gh(["issue", "edit", issue_id, "--add-label", args.label], args.dry_run)
-        return 0
+        return run_sppf_sync_compat(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/tests/test_sppf_sync_cli.py
+++ b/tests/test_sppf_sync_cli.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+
+from typer.testing import CliRunner
+
+from gabion import cli
+from scripts import sppf_sync
+
+
+def test_sppf_sync_cli_maps_flags_to_runner(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run_sppf_sync(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(cli, "_run_sppf_sync", _fake_run_sppf_sync)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "sppf-sync",
+            "--range",
+            "HEAD~3..HEAD",
+            "--comment",
+            "--close",
+            "--label",
+            "done-on-stage",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "rev_range": "HEAD~3..HEAD",
+        "comment": True,
+        "close": True,
+        "label": "done-on-stage",
+        "dry_run": True,
+    }
+
+
+def test_sppf_sync_dry_run_routes_comment_and_label(monkeypatch) -> None:
+    commits = [
+        cli.SppfSyncCommitInfo(
+            sha="abcdef0123456789",
+            subject="Link GH-22",
+            body="Refs #22",
+        )
+    ]
+    calls: list[tuple[list[str], bool]] = []
+
+    def _fake_collect(_rev_range: str):
+        return commits
+
+    def _fake_gh(args: list[str], *, dry_run: bool):
+        calls.append((args, dry_run))
+
+    monkeypatch.setattr(cli, "_collect_sppf_commits", _fake_collect)
+    monkeypatch.setattr(cli, "_run_sppf_gh", _fake_gh)
+
+    exit_code = cli._run_sppf_sync(
+        rev_range="HEAD~1..HEAD",
+        comment=True,
+        close=False,
+        label="done-on-stage",
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+    assert calls == [
+        (
+            [
+                "issue",
+                "comment",
+                "22",
+                "-b",
+                "SPPF sync from `HEAD~1..HEAD`:\n- abcdef01 Link GH-22",
+            ],
+            True,
+        ),
+        (["issue", "edit", "22", "--add-label", "done-on-stage"], True),
+    ]
+
+
+def test_sppf_issue_id_extraction_matches_previous_patterns() -> None:
+    text = "GH-11 closes #12; resolves #13; refs #12 and Fixes #14"
+    assert cli._extract_sppf_issue_ids(text) == {"11", "12", "13", "14"}
+
+
+def test_script_sppf_sync_delegates_to_cli_compat(monkeypatch) -> None:
+    captured: list[str] = []
+
+    def _fake_run(argv: list[str]):
+        captured.extend(argv)
+        return 0
+
+    monkeypatch.setattr(sppf_sync, "run_sppf_sync_compat", _fake_run)
+    monkeypatch.setattr(sys, "argv", ["scripts/sppf_sync.py", "--dry-run", "--comment"])
+
+    assert sppf_sync.main() == 0
+    assert captured == ["--dry-run", "--comment"]


### PR DESCRIPTION
### Motivation

- Provide a first-class `gabion sppf-sync` CLI entrypoint so SPPF checklist syncing is available through the same CLI surface and deadline scope conventions used elsewhere.  
- Preserve existing script semantics and flags (`--range`, `--comment`, `--close`, `--label`, `--dry-run`) while centralizing logic in the CLI for consistent output and error handling.  
- Keep the legacy `scripts/sppf_sync.py` as a thin compatibility shim to avoid breaking existing workflows.  

### Description

- Implemented shared SPPF sync helpers in `src/gabion/cli.py` including git commit collection, issue-id extraction, comment construction, and GH invocation utilities, plus the `run_sppf_sync_compat(argv)` compatibility entrypoint.  
- Added a Typer command `@app.command("sppf-sync")` in `src/gabion/cli.py` that runs under the existing `_cli_deadline_scope()` so behavior and error reporting match other commands.  
- Replaced the original `scripts/sppf_sync.py` body with a small shim that retains deadline scoping and delegates to `run_sppf_sync_compat`, keeping backward compatibility for script invocation.  
- Added `tests/test_sppf_sync_cli.py` to validate CLI-to-runner flag mapping, dry-run routing, issue-id extraction parity, and script-shim delegation.  

### Testing

- Ran `pytest` for the new test file with `PYTHONPATH=src` using `-o addopts=''` to avoid repository-local pytest options, and `tests/test_sppf_sync_cli.py` passed (4 tests, all passed).  
- Executed `tests/test_script_scope_bindings.py` to verify the script-level deadline/forest binding and it passed (1 test, passed).  
- Commands used to validate behavior: `PYTHONPATH=src python -m gabion.cli sppf-sync --help` and `mise exec -- env PYTHONPATH=src python -m pytest -o addopts='' tests/test_sppf_sync_cli.py`, both completed successfully in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952a7b4f448324b411e3f614b03499)