### PR TITLE
Stabilize SuiteSite IDs and tighten loop-scoped deadline attribution

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 150
+doc_revision: 151
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -202,9 +202,9 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [~] ASPF dimensional fingerprints (base/ctor carriers + soundness invariants). (in-22, GH-70) sppf{doc=partial; impl=done; doc_ref=in-22@2}
 - [~] ASPF provenance mapping to SPPF (packed-forest derivation reporting + invariants; base/ctor keys + JSON artifact + report summary). (in-22, GH-71) sppf{doc=partial; impl=done; doc_ref=in-22@2}
 - <a id="in-23-aspf-carrier-formalization"></a>[x] ASPF carrier obligations formalized (determinism, base conservation, ctor coherence, synth tail reversibility, provenance completeness, snapshot reproducibility). (in-23, GH-73; anchors: `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_provenance`, `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_synth`, `src/gabion/analysis/type_fingerprints.py::build_synth_registry_from_payload`, `tests/test_type_fingerprints.py::test_build_fingerprint_registry_deterministic_assignment`, `tests/test_type_fingerprints.py::test_synth_registry_payload_roundtrip`, `tests/test_fingerprint_warnings.py::test_fingerprint_provenance_emits_entries`, `scripts/audit_snapshot.sh`, `scripts/latest_snapshot.sh`). sppf{doc=done; impl=done; doc_ref=in-23@9}
-- [~] SuiteSite carriers + loop-scoped deadline obligations. (in-30, GH-85) sppf{doc=partial; impl=partial; doc_ref=in-30@24}
-- [~] Deadline propagation as gas (ticks-based carriers across LSP/CLI/server). (in-30, GH-87) sppf{doc=partial; impl=done; doc_ref=in-30@24}
-- [~] Structural ambiguity as CallCandidate alts (SuiteSite) with virtual AmbiguitySet. (in-30, GH-88) sppf{doc=partial; impl=done; doc_ref=in-30@24}
+- [x] SuiteSite carriers + loop-scoped deadline obligations (recursive loop attribution now outer-vs-inner precise; SuiteSite IDs stable and reused across deadline artifacts). (in-30, GH-85) sppf{doc=done; impl=done; doc_ref=in-30@26}
+- [~] Deadline propagation as gas (ticks-based carriers across LSP/CLI/server). (in-30, GH-87) sppf{doc=partial; impl=done; doc_ref=in-30@26}
+- [~] Structural ambiguity as CallCandidate alts (SuiteSite) with virtual AmbiguitySet. (in-30, GH-88) sppf{doc=partial; impl=done; doc_ref=in-30@26}
 - <a id="in-33-pattern-schema-unification"></a>[~] PatternSchema unification for dataflow bundles + execution patterns (shared schema IDs + residue reporting; execution rules still narrow). (in-33) sppf{doc=partial; impl=partial; doc_ref=in-33@1}
 - <a id="in-34-lambda-callable-sites"></a>[~] Lambda/closure callable indexing as first-class function sites (synthetic lambda identities + direct/bound lambda call resolution; conservative fallback retained). (in-34) sppf{doc=partial; impl=partial; doc_ref=in-34@1}
 - <a id="in-35-dict-key-carrier-tracking"></a>[~] Dict carrier tracking beyond literal subscript aliases (name-bound constant keys + unknown-key carrier evidence). (in-35) sppf{doc=partial; impl=done; doc_ref=in-35@1}

--- a/in/in-30.md
+++ b/in/in-30.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 25
+doc_revision: 26
 reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
 doc_id: in_30
 doc_role: in_step
@@ -166,7 +166,6 @@ and aligns the Forest/ProjectionSpec stack with Python's suite semantics.
 
 ## Non-goals
 - This step does not immediately retire `FunctionSite`; it remains a projection.
-- This step does not resolve all open semantics (outer vs inner loop propagation).
 - This step does not refactor every facet in one phase; migration is staged.
 
 ## Status
