### PR TITLE
Add unified ETA estimation for collection and phase progress

### DIFF
--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -2283,6 +2283,12 @@ def test_latest_report_phase_and_truthy_flag_edges() -> None:
     assert server._latest_report_phase(None) is None
     assert server._latest_report_phase({"post": {}, "forest": {}}) == "post"
     assert server._latest_report_phase({1: {}, "invalid": {}}) is None
+    assert server._latest_report_phase_without_deadline(None) is None
+    assert (
+        server._latest_report_phase_without_deadline({"edge": {}, "forest": {}})
+        == "edge"
+    )
+    assert server._latest_report_phase_without_deadline({1: {}, "invalid": {}}) is None
     assert server._truthy_flag(0) is False
     assert server._truthy_flag(2) is True
     assert server._truthy_flag(0.0) is False


### PR DESCRIPTION
### Motivation

- Provide clients a single unified ETA/progress signal derived from collection checkpoint state and phase-specific throughput so UIs can display a single ETA across collection and later projection phases.
- Use observed per-file timings and a small checkpoint-backed sample window to smooth estimates across runs and survive timeouts.

### Description

- Added ETA configuration constants and helpers: `_ETA_RECENT_FILES_WINDOW`, `_ETA_RECENT_RUNS_WINDOW`, `_ETA_PHASE_THROUGHPUT_EPSILON`, `_float_seconds_from_timing_entry`, `_collection_eta`, and `_phase_progress_metrics` in `src/gabion/server.py` to extract per-file durations and compute collection- and phase-level ETAs.
- Persist recent per-file timing samples into resume payloads as `eta_recent_file_seconds_v1` and compute/persist `eta_seconds` and `eta_confidence` on collection checkpoint emission.
- Compute `work_done`/`work_total` for projection phases from projection rows and resolved sections, sample recent phase throughput, and emit phase `eta_seconds`/`eta_confidence` that are checkpointed with phase state.
- Surface unified fields (`work_done`, `work_total`, `eta_seconds`, `eta_confidence`) in incremental report rendering so clients see a single schema for ETA across phases and during timeouts.
- When a timeout occurs, include collection ETA (from resumed checkpoint) and inherit ETA/work fields from the latest phase checkpoint when available so timeout payloads expose unified ETA information.
- Files changed: `src/gabion/server.py` (ETA logic, wiring into checkpointing, report rendering, timeout payload exposure) and `tests/test_server_execute_command_edges.py` (added unit tests for ETA behavior and rendering).

### Testing

- Static check: `python -m py_compile src/gabion/server.py tests/test_server_execute_command_edges.py` succeeded.
- Unit tests: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_server_execute_command_edges.py -k "collection_eta or unified_eta or timeout_payload_includes_collection_eta or analysis_resume_progress_uses_observed_file_counts"` ran and all selected tests passed (4 passed, others deselected).
- Note: `mise exec -- python -m py_compile ...` was not used because `mise.toml` is untrusted in this environment; manual `python -m py_compile` and `pytest` were used instead and validated the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960e1d69a4832492910b2fd66ea377)