### PR TITLE
Consolidate duplicate edge tests into parametrized cases and trim obsolescence baseline

### DIFF
--- a/baselines/test_obsolescence_baseline.json
+++ b/baselines/test_obsolescence_baseline.json
@@ -4466,7 +4466,7 @@
   "generated_by_spec_id": "d3454cce58ad58f08551264a1079d2b5b894b013a045c5aeda2f3eff302c98b6",
   "opaque_evidence_count": 0,
   "summary": {
-    "equivalent_witness": 338,
+    "equivalent_witness": 335,
     "obsolete_candidate": 139,
     "redundant_by_evidence": 224,
     "unmapped": 0
@@ -5591,10 +5591,6 @@
     {
       "class": "equivalent_witness",
       "test_id": "tests/test_dataflow_run_edges.py::test_run_synth_registry_path_invalid_json"
-    },
-    {
-      "class": "equivalent_witness",
-      "test_id": "tests/test_dataflow_run_edges.py::test_run_synth_registry_path_missing_latest"
     },
     {
       "class": "equivalent_witness",
@@ -7167,14 +7163,6 @@
     {
       "class": "equivalent_witness",
       "test_id": "tests/test_visitors_edges.py::test_alias_from_call_branches"
-    },
-    {
-      "class": "equivalent_witness",
-      "test_id": "tests/test_visitors_edges.py::test_alias_from_call_keyword_branches"
-    },
-    {
-      "class": "equivalent_witness",
-      "test_id": "tests/test_visitors_edges.py::test_alias_from_call_positional_and_kw_aliases"
     },
     {
       "class": "equivalent_witness",

--- a/tests/test_dataflow_run_edges.py
+++ b/tests/test_dataflow_run_edges.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
+import pytest
+
 def _load():
     repo_root = Path(__file__).resolve().parents[1]
     from gabion.analysis import dataflow_audit
@@ -394,140 +396,6 @@ def test_run_synth_registry_path_invalid_json(tmp_path: Path) -> None:
         ]
     )
     assert code == 0
-
-
-def test_run_seed_registry_path_invalid_json_is_ignored(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    seed_path = tmp_path / "seed.json"
-    seed_path.write_text("{invalid")
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "user_context = [\"int\"]\n"
-        f"seed_registry_path = \"{seed_path}\"\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
-
-def test_run_seed_registry_path_missing_latest_is_ignored(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "user_context = [\"int\"]\n"
-        "seed_registry_path = \"out/LATEST/fingerprint_seed.json\"\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
-
-def test_run_seed_registry_path_blank_value_is_ignored(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "user_context = [\"int\"]\n"
-        "seed_registry_path = \" \"\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
-
-def test_run_registry_seed_revision_fallback_is_applied(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "registry_seed_revision = 17\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
-
-def test_run_seed_revision_is_applied_without_fallback(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "seed_revision = 23\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
-
-# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._apply_baseline::baseline_allowlist E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_paths::config E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_dot::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._load_baseline::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_baseline_path::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_synth_registry_path::path E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._normalize_transparent_decorators::value
-def test_run_synth_registry_path_missing_latest(tmp_path: Path) -> None:
-    dataflow_audit = _load()
-    sample = tmp_path / "typed.py"
-    _write_typed_bundle_code(sample)
-    config_path = tmp_path / "gabion.toml"
-    config_path.write_text(
-        "[fingerprints]\n"
-        "user_context = [\"int\"]\n"
-        "synth_registry_path = \"out/LATEST/fingerprint_synth.json\"\n"
-    )
-    code = dataflow_audit.run(
-        [
-            str(sample),
-            "--root",
-            str(tmp_path),
-            "--config",
-            str(config_path),
-        ]
-    )
-    assert code == 0
-
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._apply_baseline::baseline_allowlist E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_paths::config E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_dot::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._load_baseline::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_baseline_path::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_synth_registry_path::path E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._normalize_transparent_decorators::value
 def test_run_synth_registry_path_valid_json(tmp_path: Path) -> None:
     dataflow_audit = _load()
@@ -651,3 +519,107 @@ def test_run_fail_on_violations_baseline_write(tmp_path: Path) -> None:
     )
     assert baseline_path.exists()
     assert code == 0
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._apply_baseline::baseline_allowlist E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_paths::config E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_dot::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._load_baseline::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_baseline_path::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_synth_registry_path::path E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._normalize_transparent_decorators::value
+@pytest.mark.parametrize(
+    "seed_registry_value",
+    [
+        pytest.param("{invalid", id="invalid_json"),
+        pytest.param("out/LATEST/fingerprint_seed.json", id="missing_latest"),
+        pytest.param(" ", id="blank"),
+    ],
+)
+def test_run_seed_registry_path_non_usable_values_are_ignored(
+    tmp_path: Path,
+    seed_registry_value: str,
+) -> None:
+    dataflow_audit = _load()
+    sample = tmp_path / "typed.py"
+    _write_typed_bundle_code(sample)
+    config_path = tmp_path / "gabion.toml"
+    if seed_registry_value == "{invalid":
+        seed_path = tmp_path / "seed.json"
+        seed_path.write_text(seed_registry_value)
+        seed_registry_value = str(seed_path)
+    config_path.write_text(
+        f"""[fingerprints]
+user_context = ["int"]
+seed_registry_path = "{seed_registry_value}"
+"""
+    )
+    code = dataflow_audit.run([
+        str(sample),
+        "--root",
+        str(tmp_path),
+        "--config",
+        str(config_path),
+    ])
+    assert code == 0
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._apply_baseline::baseline_allowlist E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_paths::config E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_dot::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._load_baseline::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_baseline_path::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_synth_registry_path::path E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._normalize_transparent_decorators::value
+@pytest.mark.parametrize(
+    "revision_setting",
+    [
+        pytest.param("registry_seed_revision = 17", id="registry_fallback"),
+        pytest.param("seed_revision = 23", id="seed_revision"),
+    ],
+)
+def test_run_seed_revision_configurations_are_applied(
+    tmp_path: Path,
+    revision_setting: str,
+) -> None:
+    dataflow_audit = _load()
+    sample = tmp_path / "typed.py"
+    _write_typed_bundle_code(sample)
+    config_path = tmp_path / "gabion.toml"
+    config_path.write_text("[fingerprints]\n" + f"{revision_setting}\n")
+    code = dataflow_audit.run([
+        str(sample),
+        "--root",
+        str(tmp_path),
+        "--config",
+        str(config_path),
+    ])
+    assert code == 0
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._apply_baseline::baseline_allowlist E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_paths::config E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_dot::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._load_baseline::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_baseline_path::path E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._resolve_synth_registry_path::path E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._normalize_transparent_decorators::value
+def test_run_synth_registry_path_missing_or_valid_configs(tmp_path: Path) -> None:
+    dataflow_audit = _load()
+    sample = tmp_path / "typed.py"
+    _write_typed_bundle_code(sample)
+
+    missing_latest_config = tmp_path / "gabion_missing.toml"
+    missing_latest_config.write_text(
+        """[fingerprints]
+user_context = ["int"]
+synth_registry_path = "out/LATEST/fingerprint_synth.json"
+"""
+    )
+    missing_code = dataflow_audit.run([
+        str(sample),
+        "--root",
+        str(tmp_path),
+        "--config",
+        str(missing_latest_config),
+    ])
+
+    synth_path = tmp_path / "synth.json"
+    synth_path.write_text('{"version": "synth@1", "min_occurrences": 2, "entries": []}')
+    valid_config = tmp_path / "gabion_valid.toml"
+    valid_config.write_text(
+        f"""[fingerprints]
+user_context = ["int"]
+synth_registry_path = "{synth_path}"
+"""
+    )
+    valid_code = dataflow_audit.run([
+        str(sample),
+        "--root",
+        str(tmp_path),
+        "--config",
+        str(valid_config),
+    ])
+
+    assert missing_code == 0
+    assert valid_code == 0
+

--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -1652,7 +1652,18 @@ def test_execute_command_ignores_invalid_tick_ns(tmp_path: Path) -> None:
 
 
 # gabion:evidence E:function_site::server.py::gabion.server.execute_command
-def test_execute_command_uses_timeout_ms(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("timeout_field", "timeout_value"),
+    [
+        ("analysis_timeout_ms", 1000),
+        ("analysis_timeout_seconds", "10"),
+    ],
+)
+def test_execute_command_accepts_duration_timeout_fields(
+    tmp_path: Path,
+    timeout_field: str,
+    timeout_value: object,
+) -> None:
     module_path = tmp_path / "sample.py"
     _write_bundle_module(module_path)
     ls = _DummyServer(str(tmp_path))
@@ -1661,58 +1672,29 @@ def test_execute_command_uses_timeout_ms(tmp_path: Path) -> None:
         {
             "root": str(tmp_path),
             "paths": [str(module_path)],
-            "analysis_timeout_ms": 1000,
+            timeout_field: timeout_value,
         },
     )
     assert result.get("exit_code") == 0
 
 
 # gabion:evidence E:function_site::server.py::gabion.server.execute_command
-def test_execute_command_invalid_timeout_ms_ignored(tmp_path: Path) -> None:
+def test_execute_command_ignores_invalid_duration_timeout_fields(
+    tmp_path: Path,
+) -> None:
     module_path = tmp_path / "sample.py"
     _write_bundle_module(module_path)
     ls = _DummyServer(str(tmp_path))
-    with pytest.raises(NeverThrown):
-        server.execute_command(
-            ls,
-            {
-                "root": str(tmp_path),
-                "paths": [str(module_path)],
-                "analysis_timeout_ms": "nope",
-            },
-        )
-
-
-# gabion:evidence E:function_site::server.py::gabion.server.execute_command
-def test_execute_command_uses_timeout_seconds(tmp_path: Path) -> None:
-    module_path = tmp_path / "sample.py"
-    _write_bundle_module(module_path)
-    ls = _DummyServer(str(tmp_path))
-    result = server.execute_command(
-        ls,
-        {
-            "root": str(tmp_path),
-            "paths": [str(module_path)],
-            "analysis_timeout_seconds": "10",
-        },
-    )
-    assert result.get("exit_code") == 0
-
-
-# gabion:evidence E:function_site::server.py::gabion.server.execute_command
-def test_execute_command_invalid_timeout_seconds_ignored(tmp_path: Path) -> None:
-    module_path = tmp_path / "sample.py"
-    _write_bundle_module(module_path)
-    ls = _DummyServer(str(tmp_path))
-    with pytest.raises(NeverThrown):
-        server.execute_command(
-            ls,
-            {
-                "root": str(tmp_path),
-                "paths": [str(module_path)],
-                "analysis_timeout_seconds": "nope",
-            },
-        )
+    for timeout_field in ("analysis_timeout_ms", "analysis_timeout_seconds"):
+        with pytest.raises(NeverThrown):
+            server.execute_command(
+                ls,
+                {
+                    "root": str(tmp_path),
+                    "paths": [str(module_path)],
+                    timeout_field: "nope",
+                },
+            )
 
 
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_paths::config,include_bundle_forest,include_coherence_witnesses,include_constant_smells,include_deadness_witnesses,include_decision_surfaces,include_exception_obligations,include_handledness_witnesses,include_invariant_propositions,include_lint_lines,include_never_invariants,include_rewrite_plans,include_unused_arg_smells,include_value_decision_surfaces,type_audit,type_audit_report E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_metrics::forest E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_structure_snapshot::forest,invariant_propositions E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_decision_snapshot::forest,project_root E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_protocol_stubs::kind E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.build_synthesis_plan::merge_overlap_threshold E:decision_surface/direct::server.py::gabion.server.execute_command::payload E:decision_surface/direct::config.py::gabion.config.decision_ignore_list::section E:decision_surface/direct::config.py::gabion.config.decision_require_tiers::section E:decision_surface/direct::config.py::gabion.config.decision_tier_map::section E:decision_surface/direct::config.py::gabion.config.exception_never_list::section E:decision_surface/direct::server.py::gabion.server._normalize_transparent_decorators::value

--- a/tests/test_visitors_edges.py
+++ b/tests/test_visitors_edges.py
@@ -246,35 +246,6 @@ def test_record_forward_skips_call_without_span() -> None:
         ctx=ast.Load(),
     )
     assert visitor._bind_sequence(mismatch_target, mismatch_rhs) is True
-
-# gabion:evidence E:call_cluster::test_visitors_edges.py::tests.test_visitors_edges._make_use_visitor
-def test_alias_from_call_keyword_branches() -> None:
-    tree, visitor, _, _ = _make_use_visitor(
-        "def f(a):\n    return a\n",
-        ["a"],
-        return_aliases={"identity": (["x"], ["x"])},
-    )
-    call = ast.parse("identity(**kwargs)").body[0].value
-    assert visitor._alias_from_call(call) is None
-    call = ast.parse("identity(extra=a)").body[0].value
-    assert visitor._alias_from_call(call) is None
-    call = ast.parse("identity(x=1)").body[0].value
-    assert visitor._alias_from_call(call) is None
-    visitor.visit(tree)
-
-# gabion:evidence E:call_cluster::test_visitors_edges.py::tests.test_visitors_edges._make_use_visitor
-def test_alias_from_call_positional_and_kw_aliases() -> None:
-    tree, visitor, _, _ = _make_use_visitor(
-        "def f(a):\n    return a\n",
-        ["a"],
-        return_aliases={"identity": (["x"], ["x"])},
-    )
-    call = ast.parse("identity(1)").body[0].value
-    assert visitor._alias_from_call(call) is None
-    call = ast.parse("identity(x=a)").body[0].value
-    assert visitor._alias_from_call(call) == ["a"]
-    visitor.visit(tree)
-
 # gabion:evidence E:call_cluster::test_visitors_edges.py::tests.test_visitors_edges._make_use_visitor
 def test_bind_return_alias_rejects_invalid_targets() -> None:
     tree, visitor, _, _ = _make_use_visitor("def f(a):\n    return a\n", ["a"])


### PR DESCRIPTION
### Motivation
- Reduce test duplication in high-density edge modules by grouping semantically equivalent variants under parametrized assertions to simplify future obsolescence classification. 
- Keep a single canonical test name per evidence surface and remove the now-redundant baseline entries that correspond to the eliminated test variants.

### Description
- Replaced duplicated timeout-field tests in `tests/test_server_execute_command_edges.py` with two canonical tests: a parametrized success case `test_execute_command_accepts_duration_timeout_fields` and an invalid-value guard `test_execute_command_ignores_invalid_duration_timeout_fields`.
- Consolidated registry/revision edge variants in `tests/test_dataflow_run_edges.py` into parametrized cases `test_run_seed_registry_path_non_usable_values_are_ignored` and `test_run_seed_revision_configurations_are_applied`, and a combined `test_run_synth_registry_path_missing_or_valid_configs` helper.
- Removed duplicate alias-call variant tests from `tests/test_visitors_edges.py` and preserved the single canonical evidence-surface coverage (`test_alias_from_call_branches`).
- Trimmed `baselines/test_obsolescence_baseline.json` by removing only the eliminated `equivalent_witness` entries and decremented `summary.equivalent_witness` accordingly; adjusted test file imports/formatting to avoid parsing issues.

### Testing
- Ran targeted pytest for the modified suites with `PYTHONPATH=src pytest -o addopts='' tests/test_server_execute_command_edges.py tests/test_dataflow_run_edges.py tests/test_visitors_edges.py` and observed all tests pass (242 passed, run time ~36s).
- During collection a duplicate-parametrization error was encountered and resolved by harmonizing the parametrized decorators prior to final test execution. 
- Attempts to run the repo-preferred `mise` tooling (`mise exec -- pytest`) and `gabion check` emit flows in this environment were blocked or exited non-zero due to toolchain/environment constraints, so the baseline edit was limited to removing only the explicitly consolidated baseline entries and counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699520743ff48324ad178ad3ce7a3ce3)