@@ -179,8 +178,7 @@ with an aggregation spec for legacy stability.
   - `src/gabion/analysis/dataflow_audit.py::_materialize_ambiguity_suite_agg_spec` and `_materialize_ambiguity_virtual_set_spec` now materialize suite-scoped ambiguity projections (`ambiguity_suite_agg`, `ambiguity_virtual_set`) for legacy-compatible reporting (SPPF: in-30 checklist row, GH-88).
   - `src/gabion/analysis/dataflow_audit.py::_materialize_suite_order_spec` plus `src/gabion/analysis/projection_registry.py` (`name="suite_order"`) provide suite-order SpecFacet materialization used by projection reports (SPPF: in-30 checklist row, GH-85).
   - `src/gabion/server.py::_analysis_timeout_total_ticks` and `gabion.analysis.timeout_context.deadline_loop_iter` wire tick-budget deadline propagation across server/analysis paths (SPPF: in-30 checklist row, GH-87).
-- **Open**
-  - `src/gabion/analysis/dataflow_audit.py::_collect_deadline_obligations` still enforces obligations through function-root traversal (`config.deadline_roots`) rather than SuiteSite-native loop obligations, so loop-local precision remains incomplete (SPPF: in-30 checklist row, GH-85).
+  - `src/gabion/analysis/dataflow_audit.py::_collect_deadline_obligations` now attributes recursive deadline obligations at loop-suite scope (outer loop remains violating when only inner loop is checked), and emits stable SuiteSite identities reused across deadline artifacts (`site.suite_id`, `site.suite_kind`) (SPPF: in-30 checklist row, GH-85; acceptance: `tests/test_dataflow_audit_edges.py::test_deadline_nested_recursion_loop_attributes_inner_only`, `...::test_deadline_suite_identity_stable_across_runs`, `...::test_deadline_obligations_emit_suite_metadata_from_forest`).
 - **Blocked/Deferred**
   - Full migration of decision-surface and never-invariant facets to SuiteSite (documented as Phases 3-4 in this step) remains staged behind current ambiguity/deadline convergence work (SPPF: in-30 checklist row, GH-85).
 
@@ -714,7 +712,6 @@ Not metaphorically — *structurally*.
 
 These are **deliberate design knobs**, not oversights:
 
-* Nested loop semantics (inner vs outer satisfaction)
 * Recursive suite satisfaction
 * Cross-suite obligation propagation
 


### PR DESCRIPTION
### Motivation
- Resolve open `in-30` semantics by making SuiteSite the primary, stable locality carrier and fixing outer-vs-inner loop attribution for deadline obligations. 
- Ensure SuiteSite identities are deterministic and reused across emitted artifacts so projections/CLI/server do not re-derive semantics (preserve LSP-first invariant). 
- Improve precision of recursive/loop deadline diagnostics so obligations attach to the correct loop suite and include stable site metadata. 

### Description
- Add deterministic SuiteSite identity generation in the Forest by attaching a canonical JSON-canonicalized SHA-derived `suite_id` to each `SuiteSite` node (`src/gabion/analysis/aspf.py::Forest._suite_site_id` and `Forest.add_suite_site`).
- Emit SuiteSite metadata (`site.suite_id`, `site.suite_kind`) with deadline obligation rows and derive those values from the interned Forest node instead of re-deriving semantics downstream (`src/gabion/analysis/dataflow_audit.py::_add_obligation`).
- Capture loop depth in loop facts and refine recursive deadline logic to attribute obligations to each loop suite (inner vs outer) and include loop-depth diagnostics while avoiding duplicate recursive+generic reports (`_DeadlineLoopFacts.depth`, loop-specific obligation pass in `_collect_deadline_obligations`).
- Add regression tests exercising nested loops, SuiteSite identity stability across runs, and consistency between emitted `site` metadata and the Forest (`tests/test_dataflow_audit_edges.py` additions and helper `_deadline_analysis`).
- Update rollout docs/checklist entries to mark `in-30`/GH-85 acceptance and reference the new tests as evidence (`in/in-30.md` and `docs/sppf_checklist.md`).

### Testing
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_dataflow_audit_edges.py` and observed all tests in that file pass (20 passed). 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_deadline_runtime.py tests/test_deadline_clock.py` and observed all selected tests pass. 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_deadline_coverage.py -k 'deadline_obligations_emit_suite_sites or include_call_resolution_requirement'` and observed the selected checks pass. 
- Note: attempted `mise exec` runs were blocked by local `mise.toml` trust / tool resolution in this environment; functional validation used direct `PYTHONPATH=src` pytest invocations which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b3b48d4883248979e8818635337c)