### PR TITLE
Harden SPPF push range resolution in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,16 @@ jobs:
           if [ -z "${BEFORE_SHA:-}" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             rev_range="HEAD~20..HEAD"
           else
-            rev_range="$BEFORE_SHA..$AFTER_SHA"
+            if ! git cat-file -e "${AFTER_SHA}^{commit}" 2>/dev/null || ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "$BEFORE_SHA" "$AFTER_SHA" || true
+            fi
+
+            if git cat-file -e "${AFTER_SHA}^{commit}" 2>/dev/null && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+              rev_range="$BEFORE_SHA..$AFTER_SHA"
+            else
+              echo "Push SHAs unavailable locally; falling back to safe local range."
+              rev_range="HEAD~20..HEAD"
+            fi
           fi
           .venv/bin/python scripts/sppf_sync.py \
             --validate \


### PR DESCRIPTION
### Motivation
- Prevent `git log`/range consumers from hard-failing when the push `before`/`after` SHAs are not present in the checked-out history (e.g. non-fast-forward updates or unreachable commits). 
- Keep the `SPPF issue lifecycle validation (non-mutating)` step non-mutating while making it resilient to missing remote SHAs. 
- Preserve the existing all-zero/empty `BEFORE_SHA` guard for initial/zero-before pushes.

### Description
- Updated the `SPPF issue lifecycle validation (non-mutating)` step in `.github/workflows/ci.yml` to validate commit existence before building the push range. 
- Added `git cat-file -e "${AFTER_SHA}^{commit}"` and `git cat-file -e "${BEFORE_SHA}^{commit}"` checks and an opportunistic targeted fetch `git fetch --no-tags origin "$BEFORE_SHA" "$AFTER_SHA" || true` when either commit is missing. 
- Use the push-derived range `"$BEFORE_SHA..$AFTER_SHA"` only when both commits are confirmed present, otherwise fall back to the safe local range `HEAD~20..HEAD`.

### Testing
- Ran `git diff --check` locally and it completed with no issues (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996030b0bac8324832fe0442bbea3cb)