### PR TITLE
Add ambient ContextVar rewrite planning (AMBIENT_REWRITE) with conservative guards and CLI/server exposure

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 150
+doc_revision: 151
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -252,8 +252,8 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [x] Const/default-aware partial-application detection (subset merge by knobs). (GH-16)
 - [~] Contextvar/ambient context rewrite suggestions. (in-15, GH-61) sppf{doc=partial; impl=partial; doc_ref=in-15@1}
 - [x] Contextvar suggestion heuristics (internal decision surfaces). (GH-61)
-- [ ] Contextvar rewrite: synthesis emits ContextVar definitions + accessors. (GH-61)
-- [ ] Contextvar rewrite: callsite replacement for ambient access. (GH-61)
+- [~] Contextvar rewrite: synthesis emits ContextVar definitions + accessors (conservative ambient scaffold + compatibility shim). (GH-61; tests: `tests/test_refactor_engine.py::test_refactor_engine_ambient_rewrite_threaded_parameter`)
+- [~] Contextvar rewrite: callsite replacement for ambient access (safe direct-threading replacement; unsafe sites skipped with explicit reasons). (GH-61; tests: `tests/test_refactor_engine.py::test_refactor_engine_ambient_rewrite_partial_skip_unsafe`, `tests/test_refactor_engine.py::test_refactor_engine_ambient_rewrite_noop_when_no_pattern`)
 - [~] Subtree reuse detection + lemma synthesis hooks. (in-17, GH-65) sppf{doc=partial; impl=partial; doc_ref=in-17@1}
 - [x] Subtree hashing/fingerprinting for FactorizationTree reuse. (GH-65)
 - [~] Lemma suggestion output + stable naming map. (GH-65)

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -990,6 +990,7 @@ def build_refactor_payload(
     compatibility_shim: bool,
     compatibility_shim_warnings: bool,
     compatibility_shim_overloads: bool,
+    ambient_rewrite: bool,
     rationale: Optional[str],
 ) -> JSONObject:
     check_deadline()
@@ -1026,6 +1027,7 @@ def build_refactor_payload(
         "target_path": str(target_path),
         "target_functions": target_functions or [],
         "compatibility_shim": compatibility_shim_payload,
+        "ambient_rewrite": ambient_rewrite,
         "rationale": rationale,
     }
 
@@ -2792,6 +2794,7 @@ def refactor_protocol(
     compatibility_shim_overloads: bool = typer.Option(
         True, "--compat-shim-overloads/--no-compat-shim-overloads"
     ),
+    ambient_rewrite: bool = typer.Option(False, "--ambient-rewrite/--no-ambient-rewrite"),
     rationale: Optional[str] = typer.Option(None, "--rationale"),
 ) -> None:
     """Generate protocol refactor edits from a JSON payload (prototype)."""
@@ -2807,6 +2810,7 @@ def refactor_protocol(
             compatibility_shim=compatibility_shim,
             compatibility_shim_warnings=compatibility_shim_warnings,
             compatibility_shim_overloads=compatibility_shim_overloads,
+            ambient_rewrite=ambient_rewrite,
             rationale=rationale,
         )
 
@@ -2823,6 +2827,7 @@ def _run_refactor_protocol(
     compatibility_shim: bool,
     compatibility_shim_warnings: bool,
     compatibility_shim_overloads: bool,
+    ambient_rewrite: bool,
     rationale: Optional[str],
     runner: Runner = run_command,
 ) -> None:
