### PR TITLE
Add deterministic obligation trace artifact and summaries for staged dataflow runs

### DIFF
--- a/tests/test_run_dataflow_stage.py
+++ b/tests/test_run_dataflow_stage.py
@@ -37,9 +37,14 @@ def _stage_paths(paths: dict[str, Path]) -> run_dataflow_stage.StagePaths:
         timeout_progress_md_path=paths["timeout_md"],
         deadline_profile_json_path=paths["deadline_json"],
         deadline_profile_md_path=paths["deadline_md"],
+        obligation_trace_json_path=_obligation_trace_path(paths),
         resume_checkpoint_path=paths["resume"],
         baseline_path=paths["baseline"],
     )
+
+
+def _obligation_trace_path(paths: dict[str, Path]) -> Path:
+    return paths["deadline_json"].parent / "obligation_trace.json"
 
 
 def test_stage_ids_are_bounded_and_ordered() -> None:
@@ -155,6 +160,8 @@ def test_emit_stage_outputs_writes_terminal_and_stage_keys(tmp_path: Path) -> No
             analysis_state="timed_out_progress_resume",
             is_timeout_resume=True,
             metrics_line="ticks=1 checks=1 ticks_per_ns=0.1 wall_s=1.000",
+            obligation_rows=(),
+            incompleteness_markers=(),
         ),
         run_dataflow_stage.StageResult(
             stage_id="b",
@@ -162,6 +169,8 @@ def test_emit_stage_outputs_writes_terminal_and_stage_keys(tmp_path: Path) -> No
             analysis_state="done",
             is_timeout_resume=False,
             metrics_line="ticks=2 checks=2 ticks_per_ns=0.2 wall_s=2.000",
+            obligation_rows=(),
+            incompleteness_markers=(),
         ),
     ]
     run_dataflow_stage._emit_stage_outputs(output_path, results)
@@ -172,3 +181,71 @@ def test_emit_stage_outputs_writes_terminal_and_stage_keys(tmp_path: Path) -> No
     assert "terminal_stage=B" in payload
     assert "terminal_status=success" in payload
     assert "analysis_state=done" in payload
+
+
+def test_obligation_trace_payload_covers_satisfied_unsatisfied_and_policy_skip() -> None:
+    rows, markers = run_dataflow_stage._obligation_rows_from_timeout_payload(
+        stage_id="a",
+        analysis_state="timed_out_progress_resume",
+        timeout_payload={
+            "incremental_obligations": [
+                {
+                    "contract": "resume_contract",
+                    "kind": "checkpoint_present_when_resumable",
+                    "status": "SATISFIED",
+                    "detail": "checkpoint.json",
+                },
+                {
+                    "contract": "progress_report_contract",
+                    "kind": "partial_report_emitted",
+                    "status": "VIOLATION",
+                    "detail": "partial report emission on timeout",
+                },
+                {
+                    "contract": "incremental_projection_contract",
+                    "kind": "section_projection_state",
+                    "status": "OBLIGATION",
+                    "detail": "policy",
+                    "section_id": "components",
+                },
+            ]
+        },
+    )
+
+    assert markers == ()
+    assert sorted(row["status"] for row in rows) == [
+        "satisfied",
+        "skipped_by_policy",
+        "unsatisfied",
+    ]
+    trace = run_dataflow_stage._obligation_trace_payload(
+        [
+            run_dataflow_stage.StageResult(
+                stage_id="a",
+                exit_code=2,
+                analysis_state="timed_out_progress_resume",
+                is_timeout_resume=True,
+                metrics_line="ticks=n/a checks=n/a ticks_per_ns=n/a wall_s=n/a",
+                obligation_rows=rows,
+                incompleteness_markers=(),
+            )
+        ]
+    )
+    assert trace["summary"] == {
+        "total": 3,
+        "satisfied": 1,
+        "unsatisfied": 1,
+        "skipped_by_policy": 1,
+    }
+    assert trace["complete"] is False
+    assert "timeout_or_partial_run" in trace["incompleteness_markers"]
+
+
+def test_timeout_stage_with_missing_incremental_obligations_marks_incomplete() -> None:
+    rows, markers = run_dataflow_stage._obligation_rows_from_timeout_payload(
+        stage_id="a",
+        analysis_state="timed_out_progress_resume",
+        timeout_payload={"analysis_state": "timed_out_progress_resume"},
+    )
+    assert rows == ()
+    assert markers == ("missing_incremental_obligations",)


### PR DESCRIPTION
### Motivation
- Provide operators a deterministic, machine-readable trace of runtime obligations evaluated during staged dataflow runs to improve visibility and post-mortem analysis.
- Ensure partial / timeout runs still emit a useful trace with explicit incompleteness markers so downstream automation and humans can reason about resumed or truncated executions.
- Make obligation entries stable and diff-friendly by deriving compact stable identifiers so traces are deterministic across runs.

### Description
- Emit a JSON obligation trace for staged runs at `artifacts/out/obligation_trace.json` containing per-obligation fields: `id`, `stage_id`, `rule_evaluated`, `trigger_evidence`, `required_action`, `status` (normalized), `raw_status`, `contract`, `kind`, `section_id`, and `phase` (implemented in `scripts/run_dataflow_stage.py`).
- Generate stable obligation identifiers using a SHA-1 digest over a canonical materialization of (`stage_id`, `contract`, `kind`, `section_id`, `phase`) so diffs remain deterministic across runs.
- Normalize obligation statuses (`SATISFIED` -> `satisfied`, `VIOLATION` -> `unsatisfied`, `OBLIGATION` with `detail` `policy`/`stale_input` -> `skipped_by_policy`) and map obligation `kind` to a short `required_action` description for operator guidance.
- Propagate obligation rows and incompleteness markers through `StageResult` and append a concise obligation trace summary block to operator-facing markdown artifacts (`timeout_progress.md`, `deadline_profile.md`) and to the GitHub step summary to improve human visibility.
- Add handling of explicit incompleteness markers (e.g. `missing_incremental_obligations`, `cleanup_truncated`, `timeout_or_partial_run`, `terminal_non_success`) so partial/timeout flows are clearly indicated.

### Testing
- Ran the focused test module with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_run_dataflow_stage.py` and all tests in that file passed (`7 passed`).
- The new tests exercise satisfied, unsatisfied, and skipped-by-policy obligation mappings and the incomplete-timeout marker behavior (tests passed).
- No other test suites were modified for this change and CI integration points append the trace summary into the existing timeout/deadline markdown outputs for visibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995337fd51c83248c2f040372d35b8e)