### PR TITLE
Improve decision-surface classification, add tier-pathway evidence, and stabilize alt evidence

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 150
+doc_revision: 151
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -181,8 +181,8 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [x] Unused-argument pass detection (non-test call sites).
 - [x] Analysis: Decorator transparency/unwrapping. (GH-9)
 - [x] Verification: Idempotency test (ensure Analysis(Refactor(Code)) == Stable). (GH-22)
-- [~] Decision surface detection + boundary elevation (tier enforcement). (in-15, GH-60) sppf{doc=partial; impl=partial; doc_ref=in-15@1}
-- [~] Decision surface hooks in grammar (`is_decision_surface`). (GH-60)
+- [~] Decision surface detection + boundary elevation (tier enforcement). (in-15, GH-60) sppf{doc=partial; impl=partial; doc_ref=in-15@2} — impl now emits explicit classification reasons + tier-pathway evidence; glossary-tier artifacts (Decision Table/Bundle docs) remain partial.
+- [~] Decision surface hooks in grammar (`is_decision_surface`). (GH-60) — branch/guard coverage now includes `if`/`while`/`assert`/`ifexp`/`match`/comprehension guards; wider grammar harmonization still partial.
 - [x] Decision surface boundary diagnostics (API surface vs internal depth). (GH-60)
 - [x] Decision surface tier enforcement via glossary metadata. (GH-60)
 - [~] Value-encoded decision surface detection (branchless / algebraic control). (in-18, GH-66) sppf{doc=partial; impl=partial; doc_ref=in-18@1}
@@ -292,8 +292,8 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [ ] Coverage smell tracking (map tests to invariants/lemmas; track unmapped tests). (GH-42)
 
 ## Decision-flow tier nodes
-- [ ] Decision Table documentation for branch-heavy modules (Tier-3 evidence). (GH-47)
-- [ ] Decision Bundle centralization for repeated guard patterns (Tier-2 evidence). (GH-48)
+- [~] Decision Table documentation for branch-heavy modules (Tier-3 evidence). (GH-47) sppf{doc=partial; impl=partial; doc_ref=in-15@2}
+- [~] Decision Bundle centralization for repeated guard patterns (Tier-2 evidence). (GH-48) sppf{doc=partial; impl=partial; doc_ref=in-15@2}
 - [ ] Decision Protocol schema enforcement for critical decision paths (Tier-1 evidence). (GH-49)
 
 ## Explicit non-goals

--- a/in/in-15.md
+++ b/in/in-15.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
 doc_id: in_15
 doc_role: inbox
@@ -192,4 +192,10 @@ Violation: parameter 'user_mode' is a tier-2 decision surface used below boundar
 
 Proposed by: internal grammar audit
 Related: in-3 (bundle propagation), in-6 (refactor constraints)
-Status: draft
+Status: partial (doc=partial; impl=partial)
+
+Impl snapshot (current branch):
+- `is_decision_surface` classification now covers repo-observed branch/guard forms (`if`, `while`, `assert`, `ifexp`, `match` subject/guard, comprehension guards).
+- Decision-surface diagnostics now render explicit classification reasons and boundary descriptors.
+- Boundary-elevation evidence now emits tier-pathway markers (`tier-2:decision-bundle-elevation` / `tier-3:decision-table-boundary`) for reporting + checklist consumers.
+- Contextvar rewrite synthesis remains pending (docs and implementation both partial).

--- a/src/gabion/analysis/aspf.py
+++ b/src/gabion/analysis/aspf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Iterable
+from typing import Iterable, cast
 
 
 NodeKey = tuple[object, ...]
@@ -118,6 +118,16 @@ def canon_param(name: str) -> str:
 def canon_paramset(params: Iterable[str]) -> tuple[str, ...]:
     cleaned = {canon_param(p) for p in params if canon_param(p)}
     return tuple(sorted(cleaned))
+
+
+def _canonicalize_evidence(evidence: dict[str, object] | None) -> dict[str, object]:
+    payload = evidence or {}
+    canonical = json.loads(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    )
+    if not isinstance(canonical, dict):
+        return {}
+    return cast(dict[str, object], canonical)
 
 
 @dataclass
