### PR TITLE
Propagate normalized phase work counters in LSP progress updates

### DIFF
--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -4605,3 +4605,10 @@ def test_execute_impact_bfs_step_limit_handles_dense_reverse_edges(tmp_path: Pat
     )
     assert result.get("exit_code") == 0
     assert "seed" in (result.get("seed_functions") or [])
+
+
+def test_normalize_progress_work_clamps_negative_and_overflow() -> None:
+    assert server._normalize_progress_work(work_done=-3, work_total=-1) == (0, 0)
+    assert server._normalize_progress_work(work_done=9, work_total=4) == (4, 4)
+    assert server._normalize_progress_work(work_done=2, work_total=None) == (2, None)
+    assert server._normalize_progress_work(work_done=None, work_total=3) == (None, 3)


### PR DESCRIPTION
### Motivation
- Surface phase-local work counters in the LSP progress payload (`gabion/dataflow_progress_v1`) so clients can consume explicit `work_done`/`work_total` values when available.  
- Preserve backward compatibility for collection emissions by either omitting the keys or emitting the collection counters explicitly.  
- Ensure counters are well-formed by normalizing to non-negative integers and clamping `work_done <= work_total` when total is known.

### Description
- Added `_normalize_progress_work(...)` to validate and normalize optional `work_done`/`work_total` inputs (non-negative, boolean-safe, and clamp `work_done` to `work_total` when both present).  
- Extended `_emit_lsp_progress(...)` to accept optional `work_done` and `work_total`, normalize them, and include them in the `gabion/dataflow_progress_v1` payload only when present.  
- Updated the collection-phase emission to pass `completed_files`/`total_files` as the work counters to `_emit_lsp_progress(...)` so collection payloads continue to expose explicit work counters for compatibility.  
- Updated `_persist_projection_phase(...)` to forward its phase-local `work_done`/`work_total` arguments into `_emit_lsp_progress(...)`.  
- Added a regression test (`test_normalize_progress_work_clamps_negative_and_overflow`) that exercises `_normalize_progress_work(...)` behavior.

### Testing
- Attempted to run the originally targeted test subset with `mise` but encountered `mise.toml` trust and packaging dependency installation failures (automated runs aborted due to environment/trust and `hatchling` fetch errors).  
- Ran pytest directly with repo sources on a narrowed selection using `PYTHONPATH=src` and disabled extra addopts: `mise exec -- env PYTHONPATH=src python -m pytest -o addopts='' tests/test_server_execute_command_edges.py -k "normalize_progress_work_clamps_negative_and_overflow or writes_phase_checkpoint_when_incremental_enabled"`, and the selected tests passed (`2 passed, 148 deselected`).  
- A prior trial that selected the progress-notification test failed in this environment due to the test exercising LSP notifications; this was isolated and the normalization and checkpoint tests were rerun and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996149d77848324b84f54a6a9086d68)