### PR TITLE
Add deterministic decision-flow tier artifacts with enforcement hooks

### DIFF
--- a/docs/decision_flow_tiers.md
+++ b/docs/decision_flow_tiers.md
@@ -1,0 +1,98 @@
+---
+doc_revision: 1
+reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
+doc_id: decision_flow_tiers
+doc_role: reference
+doc_scope:
+  - repo
+  - analysis
+  - docs
+doc_authority: informative
+doc_requires:
+  - glossary.md#decision_table
+  - glossary.md#decision_bundle
+  - glossary.md#decision_protocol
+  - docs/sppf_checklist.md#sppf_checklist
+doc_reviewed_as_of:
+  glossary.md#decision_table: 1
+  glossary.md#decision_bundle: 1
+  glossary.md#decision_protocol: 1
+  docs/sppf_checklist.md#sppf_checklist: 7
+doc_review_notes:
+  glossary.md#decision_table: Reviewed glossary decision table contract.
+  glossary.md#decision_bundle: Reviewed glossary decision bundle contract.
+  glossary.md#decision_protocol: Reviewed glossary decision protocol contract.
+  docs/sppf_checklist.md#sppf_checklist: Reviewed checklist status + GH mapping for decision tiers.
+doc_sections:
+  decision_flow_tiers: 1
+doc_section_requires:
+  decision_flow_tiers:
+    - glossary.md#decision_table
+    - glossary.md#decision_bundle
+    - glossary.md#decision_protocol
+    - docs/sppf_checklist.md#sppf_checklist
+doc_section_reviews:
+  decision_flow_tiers:
+    glossary.md#decision_table:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: Decision table tier contract applied.
+    glossary.md#decision_bundle:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: Decision bundle tier contract applied.
+    glossary.md#decision_protocol:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: Decision protocol tier contract applied.
+    docs/sppf_checklist.md#sppf_checklist:
+      dep_version: 7
+      self_version_at_review: 1
+      outcome: no_change
+      note: Checklist node references aligned to GH-47/48/49.
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_owner: maintainer
+---
+
+<a id="decision_flow_tiers"></a>
+
+# Decision-flow tier artifacts
+
+This document is the decision-flow companion for GH-47/48/49 and describes the concrete artifacts emitted by snapshot/report projections.
+
+## <a id="decision-flow-tier3"></a>Tier-3 decision tables (GH-47)
+
+| Artifact field | Meaning | Analysis evidence keys | Checklist node |
+| --- | --- | --- | --- |
+| `decision_id` | Deterministic ID for one decision surface/value-encoded surface. | Derived from `E:decision_surface/<mode>::<path>::<qual>::<param>` entries in `analysis_evidence_keys`. | `docs/sppf_checklist.md#decision-flow-tier3` |
+| `mode` / `path` / `qual` / `params` | Normalized decision site payload. | `E:decision_surface/direct::...` and `E:decision_surface/value::...` | `docs/sppf_checklist.md#decision-flow-tier3` |
+| `analysis_evidence_keys` | Stable key list proving source observations. | One key per normalized parameter. | `docs/sppf_checklist.md#decision-flow-tier3` |
+
+## <a id="decision-flow-tier2"></a>Tier-2 repeated-guard bundles (GH-48)
+
+| Artifact field | Meaning | Analysis evidence keys | Checklist node |
+| --- | --- | --- | --- |
+| `bundle_id` | Deterministic ID for a repeated decision parameter bundle. | Computed from member decision IDs emitted by Tier-3 tables. | `docs/sppf_checklist.md#decision-flow-tier2` |
+| `params` / `occurrences` | Canonical bundle members + repeat count. | Back-references Tier-3 `analysis_evidence_keys` through `member_decision_ids`. | `docs/sppf_checklist.md#decision-flow-tier2` |
+| `member_decision_ids` | Sorted IDs of linked Tier-3 tables. | IDs map to `decision_tables[*].decision_id`. | `docs/sppf_checklist.md#decision-flow-tier2` |
+
+## <a id="decision-flow-tier1"></a>Tier-1 protocol enforcement hooks (GH-49)
+
+| Violation code | Contract drift detected | Triggered by | Checklist node |
+| --- | --- | --- | --- |
+| `DECISION_PROTOCOL_EMPTY_MEMBERS` | Tier-2 bundle does not point to any decision table. | Empty `member_decision_ids`. | `docs/sppf_checklist.md#decision-flow-tier1` |
+| `DECISION_PROTOCOL_MISSING_TABLE` | Tier-2 bundle references a non-existent Tier-3 table. | Missing `decision_id` in table map. | `docs/sppf_checklist.md#decision-flow-tier1` |
+| `DECISION_PROTOCOL_MISSING_EVIDENCE` | Critical decision path lacks evidence keys. | Empty `analysis_evidence_keys` on linked Tier-3 table. | `docs/sppf_checklist.md#decision-flow-tier1` |
+| `DECISION_PROTOCOL_MISSING_CHECKLIST_LINK` | Critical decision path lacks checklist linkage. | Empty `checklist_nodes` on linked Tier-3 table. | `docs/sppf_checklist.md#decision-flow-tier1` |
+
+## Determinism contract
+
+- IDs use deterministic schema hashing over normalized payloads.
+- Artifact arrays are sorted canonically by path/qual/mode/params or bundle rank.
+- Snapshot summaries include explicit counts for Tier-3 tables, Tier-2 bundles, and Tier-1 violations.

