### PR TITLE
Clarify validation lanes in Codex repo walkthrough

### DIFF
--- a/docs/codex_repo_walkthrough.md
+++ b/docs/codex_repo_walkthrough.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: codex_repo_walkthrough
 doc_role: process
@@ -98,10 +98,18 @@ Gabion uses layered quality gates:
 - evidence-surface checks (e.g., drift checks where configured)
 - policy/docflow checks for governance and document integrity
 
-Operational commands Codex should use (repo-local tooling):
-- `mise exec -- python -m gabion check`
-- `mise exec -- python -m pytest`
-- targeted tests for changed modules first, then broader suites as needed
+### Validation lanes (selected by change scope)
+
+- **Semantic lane** (LSP-first analysis correctness and behavior confidence):
+  - `mise exec -- python -m gabion check`
+  - `mise exec -- python -m pytest`
+- **Governance lane** (governance correctness and doc/state integrity):
+  - `mise exec -- python -m gabion docflow-audit`
+  - `mise exec -- python -m gabion status-consistency --fail-on-violations`
+
+`gabion check` is the analysis gate and does **not** execute docflow governance audits.
+
+Use one or both lanes based on change scope; micro-tasks do not always require all four commands.
 
 Key point: Gabion audits itself. The same analyzer concepts (evidence carriers,
 determinism, policy constraints, dataflow grammar discipline) are applied to


### PR DESCRIPTION
### Motivation

- Make the CI/auditing guidance in section 4 explicit about separate validation concerns so readers can select checks by change scope while keeping LSP-first and governance-correctness terminology.

### Description

- Bumped `doc_revision` from `1` to `2` and updated `docs/codex_repo_walkthrough.md` to add a new "Validation lanes (selected by change scope)" subsection.
- Introduced two lanes: a **Semantic lane** with `mise exec -- python -m gabion check` and `mise exec -- python -m pytest`, and a **Governance lane** with `mise exec -- python -m gabion docflow-audit` and `mise exec -- python -m gabion status-consistency --fail-on-violations`.
- Added a single-line clarification that `gabion check` is the analysis gate and does **not** execute docflow governance audits, and framed lane usage as selectable by change scope (not mandatory for every micro-task).

### Testing

- This is a documentation-only change so no unit or integration tests were required or modified.
- Validated the updated file contents with `sed -n '80,170p' docs/codex_repo_walkthrough.md` and `nl -ba docs/codex_repo_walkthrough.md | sed -n '1,170p'` which returned the new subsection and `doc_revision` bump.
- Confirmed the change was staged and committed locally via `git status --short` and the subsequent commit operation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b2a48d448324a7a3bc230a413a72)