### PR TITLE
docs: add compact branch workflow guardrail to Codex walkthrough

### DIFF
--- a/docs/codex_repo_walkthrough.md
+++ b/docs/codex_repo_walkthrough.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: codex_repo_walkthrough
 doc_role: process
@@ -143,6 +143,11 @@ Current operating model:
 3. Open one PR per task (or small coherent bundle of tasks).
 4. Use another LLM agent to churn through integration, coverage, and merges.
 5. Repeat until class is burned down; then move to next class.
+
+Branch guardrail (compact): routine human integration is via `stage`; `next`
+and `release` are automation-only. Treat `README.md#repo_contract` and
+`CONTRIBUTING.md#contributing_contract` as the authoritative branch/workflow
+references.
 
 Task quality bar:
 - bounded scope,


### PR DESCRIPTION
### Motivation
- Add a compact guardrail to the Codex walkthrough clarifying that routine human integration is via `stage`, that `next` and `release` are automation-only, and that `README.md#repo_contract` and `CONTRIBUTING.md#contributing_contract` are the authoritative branch/workflow references.

### Description
- Updated `docs/codex_repo_walkthrough.md` (section 7) to include the branch guardrail and bumped the document front-matter `doc_revision` from `1` to `2`.

### Testing
- No automated tests were required or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b2b57aa4832492ecc1dcc6634325)