@@ -2846,6 +2851,7 @@ def _run_refactor_protocol(
         compatibility_shim=compatibility_shim,
         compatibility_shim_warnings=compatibility_shim_warnings,
         compatibility_shim_overloads=compatibility_shim_overloads,
+        ambient_rewrite=ambient_rewrite,
         rationale=rationale,
     )
     result = dispatch_command(

--- a/src/gabion/refactor/__init__.py
+++ b/src/gabion/refactor/__init__.py
@@ -4,6 +4,7 @@ from gabion.refactor.model import (
     FieldSpec,
     RefactorPlan,
     RefactorRequest,
+    RewritePlanEntry,
     TextEdit,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "RefactorEngine",
     "RefactorPlan",
     "RefactorRequest",
+    "RewritePlanEntry",
     "TextEdit",
 ]

--- a/src/gabion/refactor/model.py
+++ b/src/gabion/refactor/model.py
@@ -45,11 +45,22 @@ class RefactorRequest:
     fields: List[FieldSpec] = field(default_factory=list)
     target_functions: List[str] = field(default_factory=list)
     compatibility_shim: bool | CompatibilityShimConfig = False
+    ambient_rewrite: bool = False
     rationale: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RewritePlanEntry:
+    kind: str
+    status: str
+    target: str
+    summary: str
+    non_rewrite_reasons: List[str] = field(default_factory=list)
 
 
 @dataclass
 class RefactorPlan:
     edits: List[TextEdit] = field(default_factory=list)
+    rewrite_plans: List[RewritePlanEntry] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)

--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -77,6 +77,7 @@ class RefactorRequest(BaseModel):
     target_path: str
     target_functions: List[str] = []
     compatibility_shim: bool | RefactorCompatibilityShimDTO = False
+    ambient_rewrite: bool = False
     rationale: Optional[str] = None
 
 
@@ -87,8 +88,17 @@ class TextEditDTO(BaseModel):
     replacement: str
 
 
+class RewritePlanEntryDTO(BaseModel):
+    kind: str
+    status: str
+    target: str
+    summary: str
+    non_rewrite_reasons: List[str] = []
+
+
 class RefactorResponse(BaseModel):
     edits: List[TextEditDTO] = []
+    rewrite_plans: List[RewritePlanEntryDTO] = []
     warnings: List[str] = []
     errors: List[str] = []
 

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -135,6 +135,7 @@ from gabion.schema import (
     RefactorProtocolResponseDTO,
     RefactorRequest,
     RefactorResponse,
+    RewritePlanEntryDTO,
     StructureDiffResponseDTO,
     StructureReuseResponseDTO,
     SynthesisPlanResponseDTO,
@@ -4733,6 +4734,7 @@ def _execute_refactor_total(ls: LanguageServer, payload: dict[str, object]) -> d
                 target_path=request.target_path,
                 target_functions=request.target_functions,
                 compatibility_shim=normalized_shim,
+                ambient_rewrite=request.ambient_rewrite,
                 rationale=request.rationale,
             )
         )
@@ -4745,8 +4747,19 @@ def _execute_refactor_total(ls: LanguageServer, payload: dict[str, object]) -> d
             )
             for edit in plan.edits
         ]
+        rewrite_plans = [
+            RewritePlanEntryDTO(
+                kind=entry.kind,
+                status=entry.status,
+                target=entry.target,
+                summary=entry.summary,
+                non_rewrite_reasons=entry.non_rewrite_reasons,
+            )
+            for entry in plan.rewrite_plans
+        ]
         response = RefactorProtocolResponseDTO(
             edits=edits,
+            rewrite_plans=rewrite_plans,
             warnings=plan.warnings,
             errors=plan.errors,
         )

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -414,6 +414,7 @@ def test_build_refactor_payload_input_payload_passthrough() -> None:
         compatibility_shim=False,
         compatibility_shim_warnings=True,
         compatibility_shim_overloads=True,
+        ambient_rewrite=False,
         rationale=None,
     ) == payload
 
@@ -430,6 +431,7 @@ def test_build_refactor_payload_requires_fields(tmp_path: Path) -> None:
             compatibility_shim=False,
             compatibility_shim_warnings=True,
             compatibility_shim_overloads=True,
+            ambient_rewrite=False,
             rationale=None,
         )
 
@@ -442,6 +444,7 @@ def test_build_refactor_payload_requires_fields(tmp_path: Path) -> None:
         compatibility_shim=False,
         compatibility_shim_warnings=True,
         compatibility_shim_overloads=True,
+        ambient_rewrite=False,
         rationale=None,
     )
     assert payload["bundle"] == ["a", "b"]