@@ -264,7 +274,7 @@ class Forest:
         consume_deadline_ticks()
         normalized_kind = str(kind).strip()
         normalized_inputs = tuple(inputs)
-        normalized_evidence = evidence or {}
+        normalized_evidence = _canonicalize_evidence(evidence)
         evidence_identity = json.dumps(
             normalized_evidence,
             sort_keys=True,

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -1590,45 +1590,79 @@ def _decision_root_name(node: ast.AST) -> str | None:
     return None
 
 
+def is_decision_surface(node: ast.AST) -> bool:
+    return isinstance(
+        node,
+        (
+            ast.If,
+            ast.While,
+            ast.Assert,
+            ast.IfExp,
+            ast.Match,
+            ast.comprehension,
+        ),
+    )
+
+
+def _decision_surface_form_entries(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[tuple[str, ast.AST]]:
+    check_deadline()
+    entries: list[tuple[str, ast.AST]] = []
+    for node in ast.walk(fn):
+        check_deadline()
+        if not is_decision_surface(node):
+            continue
+        if isinstance(node, ast.If):
+            entries.append(("if", node.test))
+            continue
+        if isinstance(node, ast.While):
+            entries.append(("while", node.test))
+            continue
+        if isinstance(node, ast.Assert):
+            entries.append(("assert", node.test))
+            continue
+        if isinstance(node, ast.IfExp):
+            entries.append(("ifexp", node.test))
+            continue
+        if isinstance(node, ast.Match):
+            entries.append(("match_subject", node.subject))
+            for case in node.cases:
+                check_deadline()
+                if case.guard is not None:
+                    entries.append(("match_guard", case.guard))
+            continue
+        if isinstance(node, ast.comprehension):
+            for guard in node.ifs:
+                check_deadline()
+                entries.append(("comprehension_guard", guard))
+    return entries
+
+
+def _decision_surface_reason_map(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+    ignore_params: set[str] | None = None,
+) -> dict[str, set[str]]:
+    check_deadline()
+    params = set(_param_names(fn, ignore_params))
+    if not params:
+        return {}
+    reason_map: dict[str, set[str]] = defaultdict(set)
+    for reason, expr in _decision_surface_form_entries(fn):
+        found = _collect_param_roots(expr, params)
+        for param in found:
+            check_deadline()
+            reason_map[param].add(reason)
+    return reason_map
+
+
 def _decision_surface_params(
     fn: ast.FunctionDef | ast.AsyncFunctionDef,
     ignore_params: set[str] | None = None,
 ) -> set[str]:
     check_deadline()
-    params = set(_param_names(fn, ignore_params))
-    if not params:
-        return set()
-
-    def _mark(expr: ast.AST, out: set[str]) -> None:
-        check_deadline()
-        for node in ast.walk(expr):
-            check_deadline()
-            if isinstance(node, ast.Name) and node.id in params:
-                out.add(node.id)
-                continue
-            if isinstance(node, (ast.Attribute, ast.Subscript)):
-                root = _decision_root_name(node)
-                if root in params:
-                    out.add(root)
-
-    decision_params: set[str] = set()
-    for node in ast.walk(fn):
-        check_deadline()
-        if isinstance(node, ast.If):
-            _mark(node.test, decision_params)
-        elif isinstance(node, ast.While):
-            _mark(node.test, decision_params)
-        elif isinstance(node, ast.Assert):
-            _mark(node.test, decision_params)
-        elif isinstance(node, ast.IfExp):
-            _mark(node.test, decision_params)
-        elif isinstance(node, ast.Match):
-            _mark(node.subject, decision_params)
-            for case in node.cases:
-                check_deadline()
-                if case.guard is not None:
-                    _mark(case.guard, decision_params)
-    return decision_params
+    reason_map = _decision_surface_reason_map(fn, ignore_params)
+    return set(reason_map)
 
 
 def _mark_param_roots(expr: ast.AST, params: set[str], out: set[str]) -> None:
@@ -1734,12 +1768,53 @@ class _DecisionSurfaceSpec:
     rewrite_line: Callable[[FunctionInfo, list[str], str], str] | None = None
 
 
+def _decision_reason_summary(info: FunctionInfo, params: Iterable[str]) -> str:
+    labels: set[str] = set()
+    for param in params:
+        check_deadline()
+        labels.update(info.decision_surface_reasons.get(param, set()))
+    if not labels:
+        return "heuristic"
+    return ", ".join(
+        ordered_or_sorted(labels, source="_decision_reason_summary.labels")
+    )
+
+
+def _boundary_tier_obligation(caller_count: int) -> str:
+    if caller_count > 0:
+        return "tier-2:decision-bundle-elevation"
+    return "tier-3:decision-table-boundary"
+
+
+def _decision_surface_alt_evidence(
+    *,
+    spec: _DecisionSurfaceSpec,
+    boundary: str,
+    descriptor: str,
+    params: Iterable[str],
+    caller_count: int,
+    reason_summary: str,
+) -> JSONObject:
+    payload = dict(spec.alt_evidence(boundary, descriptor))
+    payload["classification_reason"] = reason_summary
+    payload["classification_descriptor"] = descriptor
+    payload["tier_obligation"] = _boundary_tier_obligation(caller_count)
+    payload["tier_pathway"] = "internal" if caller_count > 0 else "boundary"
+    payload["decision_params"] = ordered_or_sorted(
+        set(params),
+        source="_decision_surface_alt_evidence.params",
+    )
+    return payload
+
+
 _DIRECT_DECISION_SURFACE_SPEC = _DecisionSurfaceSpec(
     pass_id="decision_surfaces",
     alt_kind="DecisionSurface",
     surface_label="decision surface params",
     params=lambda info: info.decision_params,
-    descriptor=lambda _info, boundary: boundary,
+    descriptor=lambda info, boundary: (
+        f"{boundary}; reason={_decision_reason_summary(info, info.decision_params)}"
+    ),
     alt_evidence=lambda boundary, _descriptor: {
         "meta": boundary,
         "boundary": boundary,
@@ -1838,10 +1913,22 @@ def _analyze_decision_surface_indexed(
         descriptor = spec.descriptor(info, boundary)
         site_id = forest.add_site(info.path.name, info.qual)
         paramset_id = forest.add_paramset(params)
+        reason_summary = (
+            _decision_reason_summary(info, params)
+            if spec.pass_id == "decision_surfaces"
+            else descriptor
+        )
         forest.add_alt(
             spec.alt_kind,
             (site_id, paramset_id),
-            evidence=spec.alt_evidence(boundary, descriptor),
+            evidence=_decision_surface_alt_evidence(
+                spec=spec,
+                boundary=boundary,
+                descriptor=descriptor,
+                params=params,
+                caller_count=caller_count,
+                reason_summary=reason_summary,
+            ),
         )
         surfaces.append(
             f"{info.path.name}:{info.qual} {spec.surface_label}: "
@@ -10074,6 +10161,7 @@ class FunctionInfo:
     scope: tuple[str, ...] = ()
     lexical_scope: tuple[str, ...] = ()
     decision_params: set[str] = field(default_factory=set)
+    decision_surface_reasons: dict[str, set[str]] = field(default_factory=dict)
     value_decision_params: set[str] = field(default_factory=set)
     value_decision_reasons: set[str] = field(default_factory=set)
     positional_params: tuple[str, ...] = ()
@@ -10495,6 +10583,7 @@ def _accumulate_function_index_for_tree(
             direct_lambda_callee_by_call_span=direct_lambda_callee_by_call_span,
         )
         unused_params, unknown_key_carriers = _unused_params(use_map)
+        decision_reason_map = _decision_surface_reason_map(fn, ignore_params)
         value_params, value_reasons = _value_encoded_decision_params(fn, ignore_params)
         pos_args = [a.arg for a in (fn.args.posonlyargs + fn.args.args)]
         kwonly_args = [a.arg for a in fn.args.kwonlyargs]
@@ -10532,7 +10621,8 @@ def _accumulate_function_index_for_tree(
             class_name=class_name,
             scope=tuple(scopes),
             lexical_scope=tuple(lexical_scopes),
-            decision_params=_decision_surface_params(fn, ignore_params),
+            decision_params=set(decision_reason_map),
+            decision_surface_reasons=decision_reason_map,
             value_decision_params=value_params,
             value_decision_reasons=value_reasons,
             positional_params=tuple(pos_args),
@@ -14042,6 +14132,16 @@ def _serialize_function_info_for_resume(info: FunctionInfo) -> JSONObject:
         "scope": list(info.scope),
         "lexical_scope": list(info.lexical_scope),
         "decision_params": sorted(info.decision_params),
+        "decision_surface_reasons": {
+            param: ordered_or_sorted(
+                info.decision_surface_reasons.get(param, set()),
+                source="_serialize_function_info_for_resume.decision_surface_reasons",
+            )
+            for param in ordered_or_sorted(
+                info.decision_surface_reasons,
+                source="_serialize_function_info_for_resume.decision_surface_reason_keys",
+            )
+        },
         "value_decision_params": sorted(info.value_decision_params),
         "value_decision_reasons": sorted(info.value_decision_reasons),
         "positional_params": list(info.positional_params),
@@ -14098,6 +14198,14 @@ def _deserialize_function_info_for_resume(
     scope = str_tuple_from_sequence(payload.get("scope"))
     lexical_scope = str_tuple_from_sequence(payload.get("lexical_scope"))
     decision_params = str_set_from_sequence(payload.get("decision_params"))
+    decision_surface_reasons: dict[str, set[str]] = {}
+    for param, raw_reasons in mapping_or_empty(payload.get("decision_surface_reasons")).items():
+        check_deadline()
+        if not isinstance(param, str):
+            continue
+        reasons = str_set_from_sequence(raw_reasons)
+        if reasons:
+            decision_surface_reasons[param] = reasons
     value_decision_params = str_set_from_sequence(payload.get("value_decision_params"))
     value_decision_reasons = str_set_from_sequence(payload.get("value_decision_reasons"))
     positional_params = str_tuple_from_sequence(payload.get("positional_params"))
@@ -14131,6 +14239,7 @@ def _deserialize_function_info_for_resume(
         scope=scope,
         lexical_scope=lexical_scope,
         decision_params=decision_params,
+        decision_surface_reasons=decision_surface_reasons,
         value_decision_params=value_decision_params,
         value_decision_reasons=value_decision_reasons,
         positional_params=positional_params,
@@ -15048,6 +15157,16 @@ def build_synthesis_plan(
     by_qual = analysis_index.by_qual
     symbol_table = analysis_index.symbol_table
     class_index = analysis_index.class_index
+    _, _, transitive_callers = _build_call_graph(
+        path_list,
+        project_root=root,
+        ignore_params=audit_config.ignore_params,
+        strictness=audit_config.strictness,
+        external_filter=audit_config.external_filter,
+        transparent_decorators=audit_config.transparent_decorators,
+        parse_failure_witnesses=parse_failure_witnesses,
+        analysis_index=analysis_index,
+    )
     knob_names = _compute_knob_param_names(
         by_name=by_name,
         by_qual=by_qual,
@@ -15091,10 +15210,16 @@ def build_synthesis_plan(
     value_decision_counts: dict[tuple[str, ...], int] = defaultdict(int)
     for info in by_qual.values():
         check_deadline()
+        caller_count = len(transitive_callers.get(info.qual, set()))
         if info.decision_params:
             bundle = tuple(sorted(info.decision_params))
             decision_counts[bundle] += 1
-            bundle_evidence[frozenset(bundle)].add("decision_surface")
+            evidence = bundle_evidence[frozenset(bundle)]
+            evidence.add("decision_surface")
+            if caller_count > 0:
+                evidence.add("tier-2:decision-bundle-elevation")
+            else:
+                evidence.add("tier-3:decision-table-boundary")
         if info.value_decision_params:
             bundle = tuple(sorted(info.value_decision_params))
             value_decision_counts[bundle] += 1

--- a/tests/test_decision_surfaces.py
+++ b/tests/test_decision_surfaces.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
 
 def _load():
@@ -58,7 +59,9 @@ def test_analyze_decision_surfaces_repo(tmp_path: Path) -> None:
         transparent_decorators=None,
         forest=da.Forest(),
     )
-    assert surfaces == ["mod.py:mod.f decision surface params: b (boundary)"]
+    assert surfaces == [
+        "mod.py:mod.f decision surface params: b (boundary; reason=if)"
+    ]
     assert warnings == []
     assert any("GABION_DECISION_SURFACE" in line for line in lint_lines)
 
@@ -174,7 +177,7 @@ def test_decision_surface_internal_caller(tmp_path: Path) -> None:
         forest=da.Forest(),
     )
     assert surfaces == [
-        "mod.py:mod.f decision surface params: b (internal callers (transitive): 1)"
+        "mod.py:mod.f decision surface params: b (internal callers (transitive): 1; reason=if)"
     ]
     assert warnings == []
     assert lint_lines == []
@@ -192,7 +195,7 @@ def test_decision_surface_internal_caller(tmp_path: Path) -> None:
         config=da.AuditConfig(project_root=tmp_path),
     )
     assert analysis.context_suggestions == [
-        "Consider contextvar for mod.py:mod.f decision surface params: b (internal callers (transitive): 1)"
+        "Consider contextvar for mod.py:mod.f decision surface params: b (internal callers (transitive): 1; reason=if)"
     ]
 
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._render_component_callsite_evidence::bundle_counts E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._emit_report::bundle_sites_by_path,coherence_witnesses,constant_smells,context_suggestions,deadness_witnesses,decision_surfaces,decision_warnings,exception_obligations,fingerprint_matches,fingerprint_provenance,fingerprint_synth,fingerprint_warnings,forest,groups_by_path,handledness_witnesses,invariant_propositions,max_components,never_invariants,rewrite_plans,type_ambiguities,type_callsite_evidence,type_suggestions,unused_arg_smells,value_decision_rewrites,value_decision_surfaces E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._render_mermaid_component::component,declared_global,nodes E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._iter_dataclass_call_bundles::dataclass_registry,symbol_table E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_never_invariants::entries,include_proven_unreachable,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_coherence_witnesses::entries,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_deadness_witnesses::entries,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_exception_obligations::entries,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_handledness_witnesses::entries,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_rewrite_plans::entries,max_entries E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._summarize_fingerprint_provenance::entries,max_examples E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._bundle_projection_from_forest::file_paths E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._populate_bundle_forest::groups_by_path
@@ -268,3 +271,93 @@ def test_decision_surface_location_tier_suppresses_lint(tmp_path: Path) -> None:
     assert surfaces
     assert warnings == []
     assert not any("GABION_DECISION_SURFACE" in line for line in lint_lines)
+
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.is_decision_surface E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._decision_surface_params::fn,ignore_params
+def test_branch_heavy_module_detected_as_decision_surface(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "control.py"
+    path.write_text(
+        "def route(mode, items, payload):\n"
+        "    if mode == 'strict':\n"
+        "        return [item for item in items if payload.enabled]\n"
+        "    match mode:\n"
+        "        case 'fast' if payload.allow_fast:\n"
+        "            return payload.fast\n"
+        "        case _:\n"
+        "            return payload.slow\n"
+    )
+    surfaces, _, _ = da.analyze_decision_surfaces_repo(
+        [path],
+        project_root=tmp_path,
+        ignore_params=set(),
+        strictness="high",
+        external_filter=True,
+        transparent_decorators=None,
+        forest=da.Forest(),
+    )
+    assert surfaces == [
+        "control.py:control.route decision surface params: mode, payload (boundary; reason=comprehension_guard, if, match_guard, match_subject)"
+    ]
+
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._decision_surface_params::fn,ignore_params
+def test_non_decision_helper_not_over_classified(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "helpers.py"
+    path.write_text(
+        "def helper(value, multiplier):\n"
+        "    total = value * multiplier\n"
+        "    return total + 1\n"
+    )
+    surfaces, warnings, lint_lines = da.analyze_decision_surfaces_repo(
+        [path],
+        project_root=tmp_path,
+        ignore_params=set(),
+        strictness="high",
+        external_filter=True,
+        transparent_decorators=None,
+        forest=da.Forest(),
+    )
+    assert surfaces == []
+    assert warnings == []
+    assert lint_lines == []
+
+
+# gabion:evidence E:decision_surface/direct::aspf.py::gabion.analysis.aspf.Forest.add_alt E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.analyze_decision_surfaces_repo::forest,require_tiers
+def test_decision_surface_evidence_is_deterministic(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "stable.py"
+    path.write_text(
+        "def choose(flag, user_mode):\n"
+        "    if flag and user_mode:\n"
+        "        return 1\n"
+        "    return 0\n"
+    )
+    snapshots: list[str] = []
+    for _ in range(2):
+        forest = da.Forest()
+        da.analyze_decision_surfaces_repo(
+            [path],
+            project_root=tmp_path,
+            ignore_params=set(),
+            strictness="high",
+            external_filter=True,
+            transparent_decorators=None,
+            decision_tiers={"flag": 2, "user_mode": 3},
+            forest=forest,
+        )
+        snapshots.append(json.dumps(forest.to_json(), sort_keys=False, separators=(",", ":")))
+        decision_alts = [alt for alt in forest.to_json()["alts"] if alt.get("kind") == "DecisionSurface"]
+        assert decision_alts
+        evidence = decision_alts[0]["evidence"]
+        assert list(evidence) == [
+            "boundary",
+            "classification_descriptor",
+            "classification_reason",
+            "decision_params",
+            "meta",
+            "tier_obligation",
+            "tier_pathway",
+        ]
+    assert snapshots[0] == snapshots[1]


### PR DESCRIPTION
### Motivation

- Decision-surface detection needs fuller coverage of branch/guard forms and explicit justification so audit output can explain why a surface is decision-relevant.
- Boundary-elevation (tier) evidence must be emitted from analysis so downstream checklist/evidence consumers can rely on server-side semantics without duplicating logic in the CLI.
- ASPF alt evidence ordering must be canonical to make evidence payloads deterministic across runs.

### Description

- Added a first-class `is_decision_surface` helper and extended decision-surface extraction to cover `if`, `while`, `assert`, `ifexp`, `match` (subject + guard), and comprehension guards, and derived `_decision_surface_params` from these entries using a reason map (`_decision_surface_reason_map`). (`src/gabion/analysis/dataflow_audit.py`).
- Emit explicit classification reasons and structured alt evidence for decision surfaces by adding `classification_reason`, `classification_descriptor`, `tier_obligation`, `tier_pathway`, and `decision_params` into forest alt evidence via a helper `_decision_surface_alt_evidence` so decision surfaces carry why/how/tier metadata. (`src/gabion/analysis/dataflow_audit.py`).
- Wire boundary-elevation markers into synthesis bundle evidence so bundles inferred from decision surfaces include `tier-2:decision-bundle-elevation` or `tier-3:decision-table-boundary` as appropriate (caller-count driven). (`src/gabion/analysis/dataflow_audit.py`).
- Canonicalize ASPF alt evidence payloads before interning to stabilize evidence key ordering and serialization across runs via `_canonicalize_evidence`. (`src/gabion/analysis/aspf.py`).
- Persist decision-surface reason maps through resume serialization/deserialization so indexed analysis can re-use the classification reasons deterministically (`_serialize_function_info_for_resume` / `_deserialize_function_info_for_resume`). (`src/gabion/analysis/dataflow_audit.py`).
- Added focused tests: branch-heavy control detection, non-decision helper not over-classified, and deterministic decision-surface evidence ordering across runs, and updated existing tests to expect reason-bearing diagnostics. (`tests/test_decision_surfaces.py`).
- Updated docs/status: `in/in-15.md` and `docs/sppf_checklist.md` with doc/impl split notes and bumped `doc_revision`. (`in/in-15.md`, `docs/sppf_checklist.md`).

### Testing

- Ran unit tests for the decision-surface area with `PYTHONPATH=src python -m pytest tests/test_decision_surfaces.py -q -o addopts=''` and observed the test suite pass (12 passed).
- Ran other related suites: `PYTHONPATH=src python -m pytest tests/test_resume_codec.py -q -o addopts=''` (12 passed) and `PYTHONPATH=src python -m pytest tests/test_sppf_status_audit.py -q -o addopts=''` (9 passed).
- Performed static checks by compiling key modules with `PYTHONPATH=src python -m py_compile src/gabion/analysis/dataflow_audit.py src/gabion/analysis/aspf.py tests/test_decision_surfaces.py` which succeeded.
- Note: attempting to run tests via the repo wrapper (`mise exec -- python`) was blocked in this environment due to local `mise` trust configuration; equivalent `PYTHONPATH=src` runs were used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b3d55ce083249806b3bd8338b676)