### PR TITLE
Add docflow obligation registry and compliance plan decoration

### DIFF
--- a/scripts/audit_tools.py
+++ b/scripts/audit_tools.py
@@ -25,6 +25,10 @@ from gabion.analysis.projection_normalize import normalize_spec, spec_canonical_
 from gabion.analysis.projection_spec import ProjectionOp, ProjectionSpec, spec_from_dict
 from gabion.analysis import evidence_keys
 from gabion.analysis.impact_index import build_impact_index
+from gabion.analysis.obligation_registry import (
+    evaluate_obligations,
+    summarize_obligations,
+)
 from gabion.invariants import never
 from gabion.order_contract import ordered_or_sorted
 
@@ -179,6 +183,14 @@ class DocflowAuditContext:
     revisions: dict[str, int]
     invariant_rows: list[dict[str, object]]
     invariants: list[DocflowInvariant]
+    warnings: list[str]
+    violations: list[str]
+
+
+@dataclass(frozen=True)
+class DocflowObligationResult:
+    entries: list[dict[str, JSONValue]]
+    summary: dict[str, int]
     warnings: list[str]
     violations: list[str]
 
@@ -1837,7 +1849,11 @@ def _summarize_docflow_compliance(rows: list[dict[str, object]]) -> dict[str, in
     return counts
 
 
-def _render_docflow_compliance_md(rows: list[dict[str, object]]) -> list[str]:
+def _render_docflow_compliance_md(
+    rows: list[dict[str, object]],
+    *,
+    obligations: DocflowObligationResult | None = None,
+) -> list[str]:
     summary = _summarize_docflow_compliance(rows)
     lines: list[str] = []
     lines.append("Docflow compliance report")
@@ -1845,7 +1861,29 @@ def _render_docflow_compliance_md(rows: list[dict[str, object]]) -> list[str]:
     lines.append(f"- contradicts: {summary.get('contradicts', 0)}")
     lines.append(f"- proposed: {summary.get('proposed', 0)}")
     lines.append(f"- excess: {summary.get('excess', 0)}")
+    if obligations is not None:
+        obligation_summary = obligations.summary
+        lines.append(
+            "- obligations: "
+            f"triggered={obligation_summary.get('triggered', 0)}, "
+            f"met={obligation_summary.get('met', 0)}, "
+            f"unmet_fail={obligation_summary.get('unmet_fail', 0)}, "
+            f"unmet_warn={obligation_summary.get('unmet_warn', 0)}"
+        )
     lines.append("")
+    if obligations is not None:
+        lines.append("Obligations:")
+        for entry in obligations.entries:
+            check_deadline()
+            state = "inactive"
+            if entry.get("triggered") is True:
+                state = str(entry.get("status") or "unknown")
+            lines.append(
+                "- "
+                f"{entry.get('obligation_id')}: {state} "
+                f"({entry.get('enforcement')})"
+            )
+        lines.append("")
     lines.append("Contradictions:")
     for row in rows:
         check_deadline()
@@ -1944,13 +1982,24 @@ def _emit_docflow_compliance(
     invariants: Iterable[DocflowInvariant],
     json_output: Path | None,
     md_output: Path | None,
+    obligations: DocflowObligationResult | None = None,
 ) -> None:
     compliance_rows = _docflow_compliance_rows(rows, invariants=invariants)
+    if obligations is not None:
+        compliance_rows = _decorate_compliance_rows_with_obligations(
+            compliance_rows,
+            obligations.entries,
+        )
     payload = {
         "version": 2,
         "summary": _summarize_docflow_compliance(compliance_rows),
         "rows": compliance_rows,
     }
+    if obligations is not None:
+        payload["obligations"] = {
+            "summary": obligations.summary,
+            "entries": obligations.entries,
+        }
     if json_output is not None:
         json_output.parent.mkdir(parents=True, exist_ok=True)
         json_output.write_text(
@@ -1962,7 +2011,10 @@ def _emit_docflow_compliance(
         md_output.write_text(
             _render_docflow_report_md(
                 "docflow_compliance",
-                _render_docflow_compliance_md(compliance_rows),
+                _render_docflow_compliance_md(
+                    compliance_rows,
+                    obligations=obligations,
+                ),
             )
         )
 
@@ -3148,6 +3200,122 @@ def _sppf_sync_warnings(root: Path) -> List[str]:
     return warnings
 
 
+def _doc_status_changed(paths: Iterable[str]) -> bool:
+    tracked_docs = {"docs/sppf_checklist.md", "docs/influence_index.md"}
+    for path in paths:
+        check_deadline()
+        if path in tracked_docs:
+            return True
+        if path.startswith("in/") and path.endswith(".md"):
+            return True
+    return False
+
+
+def _has_doc_status_consistency_violations(violations: Iterable[str]) -> bool:
+    for entry in violations:
+        check_deadline()
+        if "docs/sppf_checklist.md: doc status" in entry:
+            return True
+        if "missing in docs/influence_index.md" in entry:
+            return True
+    return False
+
+
+def _evaluate_docflow_obligations(
+    *,
+    root: Path,
+    violations: list[str],
+    baseline_write_emitted: bool,
+    delta_guard_checked: bool,
+) -> DocflowObligationResult:
+    rev_range = "HEAD~1..HEAD"
+    try:
+        try:
+            from scripts import sppf_sync
+        except ModuleNotFoundError:
+            import sppf_sync
+
+        rev_range = sppf_sync._default_range()
+    except Exception:
+        pass
+
+    changed = _git_diff_paths(rev_range)
+    relevant_prefixes = ("src/", "in/")
+    relevant_paths = {"docs/sppf_checklist.md"}
+    sppf_relevant_changed = any(
+        path in relevant_paths or any(path.startswith(prefix) for prefix in relevant_prefixes)
+        for path in changed
+    )
+    gh_reference_validated = True
+    if sppf_relevant_changed:
+        gh_reference_validated = False
+        try:
+            try:
+                from scripts import sppf_sync
+            except ModuleNotFoundError:
+                import sppf_sync
+            commits = sppf_sync._collect_commits(rev_range)
+            issue_ids = sppf_sync._issue_ids_from_commits(commits)
+            gh_reference_validated = bool(issue_ids)
+        except Exception:
+            gh_reference_validated = False
+
+    doc_status_changed = _doc_status_changed(changed)
+    checklist_influence_consistent = not _has_doc_status_consistency_violations(violations)
+    context: dict[str, JSONValue] = {
+        "repo_root": str(root),
+        "changed_paths": changed,
+        "sppf_relevant_paths_changed": sppf_relevant_changed,
+        "gh_reference_validated": gh_reference_validated,
+        "baseline_write_emitted": baseline_write_emitted,
+        "delta_guard_checked": delta_guard_checked,
+        "doc_status_changed": doc_status_changed,
+        "checklist_influence_consistent": checklist_influence_consistent,
+    }
+    entries = evaluate_obligations(operation="docflow_plan", context=context)
+    summary = summarize_obligations(entries)
+    obligation_warnings: list[str] = []
+    obligation_violations: list[str] = []
+    for entry in entries:
+        check_deadline()
+        if entry.get("triggered") is not True or entry.get("status") != "unmet":
+            continue
+        message = (
+            f"obligation unmet [{entry.get('obligation_id')}]: "
+            f"{entry.get('description')}"
+        )
+        if entry.get("enforcement") == "fail":
+            obligation_violations.append(message)
+        else:
+            obligation_warnings.append(message)
+    return DocflowObligationResult(
+        entries=entries,
+        summary=summary,
+        warnings=obligation_warnings,
+        violations=obligation_violations,
+    )
+
+
+def _decorate_compliance_rows_with_obligations(
+    rows: list[dict[str, object]],
+    obligations: list[dict[str, JSONValue]],
+) -> list[dict[str, object]]:
+    active_ids = [
+        str(entry.get("obligation_id") or "")
+        for entry in obligations
+        if entry.get("triggered") is True
+    ]
+    if not active_ids:
+        return rows
+    decorated: list[dict[str, object]] = []
+    for row in rows:
+        check_deadline()
+        item = dict(row)
+        item["obligations"] = list(active_ids)
+        decorated.append(item)
+    return decorated
+
+
 # --- Decision tier candidate helpers ---
 
 
@@ -3619,6 +3787,14 @@ def _docflow_command(args: argparse.Namespace) -> int:
     docs = _load_docflow_docs(root=root, extra_paths=args.extra_path)
     violations = context.violations
     warnings = context.warnings
+    obligations = _evaluate_docflow_obligations(
+        root=root,
+        violations=violations,
+        baseline_write_emitted=bool(args.baseline_write_emitted),
+        delta_guard_checked=bool(args.delta_guard_checked),
+    )
+    warnings = warnings + obligations.warnings
+    violations = violations + obligations.violations
     _emit_docflow_suite_artifacts(
         root=root,
         extra_paths=args.extra_path,
@@ -3631,6 +3807,7 @@ def _docflow_command(args: argparse.Namespace) -> int:
         invariants=context.invariants,
         json_output=args.compliance_json,
         md_output=args.compliance_md,
+        obligations=obligations,
     )
     _emit_docflow_canonicality(
         root=root,
@@ -3795,6 +3972,16 @@ def _add_docflow_args(parser: argparse.ArgumentParser) -> None:
         "--fail-on-violations",
         action="store_true",
         help="Exit non-zero if violations are detected",
+    )
+    parser.add_argument(
+        "--baseline-write-emitted",
+        action="store_true",
+        help="Declare that this run emits a baseline write (for obligation checks).",
+    )
+    parser.add_argument(
+        "--delta-guard-checked",
+        action="store_true",
+        help="Declare that delta guard checks were executed before baseline write.",
     )
     parser.add_argument(
         "--issues-json",

--- a/src/gabion/analysis/obligation_registry.py
+++ b/src/gabion/analysis/obligation_registry.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from gabion.analysis.timeout_context import check_deadline
+from gabion.json_types import JSONValue
+
+
+Context = Mapping[str, JSONValue]
+
+
+@dataclass(frozen=True)
+class ObligationRule:
+    obligation_id: str
+    operation: str
+    context: str
+    description: str
+    enforcement: str
+    when: Callable[[Context], bool]
+    met: Callable[[Context], bool]
+
+
+def _bool_flag(context: Context, key: str) -> bool:
+    value = context.get(key)
+    return value is True
+
+
+OBLIGATION_REGISTRY: tuple[ObligationRule, ...] = (
+    ObligationRule(
+        obligation_id="sppf_gh_reference_validation",
+        operation="docflow_plan",
+        context="sppf_relevant_change",
+        description=(
+            "SPPF-relevant path changes require GH-reference validation."
+        ),
+        enforcement="fail",
+        when=lambda c: _bool_flag(c, "sppf_relevant_paths_changed"),
+        met=lambda c: _bool_flag(c, "gh_reference_validated"),
+    ),
+    ObligationRule(
+        obligation_id="baseline_delta_guard",
+        operation="docflow_plan",
+        context="baseline_write",
+        description="Baseline writes require a completed delta guard check.",
+        enforcement="warn",
+        when=lambda c: _bool_flag(c, "baseline_write_emitted"),
+        met=lambda c: _bool_flag(c, "delta_guard_checked"),
+    ),
+    ObligationRule(
+        obligation_id="doc_status_consistency",
+        operation="docflow_plan",
+        context="doc_status_change",
+        description=(
+            "Doc-status changes require checklist/influence consistency validation."
+        ),
+        enforcement="fail",
+        when=lambda c: _bool_flag(c, "doc_status_changed"),
+        met=lambda c: _bool_flag(c, "checklist_influence_consistent"),
+    ),
+)
+
+
+def evaluate_obligations(*, operation: str, context: Context) -> list[dict[str, JSONValue]]:
+    entries: list[dict[str, JSONValue]] = []
+    for rule in OBLIGATION_REGISTRY:
+        check_deadline()
+        if rule.operation != operation:
+            continue
+        triggered = bool(rule.when(context))
+        satisfied = bool(rule.met(context)) if triggered else True
+        status = "met" if satisfied else "unmet"
+        entries.append(
+            {
+                "obligation_id": rule.obligation_id,
+                "operation": rule.operation,
+                "context": rule.context,
+                "description": rule.description,
+                "enforcement": rule.enforcement,
+                "triggered": triggered,
+                "status": status,
+            }
+        )
+    return entries
+
+
+def summarize_obligations(entries: list[Mapping[str, JSONValue]]) -> dict[str, int]:
+    summary = {
+        "total": 0,
+        "triggered": 0,
+        "met": 0,
+        "unmet_fail": 0,
+        "unmet_warn": 0,
+    }
+    for entry in entries:
+        check_deadline()
+        summary["total"] += 1
+        if entry.get("triggered") is not True:
+            continue
+        summary["triggered"] += 1
+        if entry.get("status") == "met":
+            summary["met"] += 1
+            continue
+        if entry.get("enforcement") == "fail":
+            summary["unmet_fail"] += 1
+        else:
+            summary["unmet_warn"] += 1
+    return summary
+

--- a/tests/test_audit_tools_obligations.py
+++ b/tests/test_audit_tools_obligations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _load_audit_tools():
+    from scripts import audit_tools
+
+    return audit_tools
+
+
+def test_emit_docflow_compliance_includes_obligations(tmp_path: Path) -> None:
+    audit_tools = _load_audit_tools()
+    json_output = tmp_path / "compliance.json"
+    md_output = tmp_path / "compliance.md"
+
+    obligations = audit_tools.DocflowObligationResult(
+        entries=[
+            {
+                "obligation_id": "sppf_gh_reference_validation",
+                "triggered": True,
+                "status": "unmet",
+                "enforcement": "fail",
+                "description": "SPPF-relevant path changes require GH-reference validation.",
+            }
+        ],
+        summary={"total": 1, "triggered": 1, "met": 0, "unmet_fail": 1, "unmet_warn": 0},
+        warnings=[],
+        violations=["obligation unmet"],
+    )
+
+    audit_tools._emit_docflow_compliance(
+        rows=[],
+        invariants=[],
+        json_output=json_output,
+        md_output=md_output,
+        obligations=obligations,
+    )
+
+    payload = json.loads(json_output.read_text(encoding="utf-8"))
+    assert payload["obligations"]["summary"]["unmet_fail"] == 1
+    assert payload["obligations"]["entries"][0]["obligation_id"] == "sppf_gh_reference_validation"
+
+    report = md_output.read_text(encoding="utf-8")
+    assert "Obligations:" in report
+    assert "sppf_gh_reference_validation: unmet (fail)" in report

--- a/tests/test_obligation_registry.py
+++ b/tests/test_obligation_registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from gabion.analysis.obligation_registry import evaluate_obligations, summarize_obligations
+
+
+def test_evaluate_obligations_marks_unmet_rules() -> None:
+    context = {
+        "sppf_relevant_paths_changed": True,
+        "gh_reference_validated": False,
+        "baseline_write_emitted": True,
+        "delta_guard_checked": False,
+        "doc_status_changed": True,
+        "checklist_influence_consistent": False,
+    }
+
+    entries = evaluate_obligations(operation="docflow_plan", context=context)
+
+    by_id = {str(entry["obligation_id"]): entry for entry in entries}
+    assert by_id["sppf_gh_reference_validation"]["status"] == "unmet"
+    assert by_id["sppf_gh_reference_validation"]["enforcement"] == "fail"
+    assert by_id["baseline_delta_guard"]["status"] == "unmet"
+    assert by_id["baseline_delta_guard"]["enforcement"] == "warn"
+    assert by_id["doc_status_consistency"]["status"] == "unmet"
+
+
+def test_summarize_obligations_counts_unmet_by_enforcement() -> None:
+    entries = evaluate_obligations(
+        operation="docflow_plan",
+        context={
+            "sppf_relevant_paths_changed": True,
+            "gh_reference_validated": True,
+            "baseline_write_emitted": True,
+            "delta_guard_checked": False,
+            "doc_status_changed": False,
+            "checklist_influence_consistent": True,
+        },
+    )
+
+    summary = summarize_obligations(entries)
+
+    assert summary == {
+        "total": 3,
+        "triggered": 2,
+        "met": 1,
+        "unmet_fail": 0,
+        "unmet_warn": 1,
+    }


### PR DESCRIPTION
### Motivation

- Provide a centralized obligation registry keyed by operation and context to capture governance obligations that must be checked during docflow synthesis and compliance reporting.
- Encode common rules around SPPF changes, baseline writes, and doc-status changes so the audit can fail-fast or warn per policy when obligations are unmet.
- Surface obligations both to humans (markdown reports) and machines (JSON) and attach active obligations to compliance plan nodes for downstream automation.

### Description

- Add a new obligation registry module `src/gabion/analysis/obligation_registry.py` that defines `ObligationRule`, a small rule table (operation/context keyed), `evaluate_obligations`, and `summarize_obligations` helpers; implemented rules: `sppf_gh_reference_validation`, `baseline_delta_guard`, and `doc_status_consistency`.
- Wire obligation evaluation into the docflow audit in `scripts/audit_tools.py` by deriving context from the git diff and existing invariant violations, exposing `_evaluate_docflow_obligations` and decorating compliance rows with active obligation IDs via `_decorate_compliance_rows_with_obligations`.
- Extend docflow compliance outputs to include an `obligations` section in JSON (`obligations.summary`, `obligations.entries`) and an "Obligations" block in the markdown report; unmet obligations are converted into warnings or violations based on rule `enforcement` (warn vs fail).
- Add CLI flags to support baseline/delta guard checks: `--baseline-write-emitted` and `--delta-guard-checked`, and call obligation evaluation from the `_docflow_command` flow so obligations influence reported warnings/violations.

### Testing

- Added unit tests `tests/test_obligation_registry.py` (registry evaluation/summary) and `tests/test_audit_tools_obligations.py` (compliance JSON/MD emission includes obligations).
- Ran the targeted pytest invocation `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_obligation_registry.py tests/test_audit_tools_obligations.py` and the tests passed: `3 passed`.
- Note: test execution in CI should include the new files and the `--baseline-write-emitted` / `--delta-guard-checked` flags may be passed as needed by audit callers to allow correct obligation evaluation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953367db608324a903cfb94250bc79)