### PR TITLE
Add governance CLI subcommands (docflow-audit, sppf-graph, status-consistency) with centralized path config and legacy wrappers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 84
+doc_revision: 85
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -228,6 +228,13 @@ Run the docflow audit (governance docs; `in/` is included for dependency resolut
 ```
 mise exec -- python -m gabion docflow-audit
 ```
+Run governance graph/status checks through the same CLI entrypoint:
+```
+mise exec -- python -m gabion sppf-graph
+mise exec -- python -m gabion status-consistency --fail-on-violations
+```
+Legacy wrappers remain available for transition-only CI/hooks (`scripts/docflow_audit.py`,
+`scripts/sppf_graph.py`, `scripts/status_consistency.py`).
 
 Docflow now fails when commits touching SPPF-relevant paths (`src/`, `in/`, or
 `docs/sppf_checklist.md`) lack GH references in commit messages. Use `GH-####`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 64
+doc_revision: 65
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -174,6 +174,13 @@ Run the docflow audit (governance docs; `in/` is included for dependency resolut
 ```
 mise exec -- python -m gabion docflow-audit
 ```
+Run governance graph/status checks through the same CLI entrypoint:
+```
+mise exec -- python -m gabion sppf-graph
+mise exec -- python -m gabion status-consistency --fail-on-violations
+```
+Legacy wrappers remain available for transition-only CI/hooks (`scripts/docflow_audit.py`,
+`scripts/sppf_graph.py`, `scripts/status_consistency.py`).
 
 Note: docflow is a repo-local convenience feature. It is not a core Gabion
 capability and is not intended to generalize beyond this repository.

--- a/scripts/audit_tools.py
+++ b/scripts/audit_tools.py
@@ -25,6 +25,7 @@ from gabion.analysis.projection_normalize import normalize_spec, spec_canonical_
 from gabion.analysis.projection_spec import ProjectionOp, ProjectionSpec, spec_from_dict
 from gabion.analysis import evidence_keys
 from gabion.analysis.impact_index import build_impact_index
+from gabion.governance_paths import GOVERNANCE_PATHS
 from gabion.invariants import never
 from gabion.order_contract import ordered_or_sorted
 
@@ -1133,7 +1134,7 @@ def _write_sppf_graph_outputs(graph: dict[str, object], *, json_output: Path | N
 
 
 def _influence_statuses(root: Path) -> dict[str, str]:
-    index_path = root / "docs" / "influence_index.md"
+    index_path = GOVERNANCE_PATHS.influence_index_path(root=root)
     if not index_path.exists():
         return {}
     text = index_path.read_text(encoding="utf-8")
@@ -1151,7 +1152,7 @@ def _influence_statuses(root: Path) -> dict[str, str]:
 
 def _in_doc_revisions(root: Path) -> dict[str, int]:
     revisions: dict[str, int] = {}
-    inbox = root / "in"
+    inbox = GOVERNANCE_PATHS.in_dir(root=root)
     if not inbox.exists():
         return revisions
     for path in inbox.glob("in-*.md"):
@@ -1166,7 +1167,7 @@ def _in_doc_revisions(root: Path) -> dict[str, int]:
 
 def _doc_revision_for_ref(root: Path, doc_id: str) -> int | None:
     if doc_id.startswith("in-") and doc_id[3:].isdigit():
-        path = root / "in" / f"{doc_id}.md"
+        path = GOVERNANCE_PATHS.in_dir(root=root) / f"{doc_id}.md"
     else:
         path = root / doc_id
     if not path.exists():
@@ -3073,8 +3074,8 @@ def _tooling_warnings(root: Path, docs: dict[str, Doc]) -> List[str]:
 
 def _influence_warnings(root: Path) -> List[str]:
     warnings: List[str] = []
-    inbox = root / "in"
-    index_path = root / "docs" / "influence_index.md"
+    inbox = GOVERNANCE_PATHS.in_dir(root=root)
+    index_path = GOVERNANCE_PATHS.influence_index_path(root=root)
     if not inbox.exists():
         return warnings
     if not index_path.exists():
@@ -3119,12 +3120,10 @@ def _sppf_sync_warnings(root: Path) -> List[str]:
     if not changed:
         return warnings
 
-    relevant_prefixes = ("src/", "in/")
-    relevant_paths = {"docs/sppf_checklist.md"}
     relevant = [
         path
         for path in changed
-        if path in relevant_paths or any(path.startswith(prefix) for prefix in relevant_prefixes)
+        if GOVERNANCE_PATHS.is_sppf_relevant_path(path)
     ]
     if not relevant:
         return warnings
@@ -3688,6 +3687,53 @@ def _sppf_graph_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _status_consistency_command(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    docs = _load_docflow_docs(root=root, extra_paths=args.extra_path)
+    violations, warnings = _sppf_axis_audit(root, docs)
+    warnings.extend(_sppf_sync_warnings(root))
+    payload = {
+        "root": str(root),
+        "violations": violations,
+        "warnings": warnings,
+        "summary": {
+            "violation_count": len(violations),
+            "warning_count": len(warnings),
+        },
+    }
+    if args.json_output is not None:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"SPPF status consistency JSON written to {args.json_output}")
+    if args.md_output is not None:
+        args.md_output.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            "# SPPF Status Consistency",
+            "",
+            f"- violations: {len(violations)}",
+            f"- warnings: {len(warnings)}",
+            "",
+        ]
+        if violations:
+            lines.extend(["## Violations", ""])
+            lines.extend(f"- {item}" for item in violations)
+            lines.append("")
+        if warnings:
+            lines.extend(["## Warnings", ""])
+            lines.extend(f"- {item}" for item in warnings)
+            lines.append("")
+        if not warnings and not violations:
+            lines.extend(["No issues detected.", ""])
+        args.md_output.write_text("\n".join(lines), encoding="utf-8")
+        print(f"SPPF status consistency markdown written to {args.md_output}")
+    if violations and args.fail_on_violations:
+        return 1
+    return 0
+
+
 def _decision_tiers_command(args: argparse.Namespace) -> int:
     lint_path = args.lint or _latest_lint_path(args.root)
     return _decision_tier_candidates(lint_path, tier=args.tier, output_format=args.format)
@@ -3941,6 +3987,34 @@ def _add_sppf_graph_args(parser: argparse.ArgumentParser) -> None:
     parser.set_defaults(func=_sppf_graph_command)
 
 
+def _add_status_consistency_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repo root")
+    parser.add_argument(
+        "--extra-path",
+        action="append",
+        default=None,
+        help="Additional markdown path to include in docflow parsing.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("artifacts/out/status_consistency.json"),
+        help="JSON output path",
+    )
+    parser.add_argument(
+        "--md-output",
+        type=Path,
+        default=Path("artifacts/audit_reports/status_consistency.md"),
+        help="Markdown output path",
+    )
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit non-zero when violations are detected.",
+    )
+    parser.set_defaults(func=_status_consistency_command)
+
+
 def _parse_single_command_args(
     add_args: Callable[[argparse.ArgumentParser], None], argv: list[str] | None
 ) -> argparse.Namespace:
@@ -3971,6 +4045,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_sppf_graph_args(
         subparsers.add_parser("sppf-graph", help="Emit SPPF dependency graph.")
+    )
+    _add_status_consistency_args(
+        subparsers.add_parser(
+            "status-consistency", help="Run SPPF checklist/influence consistency checks."
+        )
     )
 
     with _audit_deadline_scope():
@@ -4006,6 +4085,12 @@ def run_sppf_graph_cli(argv: list[str] | None = None) -> int:
     with _audit_deadline_scope():
         args = _parse_single_command_args(_add_sppf_graph_args, argv)
         return _sppf_graph_command(args)
+
+
+def run_status_consistency_cli(argv: list[str] | None = None) -> int:
+    with _audit_deadline_scope():
+        args = _parse_single_command_args(_add_status_consistency_args, argv)
+        return _status_consistency_command(args)
 
 
 if __name__ == "__main__":

--- a/scripts/docflow_audit.py
+++ b/scripts/docflow_audit.py
@@ -1,21 +1,35 @@
 #!/usr/bin/env python3
-"""Docflow audit for governance documents."""
+"""Legacy wrapper for `gabion docflow-audit`."""
 from __future__ import annotations
 
+import argparse
 import sys
+from pathlib import Path
 
-try:  # pragma: no cover - import form depends on invocation mode
-    from scripts.audit_tools import run_docflow_cli, run_sppf_graph_cli
-except ModuleNotFoundError:  # pragma: no cover - direct script execution path
-    from audit_tools import run_docflow_cli, run_sppf_graph_cli
+from gabion.cli import _run_docflow_audit
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run governance docflow audit.")
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repo root")
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit non-zero when violations are detected.",
+    )
+    parser.add_argument(
+        "--extra-path",
+        action="append",
+        default=None,
+        help="Additional markdown path to include in docflow parsing.",
+    )
+    args = parser.parse_args(argv)
+    return _run_docflow_audit(
+        root=args.root,
+        fail_on_violations=bool(args.fail_on_violations),
+        extra_path=args.extra_path,
+    )
 
 
 if __name__ == "__main__":
