### PR TITLE
Introduce ExecutionPlan model and route `gabion check` through planning

### DIFF
--- a/src/gabion/plan.py
+++ b/src/gabion/plan.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gabion.json_types import JSONObject
+
+
+@dataclass(frozen=True)
+class ExecutionPlanObligations:
+    preconditions: list[str] = field(default_factory=list)
+    postconditions: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ExecutionPlanPolicyMetadata:
+    deadline: dict[str, int] = field(default_factory=dict)
+    baseline_mode: str = "none"
+    docflow_mode: str = "disabled"
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    requested_operations: list[str]
+    inputs: dict[str, Any]
+    derived_artifacts: list[str] = field(default_factory=list)
+    obligations: ExecutionPlanObligations = field(default_factory=ExecutionPlanObligations)
+    policy_metadata: ExecutionPlanPolicyMetadata = field(
+        default_factory=ExecutionPlanPolicyMetadata
+    )
+
+    def as_json_dict(self) -> JSONObject:
+        payload = asdict(self)
+        return {
+            str(key): payload[key] for key in payload
+        }
+
+
+def write_execution_plan_artifact(
+    plan: ExecutionPlan,
+    *,
+    root: Path,
+    rel_path: Path = Path("artifacts/out/execution_plan.json"),
+) -> Path:
+    target = root / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(plan.as_json_dict(), indent=2, sort_keys=True) + "\n")
+    return target

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -31,6 +31,12 @@ from lsprotocol.types import (
 )
 
 from gabion.json_types import JSONObject, JSONValue
+from gabion.plan import (
+    ExecutionPlan,
+    ExecutionPlanObligations,
+    ExecutionPlanPolicyMetadata,
+    write_execution_plan_artifact,
+)
 
 from gabion.analysis import (
     AnalysisResult,
@@ -2678,6 +2684,77 @@ def _timeout_context_payload(exc: TimeoutExceeded) -> JSONObject:
     }
 
 
