### PR TITLE
Add typed ExecutionPlan facets and propagate them across scripts

### DIFF
--- a/src/gabion/execution_plan.py
+++ b/src/gabion/execution_plan.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BaselineFacet:
+    """Facet that captures baseline refresh delta risk state."""
+
+    risks: tuple[tuple[str, int], ...] = ()
+
+    def risk(self, key: str) -> int:
+        for name, value in self.risks:
+            if name == key:
+                return value
+        return 0
+
+
+@dataclass(frozen=True)
+class DocflowFacet:
+    """Facet that captures docflow context from analysis."""
+
+    changed_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IssueLinkFacet:
+    """Facet for SPPF linkage and checklist impact."""
+
+    issue_ids: tuple[str, ...] = ()
+    checklist_impact: tuple[tuple[str, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class DeadlineFacet:
+    """Facet for deadline/budget controls."""
+
+    timeout_seconds: int | None = None
+
+
+@dataclass
+class ExecutionPlan:
+    """Execution plan with typed facets and deterministic decoration order."""
+
+    baseline: BaselineFacet = field(default_factory=BaselineFacet)
+    docflow: DocflowFacet = field(default_factory=DocflowFacet)
+    issue_link: IssueLinkFacet = field(default_factory=IssueLinkFacet)
+    deadline: DeadlineFacet = field(default_factory=DeadlineFacet)
+    _decorations: dict[str, dict[str, Any]] = field(default_factory=dict, init=False, repr=False)
+
+    def with_baseline(self, facet: BaselineFacet) -> ExecutionPlan:
+        self.baseline = facet
+        return self
+
+    def with_docflow(self, facet: DocflowFacet) -> ExecutionPlan:
+        self.docflow = facet
+        return self
+
+    def with_issue_link(self, facet: IssueLinkFacet) -> ExecutionPlan:
+        self.issue_link = facet
+        return self
+
+    def with_deadline(self, facet: DeadlineFacet) -> ExecutionPlan:
+        self.deadline = facet
+        return self
+
+    def decorate(self, key: str, payload: dict[str, Any]) -> None:
+        self._decorations[key] = dict(payload)
+
+    def decorations(self) -> list[tuple[str, dict[str, Any]]]:
+        return [(key, self._decorations[key]) for key in sorted(self._decorations)]

--- a/tests/test_execution_plan_facets.py
+++ b/tests/test_execution_plan_facets.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from scripts import docflow_delta_emit, refresh_baselines, sppf_sync
+from gabion.execution_plan import (
+    BaselineFacet,
+    DocflowFacet,
+    ExecutionPlan,
+)
+
+
+def test_execution_plan_decorations_are_deterministic() -> None:
+    plan = ExecutionPlan()
+    plan.decorate("zeta", {"value": 1})
+    plan.decorate("alpha", {"value": 2})
+    plan.decorate("beta", {"value": 3})
+
+    assert [name for name, _ in plan.decorations()] == ["alpha", "beta", "zeta"]
+
+
+def test_docflow_facet_propagates_changed_paths(monkeypatch) -> None:
+    monkeypatch.setattr(
+        docflow_delta_emit,
+        "_changed_paths_from_git",
+        lambda: ("docs/sppf_checklist.md", "src/gabion/cli.py"),
+    )
+
+    plan = docflow_delta_emit._build_execution_plan()
+
+    assert isinstance(plan.docflow, DocflowFacet)
+    assert plan.docflow.changed_paths == ("docs/sppf_checklist.md", "src/gabion/cli.py")
+
+
+def test_issue_link_facet_tracks_checklist_impact() -> None:
+    commits = [
+        sppf_sync.CommitInfo(sha="a", subject="GH-12", body="Refs #99"),
+        sppf_sync.CommitInfo(sha="b", subject="fix", body="GH-12 and GH-33"),
+    ]
+
+    facet = sppf_sync._build_issue_link_facet(commits)
+
+    assert facet.issue_ids == ("12", "33", "99")
+    assert dict(facet.checklist_impact) == {"12": 2, "33": 1, "99": 1}
+
+
+def test_baseline_refresh_reads_delta_risk_facet() -> None:
+    payload = {
+        "summary": {
+            "opaque_evidence": {"delta": 1},
+            "counts": {"delta": {"unmapped": 4}},
+        }
+    }
+    plan = ExecutionPlan().with_baseline(
+        BaselineFacet(risks=refresh_baselines._risk_entries(obsolescence_payload=payload))
+    )
+
+    assert plan.baseline.risk("obsolescence.opaque") == 1
+    assert plan.baseline.risk("obsolescence.unmapped") == 4


### PR DESCRIPTION
### Motivation
- Introduce a typed, composable plan schema to centralize cross-cutting execution metadata (baseline risk, docflow changes, issue linkage, deadlines).
- Move modules away from ad-hoc files/strings toward publishing structured facet outputs so downstream tools can consume them deterministically.
- Allow downstream flows (docflow, SPPF linkage, baseline refresh) to make decisions from explicit facets rather than implicit side-effects.
- Keep final artifact rendering at edge-only renderers (JSON/Markdown/CLI) while enabling deterministic plan decoration and testing.

### Description
- Add `src/gabion/execution_plan.py` defining `ExecutionPlan` plus `BaselineFacet`, `DocflowFacet`, `IssueLinkFacet`, and `DeadlineFacet` dataclasses with deterministic decoration ordering via `ExecutionPlan.decorations()`.
- Update `scripts/docflow_delta_emit.py` to build a `DocflowFacet` (from git changed paths) and include the facet payload under `facets.docflow.changed_paths` in the emitted JSON artifact.
- Update `scripts/sppf_sync.py` to produce an `IssueLinkFacet` (issue ids + `checklist_impact` counts) and drive issue iteration from `ExecutionPlan.issue_link.issue_ids`.
- Refactor `scripts/refresh_baselines.py` to build/consume a `DeadlineFacet` and `BaselineFacet`, add `_risk_entries` to extract risk tuples, and make baseline guard functions accept an `ExecutionPlan` for deterministic decision logic.
- Add regression tests `tests/test_execution_plan_facets.py` to verify facet propagation and deterministic decoration order.

### Testing
- Ran `PYTHONPATH=src pytest -o addopts='' tests/test_execution_plan_facets.py tests/test_script_scope_bindings.py` and all tests passed (`5 passed`).
- Ran bytecode checks with `python -m py_compile src/gabion/execution_plan.py scripts/docflow_delta_emit.py scripts/sppf_sync.py scripts/refresh_baselines.py tests/test_execution_plan_facets.py` which succeeded.
- Attempted `mise exec` invocation but it failed in this environment due to `mise.toml` trust / tool resolution constraints, so tests were validated with local `pytest` and `PYTHONPATH=src` instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953375c97483249aed3bd15babf64b)