-    status = run_docflow_cli()
-    if status == 0:
-        try:
-            run_sppf_graph_cli([])
-        except Exception as exc:
-            print(f"docflow: sppf-graph failed: {exc}", file=sys.stderr)
-            raise SystemExit(1)
-    raise SystemExit(status)
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/sppf_graph.py
+++ b/scripts/sppf_graph.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Legacy wrapper for `gabion sppf-graph`."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from gabion.cli import _run_governance_cli
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Emit SPPF dependency graph artifacts.")
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repo root")
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("artifacts/sppf_dependency_graph.json"),
+        help="JSON output path",
+    )
+    parser.add_argument("--dot-output", type=Path, default=None, help="Optional DOT output path")
+    parser.add_argument("--issues-json", type=Path, default=None, help="Optional GH issues JSON")
+    args = parser.parse_args(argv)
+
+    call_args = ["--root", str(args.root), "--json-output", str(args.json_output)]
+    if args.dot_output is not None:
+        call_args.extend(["--dot-output", str(args.dot_output)])
+    if args.issues_json is not None:
+        call_args.extend(["--issues-json", str(args.issues_json)])
+    return _run_governance_cli(runner_name="run_sppf_graph_cli", args=call_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/status_consistency.py
+++ b/scripts/status_consistency.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Legacy wrapper for `gabion status-consistency`."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from gabion.cli import _run_governance_cli
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run SPPF status consistency checks.")
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repo root")
+    parser.add_argument(
+        "--extra-path",
+        action="append",
+        default=None,
+        help="Additional markdown path to include in docflow parsing.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("artifacts/out/status_consistency.json"),
+        help="JSON output path",
+    )
+    parser.add_argument(
+        "--md-output",
+        type=Path,
+        default=Path("artifacts/audit_reports/status_consistency.md"),
+        help="Markdown output path",
+    )
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit non-zero when violations are detected.",
+    )
+    args = parser.parse_args(argv)
+
+    call_args = [
+        "--root",
+        str(args.root),
+        "--json-output",
+        str(args.json_output),
+        "--md-output",
+        str(args.md_output),
+    ]
+    for entry in args.extra_path or []:
+        call_args.extend(["--extra-path", entry])
+    if args.fail_on_violations:
+        call_args.append("--fail-on-violations")
+    return _run_governance_cli(runner_name="run_status_consistency_cli", args=call_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -1632,25 +1632,18 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _run_docflow_audit(
+def _load_audit_tools_module(
     *,
-    root: Path,
-    fail_on_violations: bool,
     audit_tools_path: Path | None = None,
     spec_from_file_location_fn: Callable[..., object | None] = importlib.util.spec_from_file_location,
     module_from_spec_fn: Callable[..., object] = importlib.util.module_from_spec,
     sys_path_list: list[str] | None = None,
     sys_modules_map: MutableMapping[str, object] | None = None,
-) -> int:
+) -> Generator[object, None, None]:
     repo_root = _find_repo_root()
     module_path = audit_tools_path or (repo_root / "scripts" / "audit_tools.py")
     if not module_path.exists():
-        typer.secho(
-            "audit_tools.py not found; repository layout required",
-            err=True,
-            fg=typer.colors.RED,
-        )
-        return 2
+        raise FileNotFoundError("audit_tools.py not found; repository layout required")
 
     @contextmanager
     def _load_audit_tools() -> Generator[object, None, None]:
@@ -1684,9 +1677,93 @@ def _run_docflow_audit(
                 except ValueError:
                     pass
 
+    return _load_audit_tools()
+
+
+def _run_governance_cli(
+    *,
+    runner_name: str,
+    args: list[str],
+    audit_tools_path: Path | None = None,
+    spec_from_file_location_fn: Callable[..., object | None] = importlib.util.spec_from_file_location,
+    module_from_spec_fn: Callable[..., object] = importlib.util.module_from_spec,
+    sys_path_list: list[str] | None = None,
+    sys_modules_map: MutableMapping[str, object] | None = None,
+) -> int:
     try:
-        with _load_audit_tools() as module:
+        loader = _load_audit_tools_module(
+            audit_tools_path=audit_tools_path,
+            spec_from_file_location_fn=spec_from_file_location_fn,
+            module_from_spec_fn=module_from_spec_fn,
+            sys_path_list=sys_path_list,
+            sys_modules_map=sys_modules_map,
+        )
+    except FileNotFoundError as exc:
+        typer.secho(str(exc), err=True, fg=typer.colors.RED)
+        return 2
+    except Exception as exc:
+        typer.secho(
+            f"failed to load audit_tools module: {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        return 2
+
+    try:
+        with loader as module:
+            runner = getattr(module, runner_name, None)
+            if runner is None:
+                typer.secho(
+                    f"audit_tools missing runner: {runner_name}",
+                    err=True,
+                    fg=typer.colors.RED,
+                )
+                return 2
+            return int(runner(args))
+    except Exception as exc:
+        typer.secho(
+            f"governance command failed ({runner_name}): {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        return 1
+
+
+def _run_docflow_audit(
+    *,
+    root: Path,
+    fail_on_violations: bool,
+    extra_path: list[str] | None = None,
+    audit_tools_path: Path | None = None,
+    spec_from_file_location_fn: Callable[..., object | None] = importlib.util.spec_from_file_location,
+    module_from_spec_fn: Callable[..., object] = importlib.util.module_from_spec,
+    sys_path_list: list[str] | None = None,
+    sys_modules_map: MutableMapping[str, object] | None = None,
+) -> int:
+    try:
+        loader = _load_audit_tools_module(
+            audit_tools_path=audit_tools_path,
+            spec_from_file_location_fn=spec_from_file_location_fn,
+            module_from_spec_fn=module_from_spec_fn,
+            sys_path_list=sys_path_list,
+            sys_modules_map=sys_modules_map,
+        )
+    except FileNotFoundError as exc:
+        typer.secho(str(exc), err=True, fg=typer.colors.RED)
+        return 2
+    except Exception as exc:
+        typer.secho(
+            f"failed to load audit_tools module: {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        return 2
+
+    try:
+        with loader as module:
             args = ["--root", str(root)]
+            for entry in extra_path or []:
+                args.extend(["--extra-path", entry])
             if fail_on_violations:
                 args.append("--fail-on-violations")
             status = int(module.run_docflow_cli(args))
@@ -1716,9 +1793,51 @@ def docflow_audit(
     fail_on_violations: bool = typer.Option(
         False, "--fail-on-violations/--no-fail-on-violations"
     ),
+    extra_path: list[str] = typer.Option([], "--extra-path"),
 ) -> None:
     """Run the docflow audit (governance docs only)."""
-    exit_code = _run_docflow_audit(root=root, fail_on_violations=fail_on_violations)
+    exit_code = _run_docflow_audit(
+        root=root,
+        fail_on_violations=fail_on_violations,
+        extra_path=extra_path,
+    )
+    raise typer.Exit(code=exit_code)
+
+
+@app.command("sppf-graph")
+def sppf_graph(
+    root: Path = typer.Option(Path("."), "--root"),
+    json_output: Path = typer.Option(Path("artifacts/sppf_dependency_graph.json"), "--json-output"),
+    dot_output: Path | None = typer.Option(None, "--dot-output"),
+    issues_json: Path | None = typer.Option(None, "--issues-json"),
+) -> None:
+    """Emit SPPF dependency graph artifacts."""
+    args = ["--root", str(root), "--json-output", str(json_output)]
+    if dot_output is not None:
+        args.extend(["--dot-output", str(dot_output)])
+    if issues_json is not None:
+        args.extend(["--issues-json", str(issues_json)])
+    exit_code = _run_governance_cli(runner_name="run_sppf_graph_cli", args=args)
+    raise typer.Exit(code=exit_code)
+
+
+@app.command("status-consistency")
+def status_consistency(
+    root: Path = typer.Option(Path("."), "--root"),
+    extra_path: list[str] = typer.Option([], "--extra-path"),
+    fail_on_violations: bool = typer.Option(
+        False, "--fail-on-violations/--no-fail-on-violations"
+    ),
+    json_output: Path = typer.Option(Path("artifacts/out/status_consistency.json"), "--json-output"),
+    md_output: Path = typer.Option(Path("artifacts/audit_reports/status_consistency.md"), "--md-output"),
+) -> None:
+    """Check SPPF checklist status consistency across in/ + influence index metadata."""
+    args = ["--root", str(root), "--json-output", str(json_output), "--md-output", str(md_output)]
+    for entry in extra_path:
+        args.extend(["--extra-path", entry])
+    if fail_on_violations:
+        args.append("--fail-on-violations")
+    exit_code = _run_governance_cli(runner_name="run_status_consistency_cli", args=args)
     raise typer.Exit(code=exit_code)
 
 

--- a/src/gabion/governance_paths.py
+++ b/src/gabion/governance_paths.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GovernancePathConfig:
+    """Centralized governance path/linkage rules for repo-local tooling."""
+
+    src_prefix: str = "src/"
+    in_prefix: str = "in/"
+    sppf_checklist_rel: str = "docs/sppf_checklist.md"
+    influence_index_rel: str = "docs/influence_index.md"
+
+    def in_dir(self, *, root: Path) -> Path:
+        return root / self.in_prefix.rstrip("/")
+
+    def sppf_checklist_path(self, *, root: Path) -> Path:
+        return root / self.sppf_checklist_rel
+
+    def influence_index_path(self, *, root: Path) -> Path:
+        return root / self.influence_index_rel
+
+    def is_sppf_relevant_path(self, path: str) -> bool:
+        if path == self.sppf_checklist_rel:
+            return True
+        return path.startswith(self.src_prefix) or path.startswith(self.in_prefix)
+
+
+GOVERNANCE_PATHS = GovernancePathConfig()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -197,6 +197,43 @@ def test_cli_docflow_audit() -> None:
 
 
 # gabion:evidence E:call_footprint::tests/test_cli_commands.py::test_cli_dataflow_audit_requires_paths::cli.py::gabion.cli.app
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_commands.py::test_cli_sppf_graph_and_status_consistency::cli.py::gabion.cli.app
+def test_cli_sppf_graph_and_status_consistency(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    graph_json = tmp_path / "graph.json"
+    status_json = tmp_path / "status.json"
+
+    runner = CliRunner()
+    graph_result = _invoke(
+        runner,
+        [
+            "sppf-graph",
+            "--root",
+            str(repo_root),
+            "--json-output",
+            str(graph_json),
+        ],
+    )
+    assert graph_result.exit_code == 0
+    assert graph_json.exists()
+
+    status_result = _invoke(
+        runner,
+        [
+            "status-consistency",
+            "--root",
+            str(repo_root),
+            "--json-output",
+            str(status_json),
+            "--no-fail-on-violations",
+        ],
+    )
+    assert status_result.exit_code == 0
+    assert status_json.exists()
+
+
 def test_cli_dataflow_audit_requires_paths() -> None:
     runner = CliRunner()
     result = _invoke(runner, ["dataflow-audit"])


### PR DESCRIPTION
### Motivation
- Provide governance-oriented entrypoints in the main `gabion` CLI for existing audit behaviors (docflow audit, SPPF graph, and SPPF status consistency) so `gabion <subcommand>` is the canonical invocation. 
- Ensure these subcommands emit structured JSON/Markdown artifacts in the same style and locations as existing `gabion check` outputs so CI and consumers can rely on artifact layout.
- Centralize path and checklist linkage rules so `src/`, `in/`, and SPPF checklist logic are defined in one place and reused across scripts and CLI implementations.
- Preserve legacy script entrypoints as thin wrappers to avoid immediate breakage of CI/hooks while migrating to the CLI-first flow.

### Description
- Added `src/gabion/governance_paths.py` to centralize governance path and linkage rules (helpers for `src/`, `in/`, `docs/sppf_checklist.md`, and influence index paths). 
- Introduced governance CLI loader/runner helpers in `src/gabion/cli.py` (`_load_audit_tools_module` and `_run_governance_cli`) and wired `docflow-audit` to use them; added first-class CLI subcommands `sppf-graph` and `status-consistency` that invoke repository-local audit tooling via those helpers and emit structured artifacts. 
- Updated `scripts/audit_tools.py` to consume `GOVERNANCE_PATHS`, to centralize path checks, and to add a `_status_consistency_command` that writes JSON (under `artifacts/out`) and Markdown (under `artifacts/audit_reports`) outputs matching existing artifact conventions. 
- Added thin legacy wrappers that call the new CLI-driven functionality without reimplementing logic: `scripts/docflow_audit.py`, `scripts/sppf_graph.py`, and `scripts/status_consistency.py`. 
- Updated contributor docs (`README.md`, `CONTRIBUTING.md`) to recommend `gabion <subcommand>` as the canonical entrypoint and documented the legacy scripts as transition wrappers. 
- Added CLI test coverage in `tests/test_cli_commands.py` for the new `sppf-graph` and `status-consistency` subcommands. 

### Testing
- Ran targeted pytest suites for CLI helpers and commands with `PYTHONPATH=src` and relevant test selections: `python -m pytest -q -o addopts='' tests/test_cli_helpers.py tests/test_cli_commands.py::test_cli_docflow_audit tests/test_cli_commands.py::test_cli_sppf_graph_and_status_consistency`, and full relevant command tests; these passed (CLI-related tests passed locally). 
- Ran the combined `pytest` subset used for validation; observed `78 passed` for the exercised tests in this environment. 
- Verified legacy wrapper help and CLI invocations: `python scripts/docflow_audit.py --help`, `python scripts/sppf_graph.py --help`, `python scripts/status_consistency.py --help`, and `python -m gabion docflow-audit`, `python -m gabion sppf-graph`, `python -m gabion status-consistency` (these produced artifacts or help output as expected in the test environment). 
- Note: running via `mise exec` was blocked in this environment due to local trust/tooling resolution (`mise` config trust/remote resolution), but direct `PYTHONPATH=src` test runs and script invocations validated behavior and artifact emission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952a7f8dd88324a9bad7b65e460a1a)