### PR TITLE
Add explicit rewrite-plan kinds/schemas with gated emission and abstentions

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 150
+doc_revision: 151
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -267,8 +267,8 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [x] Invariant-enriched JSON output for bundles/trees. (GH-67)
 - [ ] Property-based test hooks from invariants. (GH-67)
 - [~] ASPF entropy-controlled synthesis (synth@k primes + tail mapping + versioned registry; report + JSON registry output + snapshots + loadable registry). (in-22, GH-72) sppf{doc=partial; impl=partial; doc_ref=in-22@2}
-- [~] Proof-carrying rewrite plans (rewrite plan artifacts + evidence links + report/LSP/snapshots; verification predicates executable + tested; see `docs/matrix_acceptance.md`). (in-26, GH-76) sppf{doc=partial; impl=done; doc_ref=in-26@9}
-- [ ] Rewrite plan kinds beyond BUNDLE_ALIGN (CTOR_NORMALIZE, SURFACE_CANONICALIZE, AMBIENT_REWRITE). (in-26, GH-78) sppf{doc=partial; impl=planned; doc_ref=in-26@9}
+- [~] Proof-carrying rewrite plans (rewrite plan artifacts + evidence links + report/LSP/snapshots; verification predicates executable + tested; see `docs/matrix_acceptance.md`). (in-26, GH-76) sppf{doc=partial; impl=done; doc_ref=in-26@10}
+- [x] Rewrite plan kinds beyond BUNDLE_ALIGN (CTOR_NORMALIZE, SURFACE_CANONICALIZE, AMBIENT_REWRITE) with per-kind payload schemas, gated emission + reasoned abstentions, and predicate wiring. (in-26, GH-78) sppf{doc=partial; impl=done; doc_ref=in-26@10}
 - [~] Rewrite-plan verification: exception obligation non-regression predicates. (in-27, GH-79) sppf{doc=partial; impl=done; doc_ref=in-27@7}
 
 ## LSP operational semantics

--- a/in/in-26.md
+++ b/in/in-26.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 9
+doc_revision: 10
 reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
 doc_id: in_26
 doc_role: in_step
