### PR TITLE
Fix CI SPPF revision-range failures by enabling full git fetch in checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       # Allow-listed actions: actions/checkout, jdx/mise-action
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
       - name: Install mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
       - name: Install toolchain


### PR DESCRIPTION
### Motivation
- Prevent `git log` failing with `Invalid revision range ...` during the SPPF issue lifecycle validation when the push range `${{ github.event.before }}..${{ github.sha }}` is not present in a shallow checkout.

### Description
- Configure the pinned `actions/checkout` step in `.github/workflows/ci.yml` with `fetch-depth: 0` so the push-time `BEFORE_SHA..AFTER_SHA` range is available locally before running `scripts/sppf_sync.py --validate`.

### Testing
- Verified the change in-tree with `git diff`/`git status` and attempted `mise exec -- python scripts/policy_check.py --workflows`, which could not complete in this environment due to unresolved toolchain and missing modules (`ModuleNotFoundError: gabion`); CI validation should be exercised on GitHub where the full toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699600ffdf008324a1c44dee0714905c)