### PR TITLE
docs: add governance verification step to Codex repo walkthrough

### DIFF
--- a/docs/codex_repo_walkthrough.md
+++ b/docs/codex_repo_walkthrough.md
@@ -175,13 +175,18 @@ Suggested sequence:
    - `rg -n "baseline|ratchet|waiver|drift" src docs tests`
    - `sed -n '1,260p' docs/sppf_checklist.md`
 
-5. Clean-state confirmation before proposing changes:
+5. Governance verification (required when touching docs/process/checklists/policy surfaces):
+   - `mise exec -- python -m gabion docflow-audit`
+   - `mise exec -- python -m gabion status-consistency --fail-on-violations`
+
+6. Clean-state confirmation before proposing changes:
    - `git status --short`
 
 The Codex response should include:
 - concise architecture summary,
 - one or more debt classes,
 - prioritized task stubs,
+- surfaced governance violations (if any), listed separately from semantic-analysis findings,
 - exact commands used.
 
 ## 9. Why this process works


### PR DESCRIPTION
### Motivation
- Ensure changes that touch documentation, processes, checklists, or policy surfaces trigger explicit governance verification steps so repo-native agents and contributors run mechanized checks before proposing changes.

### Description
- Inserted a new governance verification step in section 8 of `docs/codex_repo_walkthrough.md` that adds command bullets for `mise exec -- python -m gabion docflow-audit` and `mise exec -- python -m gabion status-consistency --fail-on-violations`, and updated the expected response guidance to require surfaced governance violations be listed separately from semantic-analysis findings.

### Testing
- Attempted to run `mise exec -- python -m gabion docflow-audit` and `mise exec -- python -m gabion status-consistency --fail-on-violations`, both of which failed in this environment due to `mise` toolchain resolution/network issues and the fallback interpreter not having the `gabion` module; `git status --short` indicated a clean tree and the file `docs/codex_repo_walkthrough.md` was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b2b0034483248ff55d24564c9c7b)