@@ -156,6 +156,24 @@ This step makes those artifacts *operational*: it defines how the system may pro
 This is the first “write-back” step: the pipeline stops at reporting in 23–25; here we define a proof-carrying rewrite contract.
 
 Normative pointers (explicit): [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#deadness_witness](glossary.md#deadness_witness), [glossary.md#coherence_witness](glossary.md#coherence_witness), [glossary.md#rewrite_plan](glossary.md#rewrite_plan), [CONTRIBUTING.md#contributing_contract](CONTRIBUTING.md#contributing_contract), [README.md#repo_contract](README.md#repo_contract), [AGENTS.md#agent_obligations](AGENTS.md#agent_obligations), [in/in-23.md#in_in_23](in/in-23.md#in_in_23), [in/in-24.md#in_in_24](in/in-24.md#in_in_24), [in/in-25.md#in_in_25](in/in-25.md#in_in_25), [out/out-3.md#out_out_3](out/out-3.md#out_out_3).
+
+
+## 0.1 Implementation status update (GH-78)
+
+Status: **implemented** for the three additional kinds originally scoped as planned in rev9.
+
+Delivered in code:
+- explicit kinds emitted in rewrite artifacts: `CTOR_NORMALIZE`, `SURFACE_CANONICALIZE`, `AMBIENT_REWRITE`;
+- per-kind payload schema materialized as `payload_schema` with required parameters, evidence references, and verification predicates;
+- generation now gates each kind on preconditions and emits `status=ABSTAINED` plans with reasoned precondition failures when unavailable;
+- verification enforces schema obligations and rejects malformed kind payloads in addition to existing non-regression predicates;
+- server projection normalizes rewrite-plan ordering and surfaces schema-validation errors.
+
+Acceptance evidence (tests):
+- `tests/test_dataflow_decision_surfaces_module.py::test_rewrite_plan_roundtrip_and_deterministic_ordering`;
+- `tests/test_rewrite_plan_verification.py::test_rewrite_plan_precondition_abstentions_and_kind_predicates`;
+- `tests/test_rewrite_plan_verification.py::test_verify_rewrite_plan_rejects_missing_kind_payload_fields`;
+- `tests/test_server_rewrite_plan_projection.py::test_server_projection_normalizes_rewrite_plan_order_and_schema_errors`.
 
 ---
 

--- a/src/gabion/refactor/__init__.py
+++ b/src/gabion/refactor/__init__.py
@@ -6,6 +6,13 @@ from gabion.refactor.model import (
     RefactorRequest,
     TextEdit,
 )
+from gabion.refactor.rewrite_plan import (
+    RewritePlanKind,
+    attach_plan_schema,
+    normalize_rewrite_plan_order,
+    rewrite_plan_schema,
+    validate_rewrite_plan_payload,
+)
 
 __all__ = [
     "FieldSpec",
@@ -14,4 +21,9 @@ __all__ = [
     "RefactorPlan",
     "RefactorRequest",
     "TextEdit",
+    "RewritePlanKind",
+    "attach_plan_schema",
+    "normalize_rewrite_plan_order",
+    "rewrite_plan_schema",
+    "validate_rewrite_plan_payload",
 ]

--- a/src/gabion/refactor/rewrite_plan.py
+++ b/src/gabion/refactor/rewrite_plan.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from gabion.analysis.json_types import JSONObject
+from gabion.order_contract import ordered_or_sorted
+
+
+class RewritePlanKind(StrEnum):
+    BUNDLE_ALIGN = "BUNDLE_ALIGN"
+    CTOR_NORMALIZE = "CTOR_NORMALIZE"
+    SURFACE_CANONICALIZE = "SURFACE_CANONICALIZE"
+    AMBIENT_REWRITE = "AMBIENT_REWRITE"
+
+
+@dataclass(frozen=True)
+class RewritePlanSchema:
+    kind: RewritePlanKind
+    required_parameters: tuple[str, ...]
+    required_evidence_refs: tuple[str, ...]
+    required_predicates: tuple[str, ...]
+
+    def as_json(self) -> JSONObject:
+        return {
+            "kind": self.kind.value,
+            "required": {
+                "parameters": list(self.required_parameters),
+                "evidence_refs": list(self.required_evidence_refs),
+                "verification_predicates": list(self.required_predicates),
+            },
+        }
+
+
+_REWRITE_PLAN_SCHEMAS: dict[RewritePlanKind, RewritePlanSchema] = {
+    RewritePlanKind.BUNDLE_ALIGN: RewritePlanSchema(
+        kind=RewritePlanKind.BUNDLE_ALIGN,
+        required_parameters=("candidates",),
+        required_evidence_refs=("provenance_id", "coherence_id"),
+        required_predicates=("base_conservation", "ctor_coherence", "match_strata", "remainder_non_regression"),
+    ),
+    RewritePlanKind.CTOR_NORMALIZE: RewritePlanSchema(
+        kind=RewritePlanKind.CTOR_NORMALIZE,
+        required_parameters=("target_ctor_keys", "candidates"),
+        required_evidence_refs=("provenance_id", "coherence_id"),
+        required_predicates=("base_conservation", "ctor_coherence", "match_strata", "remainder_non_regression"),
+    ),
+    RewritePlanKind.SURFACE_CANONICALIZE: RewritePlanSchema(
+        kind=RewritePlanKind.SURFACE_CANONICALIZE,
+        required_parameters=("canonical_candidate", "candidates"),
+        required_evidence_refs=("provenance_id", "coherence_id"),
+        required_predicates=("base_conservation", "match_strata", "remainder_non_regression"),
+    ),
+    RewritePlanKind.AMBIENT_REWRITE: RewritePlanSchema(
+        kind=RewritePlanKind.AMBIENT_REWRITE,
+        required_parameters=("strategy", "candidates"),
+        required_evidence_refs=("provenance_id", "coherence_id"),
+        required_predicates=("base_conservation", "match_strata", "remainder_non_regression"),
+    ),
+}
+
+
+def rewrite_plan_schema(kind: str | RewritePlanKind) -> RewritePlanSchema | None:
+    try:
+        parsed = kind if isinstance(kind, RewritePlanKind) else RewritePlanKind(str(kind))
+    except ValueError:
+        return None
+    return _REWRITE_PLAN_SCHEMAS.get(parsed)
+
+
+def rewrite_plan_kind_sort_key(kind: str) -> int:
+    order = {
+        RewritePlanKind.BUNDLE_ALIGN.value: 0,
+        RewritePlanKind.CTOR_NORMALIZE.value: 1,
+        RewritePlanKind.SURFACE_CANONICALIZE.value: 2,
+        RewritePlanKind.AMBIENT_REWRITE.value: 3,
+    }
+    return order.get(str(kind), 99)
+
+
+def _missing_keys(container: object, required: tuple[str, ...]) -> list[str]:
+    if not isinstance(container, dict):
+        return list(required)
+    missing: list[str] = []
+    for key in required:
+        value = container.get(key)
+        if value in (None, "", []):
+            missing.append(key)
+    return missing
+
+
+def validate_rewrite_plan_payload(plan: JSONObject) -> list[str]:
+    rewrite = plan.get("rewrite")
+    if not isinstance(rewrite, dict):
+        return ["missing rewrite payload"]
+    kind = str(rewrite.get("kind", ""))
+    schema = rewrite_plan_schema(kind)
+    if schema is None:
+        return [f"unknown rewrite kind: {kind}"]
+
+    issues: list[str] = []
+    params = rewrite.get("parameters")
+    missing_params = _missing_keys(params, schema.required_parameters)
+    if missing_params:
+        issues.append(f"missing parameters: {', '.join(missing_params)}")
+
+    evidence = plan.get("evidence")
+    missing_evidence = _missing_keys(evidence, schema.required_evidence_refs)
+    if missing_evidence:
+        issues.append(f"missing evidence refs: {', '.join(missing_evidence)}")
+
+    verification = plan.get("verification")
+    predicates = []
+    if isinstance(verification, dict) and isinstance(verification.get("predicates"), list):
+        predicates = [
+            str(predicate.get("kind", ""))
+            for predicate in verification.get("predicates", [])
+            if isinstance(predicate, dict)
+        ]
+    for required in schema.required_predicates:
+        if required not in predicates:
+            issues.append(f"missing predicate: {required}")
+    return issues
+
+
+def normalize_rewrite_plan_order(plans: list[JSONObject]) -> list[JSONObject]:
+    return ordered_or_sorted(
+        plans,
+        source="normalize_rewrite_plan_order",
+        key=lambda entry: (
+            str(entry.get("site", {}).get("path", "")),
+            str(entry.get("site", {}).get("function", "")),
+            ",".join(entry.get("site", {}).get("bundle", []) or []),
+            rewrite_plan_kind_sort_key(str(entry.get("rewrite", {}).get("kind", ""))),
+            str(entry.get("plan_id", "")),
+        ),
+    )
+
+
+def attach_plan_schema(plan: JSONObject) -> JSONObject:
+    rewrite = plan.get("rewrite")
+    if not isinstance(rewrite, dict):
+        return plan
+    schema = rewrite_plan_schema(str(rewrite.get("kind", "")))
+    if schema is None:
+        return plan
+    out = dict(plan)
+    out["payload_schema"] = schema.as_json()
+    return out

--- a/tests/test_server_rewrite_plan_projection.py
+++ b/tests/test_server_rewrite_plan_projection.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from gabion.server import _normalize_dataflow_response
+
+
+def test_server_projection_normalizes_rewrite_plan_order_and_schema_errors() -> None:
+    response = {
+        "exit_code": 0,
+        "fingerprint_rewrite_plans": [
+            {
+                "plan_id": "rewrite:z.py:f:a:glossary-ambiguity:surface-canonicalize",
+                "site": {"path": "z.py", "function": "f", "bundle": ["a"]},
+                "rewrite": {"kind": "SURFACE_CANONICALIZE", "parameters": {"candidates": ["ctx"]}},
+                "verification": {"predicates": [{"kind": "base_conservation"}]},
+                "evidence": {"provenance_id": "p", "coherence_id": "c"},
+            },
+            {
+                "plan_id": "rewrite:a.py:f:a:glossary-ambiguity:bundle-align",
+                "site": {"path": "a.py", "function": "f", "bundle": ["a"]},
+                "rewrite": {"kind": "BUNDLE_ALIGN", "parameters": {"candidates": ["ctx"]}},
+                "verification": {
+                    "predicates": [
+                        {"kind": "base_conservation"},
+                        {"kind": "ctor_coherence"},
+                        {"kind": "match_strata"},
+                        {"kind": "remainder_non_regression"},
+                    ]
+                },
+                "evidence": {"provenance_id": "p", "coherence_id": "c"},
+            },
+        ],
+    }
+    normalized = _normalize_dataflow_response(response)
+    plans = normalized["fingerprint_rewrite_plans"]
+    assert plans[0]["site"]["path"] == "a.py"
+    assert "rewrite_plan_schema_errors" in normalized
+    assert normalized["rewrite_plan_schema_errors"][0]["plan_id"].startswith("rewrite:z.py")


### PR DESCRIPTION
### Motivation
- Provide explicit, verifiable rewrite-plan kinds beyond `BUNDLE_ALIGN` to enable safe, proof-carrying refactors (`CTOR_NORMALIZE`, `SURFACE_CANONICALIZE`, `AMBIENT_REWRITE`).
- Ensure each kind carries a minimal payload schema and that generation only emits actionable plans when preconditions hold, otherwise emit reasoned abstentions. 
- Strengthen verification so kind-specific non-regression predicates and payload-shape checks prevent malformed or unsafe proposals.

### Description
- Add `src/gabion/refactor/rewrite_plan.py` defining `RewritePlanKind`, per-kind `RewritePlanSchema`, `validate_rewrite_plan_payload`, `attach_plan_schema`, and deterministic ordering helpers. 
- Update plan generation in `src/gabion/analysis/dataflow_decision_surfaces.py` to attach `payload_schema`, gate emission of `CTOR_NORMALIZE`/`SURFACE_CANONICALIZE`/`AMBIENT_REWRITE`, and emit `status=ABSTAINED` plans with explicit `abstention` reasons when preconditions are not satisfied. 
- Extend verification in `src/gabion/analysis/dataflow_audit.py` to: short-circuit and report abstained plans, validate per-kind payload/evidence shape (filtering schema errors from predicate defaults), and preserve existing non-regression predicate checks. 
- Wire server projection in `src/gabion/server.py` to canonicalize rewrite-plan ordering via the new ordering helper and surface `rewrite_plan_schema_errors` in the normalized response payload. 
- Export the new helpers via `src/gabion/refactor/__init__.py`, add/adjust tests in `tests/test_rewrite_plan_verification.py`, `tests/test_dataflow_decision_surfaces_module.py`, and `tests/test_server_rewrite_plan_projection.py`, and update docs `docs/sppf_checklist.md` and `in/in-26.md` to record implementation status and acceptance evidence. 

### Testing
- Ran the focused pytest subset with the local interpreter: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_rewrite_plan_verification.py tests/test_dataflow_decision_surfaces_module.py tests/test_server_rewrite_plan_projection.py`, which completed successfully with all tests passing (`19 passed`).
- Initial `mise` warnings about trusting `mise.toml`/tool metadata were observed but did not affect the final local test run. 
- Tests cover roundtrip serialization, deterministic ordering, per-kind payload/schema validation, abstention behavior, and verification predicate enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b48de04883249388c614fd22fb27)