--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 150
+doc_revision: 151
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -292,9 +292,9 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [ ] Coverage smell tracking (map tests to invariants/lemmas; track unmapped tests). (GH-42)
 
 ## Decision-flow tier nodes
-- [ ] Decision Table documentation for branch-heavy modules (Tier-3 evidence). (GH-47)
-- [ ] Decision Bundle centralization for repeated guard patterns (Tier-2 evidence). (GH-48)
-- [ ] Decision Protocol schema enforcement for critical decision paths (Tier-1 evidence). (GH-49)
+- <a id="decision-flow-tier3"></a>[x] Decision Table documentation for branch-heavy modules (Tier-3 evidence; see `docs/decision_flow_tiers.md#decision-flow-tier3`). (GH-47)
+- <a id="decision-flow-tier2"></a>[x] Decision Bundle centralization for repeated guard patterns (Tier-2 evidence; see `docs/decision_flow_tiers.md#decision-flow-tier2`). (GH-48)
+- <a id="decision-flow-tier1"></a>[x] Decision Protocol schema enforcement for critical decision paths (Tier-1 evidence; see `docs/decision_flow_tiers.md#decision-flow-tier1`). (GH-49)
 
 ## Explicit non-goals
 - [x] Agda proof kernel (deferred).

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -102,6 +102,11 @@ from .timeout_context import (
 from .projection_exec import apply_spec
 from .projection_normalize import spec_hash as projection_spec_hash
 from .baseline_io import load_json
+from .decision_flow import (
+    build_decision_tables,
+    detect_repeated_guard_bundles,
+    enforce_decision_protocol_contracts,
+)
 from .resume_codec import (
     allowed_path_lookup,
     int_str_pairs_from_sequence,
@@ -13324,6 +13329,15 @@ def render_decision_snapshot(
             include_execution=True,
         )
     schema_instances, schema_residue = _pattern_schema_snapshot_entries(instances)
+    decision_tables = build_decision_tables(
+        decision_surfaces=surfaces.decision_surfaces,
+        value_decision_surfaces=surfaces.value_decision_surfaces,
+    )
+    decision_bundles = detect_repeated_guard_bundles(decision_tables)
+    decision_protocol_violations = enforce_decision_protocol_contracts(
+        decision_tables=decision_tables,
+        decision_bundles=decision_bundles,
+    )
     snapshot: JSONObject = {
         "format_version": 1,
         "root": str(project_root) if project_root is not None else None,
@@ -13331,11 +13345,17 @@ def render_decision_snapshot(
         "value_decision_surfaces": sorted(surfaces.value_decision_surfaces),
         "pattern_schema_instances": schema_instances,
         "pattern_schema_residue": schema_residue,
+        "decision_tables": decision_tables,
+        "decision_bundles": decision_bundles,
+        "decision_protocol_violations": decision_protocol_violations,
         "summary": {
             "decision_surfaces": len(surfaces.decision_surfaces),
             "value_decision_surfaces": len(surfaces.value_decision_surfaces),
             "pattern_schema_instances": len(schema_instances),
             "pattern_schema_residue": len(schema_residue),
+            "decision_tables": len(decision_tables),
+            "decision_bundles": len(decision_bundles),
+            "decision_protocol_violations": len(decision_protocol_violations),
         },
     }
     snapshot["forest"] = forest.to_json()

--- a/src/gabion/analysis/decision_flow.py
+++ b/src/gabion/analysis/decision_flow.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+import re
+
+from . import evidence_keys
+from .json_types import JSONObject
+from .pattern_schema import PatternAxis, pattern_schema_id
+from gabion.order_contract import OrderPolicy, ordered_or_sorted
+
+_DECISION_LINE_RE = re.compile(
+    r"^(?P<path>[^:]+):(?P<qual>[^ ]+) (?P<mode>value-encoded decision|decision surface) params: (?P<params>[^()]+)"
+)
+
+
+@dataclass(frozen=True)
+class DecisionSurfaceRecord:
+    path: str
+    qual: str
+    mode: str
+    params: tuple[str, ...]
+
+    @property
+    def decision_id(self) -> str:
+        kind = "value_decision" if self.mode == "value" else "direct_decision"
+        return pattern_schema_id(
+            axis=PatternAxis.DATAFLOW,
+            kind=kind,
+            signature={
+                "path": self.path,
+                "qual": self.qual,
+                "params": list(self.params),
+            },
+        )
+
+
+# dataflow-bundle: entry
+
+def parse_decision_surface_line(entry: str) -> DecisionSurfaceRecord | None:
+    match = _DECISION_LINE_RE.match(entry.strip())
+    if not match:
+        return None
+    raw_mode = match.group("mode")
+    mode = "value" if raw_mode.startswith("value-encoded") else "direct"
+    params = evidence_keys.normalize_params(match.group("params").split(","))
+    return DecisionSurfaceRecord(
+        path=match.group("path").strip(),
+        qual=match.group("qual").strip(),
+        mode=mode,
+        params=tuple(params),
+    )
+
+
+# dataflow-bundle: decision_surfaces, value_decision_surfaces
+
+def build_decision_tables(
+    *,
+    decision_surfaces: Iterable[str],
+    value_decision_surfaces: Iterable[str],
+) -> list[JSONObject]:
+    tables: list[JSONObject] = []
+    for raw in [*decision_surfaces, *value_decision_surfaces]:
+        parsed = parse_decision_surface_line(raw)
+        if parsed is None:
+            continue
+        evidence_refs = ordered_or_sorted(
+            [
+                evidence_keys.render_display(
+                    evidence_keys.make_decision_surface_key(
+                        mode=parsed.mode,
+                        path=parsed.path,
+                        qual=parsed.qual,
+                        param=param,
+                    )
+                )
+                for param in parsed.params
+            ],
+            source="decision_flow.build_decision_tables.evidence_refs",
+            policy=OrderPolicy.SORT,
+        )
+        tables.append(
+            {
+                "decision_id": parsed.decision_id,
+                "tier": 3,
+                "mode": parsed.mode,
+                "path": parsed.path,
+                "qual": parsed.qual,
+                "params": list(parsed.params),
+                "analysis_evidence_keys": evidence_refs,
+                "checklist_nodes": [
+                    "docs/sppf_checklist.md#decision-flow-tier3",
+                ],
+            }
+        )
+    return ordered_or_sorted(
+        tables,
+        source="decision_flow.build_decision_tables.tables",
+        key=lambda item: (
+            str(item.get("path", "")),
+            str(item.get("qual", "")),
+            str(item.get("mode", "")),
+            ",".join(str(v) for v in item.get("params", [])),
+            str(item.get("decision_id", "")),
+        ),
+        policy=OrderPolicy.SORT,
+    )
+
+
+def detect_repeated_guard_bundles(tables: Iterable[JSONObject]) -> list[JSONObject]:
+    grouped: dict[tuple[str, ...], list[JSONObject]] = defaultdict(list)
+    for table in tables:
+        params = evidence_keys.normalize_params(table.get("params", []))
+        if not params:
+            continue
+        grouped[tuple(params)].append(table)
+    bundles: list[JSONObject] = []
+    for params, members in grouped.items():
+        if len(members) < 2:
+            continue
+        member_ids = ordered_or_sorted(
+            [str(item.get("decision_id", "")) for item in members],
+            source="decision_flow.detect_repeated_guard_bundles.member_ids",
+            policy=OrderPolicy.SORT,
+        )
+        bundle_id = pattern_schema_id(
+            axis=PatternAxis.DATAFLOW,
+            kind="decision_bundle",
+            signature={"params": list(params), "members": member_ids},
+        )
+        bundles.append(
+            {
+                "bundle_id": bundle_id,
+                "tier": 2,
+                "params": list(params),
+                "occurrences": len(member_ids),
+                "member_decision_ids": member_ids,
+                "checklist_nodes": ["docs/sppf_checklist.md#decision-flow-tier2"],
+            }
+        )
+    return ordered_or_sorted(
+        bundles,
+        source="decision_flow.detect_repeated_guard_bundles.bundles",
+        key=lambda item: (
+            -int(item.get("occurrences", 0)),
+            ",".join(str(v) for v in item.get("params", [])),
+            str(item.get("bundle_id", "")),
+        ),
+        policy=OrderPolicy.SORT,
+    )
+
+
+def enforce_decision_protocol_contracts(
+    *,
+    decision_tables: Iterable[JSONObject],
+    decision_bundles: Iterable[JSONObject],
+) -> list[JSONObject]:
+    table_map = {str(entry.get("decision_id", "")): entry for entry in decision_tables}
+    violations: list[JSONObject] = []
+
+    for bundle in decision_bundles:
+        bundle_id = str(bundle.get("bundle_id", ""))
+        member_ids = bundle.get("member_decision_ids", [])
+        if not isinstance(member_ids, list):
+            member_ids = []
+        if not member_ids:
+            violations.append(
+                {
+                    "violation_id": f"decision_protocol:empty-members:{bundle_id}",
+                    "tier": 1,
+                    "code": "DECISION_PROTOCOL_EMPTY_MEMBERS",
+                    "message": f"Bundle {bundle_id} has no linked decision tables.",
+                    "bundle_id": bundle_id,
+                    "checklist_node": "docs/sppf_checklist.md#decision-flow-tier1",
+                }
+            )
+            continue
+        for decision_id in member_ids:
+            table = table_map.get(str(decision_id))
+            if table is None:
+                violations.append(
+                    {
+                        "violation_id": f"decision_protocol:missing-table:{bundle_id}:{decision_id}",
+                        "tier": 1,
+                        "code": "DECISION_PROTOCOL_MISSING_TABLE",
+                        "message": (
+                            f"Bundle {bundle_id} references missing decision table {decision_id}."
+                        ),
+                        "bundle_id": bundle_id,
+                        "decision_id": str(decision_id),
+                        "checklist_node": "docs/sppf_checklist.md#decision-flow-tier1",
+                    }
+                )
+                continue
+            evidence_keys_list = table.get("analysis_evidence_keys", [])
+            checklist_nodes = table.get("checklist_nodes", [])
+            if not evidence_keys_list:
+                violations.append(
+                    {
+                        "violation_id": f"decision_protocol:missing-evidence:{decision_id}",
+                        "tier": 1,
+                        "code": "DECISION_PROTOCOL_MISSING_EVIDENCE",
+                        "message": (
+                            f"Critical decision path {decision_id} is missing analysis evidence keys."
+                        ),
+                        "bundle_id": bundle_id,
+                        "decision_id": str(decision_id),
+                        "checklist_node": "docs/sppf_checklist.md#decision-flow-tier1",
+                    }
+                )
+            if not checklist_nodes:
+                violations.append(
+                    {
+                        "violation_id": f"decision_protocol:missing-checklist:{decision_id}",
+                        "tier": 1,
+                        "code": "DECISION_PROTOCOL_MISSING_CHECKLIST_LINK",
+                        "message": (
+                            f"Critical decision path {decision_id} is missing checklist linkage."
+                        ),
+                        "bundle_id": bundle_id,
+                        "decision_id": str(decision_id),
+                        "checklist_node": "docs/sppf_checklist.md#decision-flow-tier1",
+                    }
+                )
+
+    return ordered_or_sorted(
+        violations,
+        source="decision_flow.enforce_decision_protocol_contracts.violations",
+        key=lambda item: str(item.get("violation_id", "")),
+        policy=OrderPolicy.SORT,
+    )

--- a/tests/test_decision_flow_tiers.py
+++ b/tests/test_decision_flow_tiers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion.analysis import dataflow_audit as da
+from gabion.analysis.decision_flow import (
+    build_decision_tables,
+    detect_repeated_guard_bundles,
+    enforce_decision_protocol_contracts,
+)
+
+
+def test_tier3_decision_tables_emit_deterministic_ids_and_links() -> None:
+    tables = build_decision_tables(
+        decision_surfaces=[
+            "mod.py:mod.f decision surface params: mode, flag (internal callers (transitive): 1)",
+        ],
+        value_decision_surfaces=[
+            "mod.py:mod.g value-encoded decision params: mode, flag (min/max)",
+        ],
+    )
+    assert len(tables) == 2
+    assert all(table["tier"] == 3 for table in tables)
+    assert all(str(table["decision_id"]).startswith("dataflow:") for table in tables)
+    assert all(table["analysis_evidence_keys"] for table in tables)
+    assert all(table["checklist_nodes"] == ["docs/sppf_checklist.md#decision-flow-tier3"] for table in tables)
+
+
+def test_tier2_repeated_guard_detection_collects_bundle() -> None:
+    tables = build_decision_tables(
+        decision_surfaces=[
+            "mod.py:mod.f decision surface params: mode, flag",
+            "mod.py:mod.h decision surface params: flag, mode",
+        ],
+        value_decision_surfaces=[],
+    )
+    bundles = detect_repeated_guard_bundles(tables)
+    assert len(bundles) == 1
+    bundle = bundles[0]
+    assert bundle["tier"] == 2
+    assert bundle["params"] == ["flag", "mode"]
+    assert bundle["occurrences"] == 2
+    assert bundle["checklist_nodes"] == ["docs/sppf_checklist.md#decision-flow-tier2"]
+
+
+def test_tier1_schema_enforcement_reports_contract_drift() -> None:
+    tables = build_decision_tables(
+        decision_surfaces=[
+            "mod.py:mod.f decision surface params: mode, flag",
+            "mod.py:mod.h decision surface params: mode, flag",
+        ],
+        value_decision_surfaces=[],
+    )
+    tables[0]["analysis_evidence_keys"] = []
+    bundles = detect_repeated_guard_bundles(tables)
+    violations = enforce_decision_protocol_contracts(
+        decision_tables=tables,
+        decision_bundles=bundles,
+    )
+    assert any(v["code"] == "DECISION_PROTOCOL_MISSING_EVIDENCE" for v in violations)
+
+
+def test_end_to_end_snapshot_contains_tier3_to_tier1_artifacts() -> None:
+    forest = da.Forest()
+    site_id = forest.add_site("mod.py", "f")
+    paramset_id = forest.add_paramset(["mode", "flag"])
+    forest.add_alt("DecisionSurface", (site_id, paramset_id))
+
+    snapshot = da.render_decision_snapshot(
+        surfaces=da.DecisionSnapshotSurfaces(
+            decision_surfaces=[
+                "mod.py:mod.f decision surface params: mode, flag",
+                "mod.py:mod.h decision surface params: mode, flag",
+            ],
+            value_decision_surfaces=[
+                "mod.py:mod.g value-encoded decision params: mode, flag (min/max)",
+            ],
+        ),
+        project_root=Path("."),
+        forest=forest,
+        groups_by_path={},
+    )
+    assert snapshot["decision_tables"]
+    assert snapshot["decision_bundles"]
+    assert "decision_protocol_violations" in snapshot
+    summary = snapshot["summary"]
+    assert summary["decision_tables"] == len(snapshot["decision_tables"])
+    assert summary["decision_bundles"] == len(snapshot["decision_bundles"])


### PR DESCRIPTION
### Motivation
- Provide deterministic, auditable artifacts for decision surfaces across Tier-3 → Tier-2 → Tier-1 so branch-heavy modules can be documented and governed.
- Surface recurring guard patterns (repeated guards) as Tier-2 decision bundles so they can be reified or reviewed before merge.
- Enforce schema/linkage for critical decision paths (Tier-1) and emit explicit violations when evidence or checklist links are missing.
- Keep IDs and ordering deterministic so snapshot/report projections remain stable and traceable.

### Description
- Added `src/gabion/analysis/decision_flow.py` implementing `parse_decision_surface_line`, `build_decision_tables`, `detect_repeated_guard_bundles`, and `enforce_decision_protocol_contracts` to produce Tier-3 tables, Tier-2 bundles, and Tier-1 violations with deterministic IDs and canonical ordering.
- Wired the new decision-flow pipeline into snapshots by extending `render_decision_snapshot` to include `decision_tables`, `decision_bundles`, and `decision_protocol_violations`, and to expose summary counts for those artifacts via the snapshot `summary` object.
- Introduced documentation `docs/decision_flow_tiers.md` describing Tier-3/Tier-2/Tier-1 artifact fields, evidence-key linkage, checklist anchors and determinism guarantees, and updated `docs/sppf_checklist.md` to mark GH-47/GH-48/GH-49 done and cross-link to the new doc.
- Added tests `tests/test_decision_flow_tiers.py` covering Tier-3 table emission, Tier-2 repeated-guard detection, Tier-1 schema enforcement violations, and an end-to-end snapshot path that exposes Tier-3→Tier-2→Tier-1 artifacts; also adapted small rendering calls to produce stable evidence displays.

### Testing
- Ran the targeted test slice with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_dataflow_decision_surfaces_module.py tests/test_decision_snapshots.py tests/test_decision_flow_tiers.py` and all tests passed (`8 passed`).
- Attempts to run the canonical `mise`-driven invocation were made but were blocked in this environment by local `mise` trust/toolchain resolution and network constraints, so the tests above were executed directly to validate behavior. 
- The added unit tests in `tests/test_decision_flow_tiers.py` exercise deterministic IDs/ordering, bundle detection, protocol violation emission, and snapshot integration and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b4a71bf883248a7c1cee7f16b8f1)