### PR TITLE
ci: fetch full history in checks checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
       # Allow-listed actions: actions/checkout, jdx/mise-action
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
       - name: Install mise
         uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
       - name: Install toolchain


### PR DESCRIPTION
### Motivation
- Ensure the `checks` job has full git history available before computing `rev_range="$BEFORE_SHA..$AFTER_SHA"` by making the checkout fetch the full history.

### Description
- Add `with:` / `fetch-depth: 0` to the pinned `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` in `.github/workflows/ci.yml` under `jobs.checks.steps` while keeping the existing pinned SHA unchanged.

### Testing
- Reviewed the workflow diff with `git diff -- .github/workflows/ci.yml` which shows only the `with: fetch-depth: 0` addition, and attempted to run `mise exec -- python scripts/policy_check.py --workflows` which failed due to untrusted/missing `mise` configuration and unresolved local package context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699603060d5c83249eed736edaec5aca)