+def _materialize_execution_plan(payload: Mapping[str, object]) -> ExecutionPlan:
+    request_value = payload.get("execution_plan_request")
+    if isinstance(request_value, Mapping):
+        req_ops = request_value.get("requested_operations")
+        requested_operations = [str(op) for op in req_ops] if isinstance(req_ops, list) else [DATAFLOW_COMMAND]
+        inputs_value = request_value.get("inputs")
+        if isinstance(inputs_value, Mapping):
+            inputs = {str(key): inputs_value[key] for key in inputs_value}
+        else:
+            inputs = {str(key): payload[key] for key in payload if key != "execution_plan_request"}
+        artifacts_value = request_value.get("derived_artifacts")
+        derived_artifacts = (
+            [str(path) for path in artifacts_value]
+            if isinstance(artifacts_value, list)
+            else ["artifacts/out/execution_plan.json"]
+        )
+        obligations_value = request_value.get("obligations")
+        preconditions: list[str] = []
+        postconditions: list[str] = []
+        if isinstance(obligations_value, Mapping):
+            pre_raw = obligations_value.get("preconditions")
+            post_raw = obligations_value.get("postconditions")
+            if isinstance(pre_raw, list):
+                preconditions = [str(item) for item in pre_raw]
+            if isinstance(post_raw, list):
+                postconditions = [str(item) for item in post_raw]
+        policy_value = request_value.get("policy_metadata")
+        policy_deadline: dict[str, int] = {}
+        policy_baseline_mode = "none"
+        policy_docflow_mode = "disabled"
+        if isinstance(policy_value, Mapping):
+            deadline_value = policy_value.get("deadline")
+            if isinstance(deadline_value, Mapping):
+                for key, value in deadline_value.items():
+                    if isinstance(value, bool):
+                        continue
+                    if isinstance(value, int):
+                        policy_deadline[str(key)] = int(value)
+            baseline_mode = policy_value.get("baseline_mode")
+            if isinstance(baseline_mode, str):
+                policy_baseline_mode = baseline_mode
+            docflow_mode = policy_value.get("docflow_mode")
+            if isinstance(docflow_mode, str):
+                policy_docflow_mode = docflow_mode
+        return ExecutionPlan(
+            requested_operations=requested_operations,
+            inputs=inputs,
+            derived_artifacts=derived_artifacts,
+            obligations=ExecutionPlanObligations(
+                preconditions=preconditions,
+                postconditions=postconditions,
+            ),
+            policy_metadata=ExecutionPlanPolicyMetadata(
+                deadline=policy_deadline,
+                baseline_mode=policy_baseline_mode,
+                docflow_mode=policy_docflow_mode,
+            ),
+        )
+    inputs = {str(key): payload[key] for key in payload}
+    return ExecutionPlan(
+        requested_operations=[DATAFLOW_COMMAND],
+        inputs=inputs,
+        derived_artifacts=["artifacts/out/execution_plan.json"],
+        obligations=ExecutionPlanObligations(
+            preconditions=["payload accepted by server"],
+            postconditions=["command response emitted"],
+        ),
+        policy_metadata=ExecutionPlanPolicyMetadata(deadline={}, baseline_mode="none", docflow_mode="disabled"),
+    )
+
+
 def _default_execute_command_deps() -> ExecuteCommandDeps:
     return ExecuteCommandDeps(
         analyze_paths_fn=analyze_paths,
@@ -2723,6 +2800,12 @@ def _execute_command_total(
     deps: ExecuteCommandDeps | None = None,
 ) -> dict:
     execute_deps = deps or _default_execute_command_deps()
+    execution_plan = _materialize_execution_plan(payload)
+    payload = dict(execution_plan.inputs)
+    write_execution_plan_artifact(
+        execution_plan,
+        root=Path(str(payload.get("root") or ls.workspace.root_path or ".")),
+    )
     profile_enabled = _truthy_flag(payload.get("deadline_profile"))
     profile_root_value = payload.get("root") or ls.workspace.root_path or "."
     initial_root = Path(str(profile_root_value))
@@ -4162,6 +4245,7 @@ def _execute_command_total(
             else:
                 response["exit_code"] = 1 if (fail_on_violations and effective_violations) else 0
         response["analysis_state"] = "succeeded"
+        response["execution_plan"] = execution_plan.as_json_dict()
         return _normalize_dataflow_response(response)
     except TimeoutExceeded as exc:
         cleanup_now_ns = time.monotonic_ns()
@@ -4444,6 +4528,7 @@ def _execute_command_total(
                     "exit_code": 2,
                     "timeout": True,
                     "analysis_state": analysis_state,
+                    "execution_plan": execution_plan.as_json_dict(),
                     "timeout_context": timeout_payload,
                 }
             )

--- a/tests/test_cli_payloads.py
+++ b/tests/test_cli_payloads.py
@@ -411,6 +411,13 @@ def test_run_check_uses_runner_dispatch(tmp_path: Path) -> None:
     assert captured["payload"]["emit_ambiguity_state"] is False
     assert captured["payload"]["ambiguity_state"] is None
     assert captured["payload"]["write_ambiguity_baseline"] is False
+    execution_plan_request = captured["payload"].get("execution_plan_request")
+    assert isinstance(execution_plan_request, dict)
+    assert execution_plan_request["requested_operations"] == [
+        cli.DATAFLOW_COMMAND,
+        "gabion.check",
+    ]
+    assert execution_plan_request["derived_artifacts"]
     assert captured["root"] == tmp_path
 
 

--- a/tests/test_server_helpers.py
+++ b/tests/test_server_helpers.py
@@ -59,3 +59,31 @@ def test_deadline_tick_budget_allows_check_non_meter_clock() -> None:
         pass
 
     assert server._deadline_tick_budget_allows_check(_Clock()) is True
+
+
+def test_materialize_execution_plan_uses_request_payload(tmp_path: Path) -> None:
+    server = _load()
+    payload = {
+        "root": str(tmp_path),
+        "execution_plan_request": {
+            "requested_operations": ["gabion.dataflowAudit", "gabion.check"],
+            "inputs": {"root": str(tmp_path), "paths": ["."]},
+            "derived_artifacts": ["artifacts/out/execution_plan.json"],
+            "obligations": {
+                "preconditions": ["input paths resolve under root"],
+                "postconditions": ["execution plan artifact is emitted"],
+            },
+            "policy_metadata": {
+                "deadline": {"analysis_timeout_ticks": 10, "analysis_timeout_tick_ns": 1000},
+                "baseline_mode": "none",
+                "docflow_mode": "disabled",
+            },
+        },
+    }
+    plan = server._materialize_execution_plan(payload)
+    assert plan.requested_operations == ["gabion.dataflowAudit", "gabion.check"]
+    assert plan.policy_metadata.deadline["analysis_timeout_ticks"] == 10
+    artifact_path = server.write_execution_plan_artifact(plan, root=tmp_path)
+    assert artifact_path.exists()
+    contents = artifact_path.read_text()
+    assert '"requested_operations"' in contents


### PR DESCRIPTION
### Motivation

- Reify a lightweight execution planning object so the CLI can request a plan and the server can materialize and act on it instead of the CLI driving execution directly.
- Keep the CLI as a thin transport that parses args → builds a plan request → invokes the server, enabling server-side policy logic and introspection.
- Emit a JSON execution plan artifact for debugging and to make derived artifacts/obligations explicit.

### Description

- Added a central execution-plan model in `src/gabion/plan.py` with `ExecutionPlan`, `ExecutionPlanObligations`, `ExecutionPlanPolicyMetadata`, and `write_execution_plan_artifact` that writes `artifacts/out/execution_plan.json`.
- Added `ExecutionPlanRequest` and `build_check_execution_plan_request` to `src/gabion/cli.py` plus helper `_check_derived_artifacts` to construct the plan for `gabion check` and attached the plan to the dispatched payload.
- Updated `dispatch_command` to accept an `execution_plan_request` and merge inputs/deadline metadata into the transport payload so the server can materialize the plan consistently.
- Updated server-side dataflow dispatch in `src/gabion/server.py` with `_materialize_execution_plan` to turn the transport payload into an `ExecutionPlan`, to call `write_execution_plan_artifact`, and to include the `execution_plan` in both success and timeout responses for introspection.
- Added/updated tests to assert that `run_check` attaches an execution-plan payload and that server-side plan materialization and artifact writing behave as expected (`tests/test_cli_payloads.py` and `tests/test_server_helpers.py`).

### Testing

- Compiled the modified modules with `python -m py_compile src/gabion/cli.py src/gabion/server.py src/gabion/plan.py`, which succeeded.
- Ran unit tests `tests/test_cli_payloads.py tests/test_cli_helpers.py tests/test_server_helpers.py tests/test_cli_server_parity.py` with `PYTHONPATH=src python -m pytest -o addopts='' ... -q`, and all tests passed (`103 passed`).
- Verified the new test `test_materialize_execution_plan_uses_request_payload` creates the execution-plan artifact and inspects its JSON content successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952b2dc8c88324acba4a1c0372f93a)