@@ -1338,6 +1341,7 @@ def test_run_refactor_protocol_accepts_object_payload(tmp_path: Path) -> None:
         compatibility_shim=False,
         compatibility_shim_warnings=True,
         compatibility_shim_overloads=True,
+        ambient_rewrite=False,
         rationale=None,
         runner=runner,
     )

--- a/tests/test_cli_payloads.py
+++ b/tests/test_cli_payloads.py
@@ -371,6 +371,7 @@ def test_refactor_protocol_payload(tmp_path: Path) -> None:
         compatibility_shim=True,
         compatibility_shim_warnings=True,
         compatibility_shim_overloads=True,
+        ambient_rewrite=False,
         rationale="use bundle",
     )
     assert payload["protocol_name"] == "Bundle"
@@ -394,6 +395,7 @@ def test_refactor_payload_infers_bundle(tmp_path: Path) -> None:
         compatibility_shim=False,
         compatibility_shim_warnings=True,
         compatibility_shim_overloads=True,
+        ambient_rewrite=False,
         rationale=None,
     )
     assert payload["bundle"] == ["a", "b"]


### PR DESCRIPTION
### Motivation
- Provide a planned refactor path for migrating threaded context parameters to ambient ContextVar accessors so ContextVar-based APIs can be introduced mechanically.
- Apply conservative rewrite rules to avoid unsafe transformations when aliasing, writes, or dynamic arg patterns prevent a provably-safe conversion.
- Surface rewrite plan metadata to users so planned edits and explicit non-rewrite reasons are inspectable via server responses and CLI output.

### Description
- Add request/plan DTOs: `RefactorRequest.ambient_rewrite`, `RewritePlanEntry`, and `RefactorPlan.rewrite_plans` to carry structured `AMBIENT_REWRITE` entries (kind, status, target, summary, non_rewrite_reasons).
- Implement an ambient rewrite path in `RefactorEngine.plan_protocol_extraction` that runs `_AmbientRewriteTransformer` to detect eligible threaded parameters, performs safe in-function rewrites, and collects plan entries and warnings.
- Implement conservative safety checks and rewrites in `src/gabion/refactor/engine.py`: `_AmbientSafetyVisitor` for alias/write detection, `_AmbientArgThreadingRewriter` to remove threaded args at callsites, and `_ensure_ambient_scaffolding` to insert `ContextVar` import + accessor/getter/setter scaffolding only when needed.
- Wire metadata through server/CLI/schema: add `ambient_rewrite` to payload builders and DTOs, map `RewritePlanEntry` into `RewritePlanEntryDTO` in server responses, and expose `rewrite_plans` in CLI output; update `refactor` flow to skip project-wide callsite edits when ambient rewriting is enabled.
- Add regression tests covering straightforward migration, partial migration with skipped unsafe site, no-op when no eligible pattern exists, and server/CLI exposure of `rewrite_plans`, and update `docs/sppf_checklist.md` GH-61 entries to partial with test references.

### Testing
- Attempted `mise exec -- pytest tests/test_refactor_engine.py tests/test_server_execute_command_edges.py -k "ambient_rewrite or execute_refactor_exposes_rewrite_plan_metadata"` but `mise` tool resolution was blocked in this environment; proceeded with direct pytest runs instead.
- Ran `PYTHONPATH=src pytest -o addopts='' tests/test_refactor_engine.py tests/test_server_execute_command_edges.py tests/test_cli_commands.py tests/test_cli_payloads.py tests/test_cli_helpers.py -k "ambient_rewrite or rewrite_plan_metadata or refactor_protocol_payload or build_refactor_payload"` and the selected tests passed (8 passed, others deselected).
- Ran `PYTHONPATH=src pytest -o addopts='' tests/test_server_execute_command.py tests/test_cli_server_parity.py tests/test_refactor_engine_more.py -k "refactor"` and the selected refactor-related tests passed (19 passed).
- Additional targeted runs combining the relevant suites completed successfully (all selected tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b488b4f48324bdc9206f475d159b)