### PR TITLE
Emit terminal progress and resolve VSCode progress on timeout/failure

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -3342,6 +3342,9 @@ def _execute_command_total(
             collection_progress: Mapping[str, JSONValue],
             semantic_progress: Mapping[str, JSONValue] | None,
             include_timing: bool = False,
+            done: bool = False,
+            analysis_state: str | None = None,
+            classification: str | None = None,
         ) -> None:
             semantic_payload: JSONObject = {}
             if isinstance(semantic_progress, Mapping):
@@ -3374,6 +3377,12 @@ def _execute_command_total(
                         "counters": dict(profiling_counters),
                     },
                 }
+            if done:
+                progress_value["done"] = True
+            if isinstance(analysis_state, str) and analysis_state:
+                progress_value["analysis_state"] = analysis_state
+            if isinstance(classification, str) and classification:
+                progress_value["classification"] = classification
             send_notification = getattr(ls, "send_notification", None)
             if not callable(send_notification):
                 return
@@ -4429,6 +4438,15 @@ def _execute_command_total(
                 response["exit_code"] = 1 if (fail_on_violations and effective_violations) else 0
         response["analysis_state"] = "succeeded"
         response["execution_plan"] = execution_plan.as_json_dict()
+        _emit_lsp_progress(
+            phase="post",
+            collection_progress=latest_collection_progress,
+            semantic_progress=semantic_progress_cumulative,
+            include_timing=True,
+            done=True,
+            analysis_state="succeeded",
+            classification="succeeded",
+        )
         return _normalize_dataflow_response(response)
     except TimeoutExceeded as exc:
         cleanup_now_ns = time.monotonic_ns()
@@ -4706,6 +4724,20 @@ def _execute_command_total(
             if cleanup_timeout_steps:
                 progress_payload["cleanup_truncated"] = True
                 progress_payload["cleanup_timeout_steps"] = cleanup_timeout_steps
+            timeout_classification = progress_payload.get("classification")
+            _emit_lsp_progress(
+                phase="post",
+                collection_progress=latest_collection_progress,
+                semantic_progress=semantic_progress_cumulative,
+                include_timing=True,
+                done=True,
+                analysis_state=analysis_state,
+                classification=(
+                    timeout_classification
+                    if isinstance(timeout_classification, str)
+                    else "timed_out_no_progress"
+                ),
+            )
             return _normalize_dataflow_response(
                 {
                     "exit_code": 2,
@@ -4717,6 +4749,17 @@ def _execute_command_total(
             )
         finally:
             reset_deadline(cleanup_deadline_token)
+    except Exception:
+        _emit_lsp_progress(
+            phase="post",
+            collection_progress=latest_collection_progress,
+            semantic_progress=semantic_progress_cumulative,
+            include_timing=True,
+            done=True,
+            analysis_state="failed",
+            classification="failed",
+        )
+        raise
     finally:
         reset_forest(forest_token)
         reset_deadline_clock(deadline_clock_token)


### PR DESCRIPTION
### Motivation
- Ensure clients always receive a terminal `$/progress` event with explicit completion metadata so UI progress notifications can be closed on success, timeout, or error.
- Prevent stranded progress UI when server commands time out or when `workspace/executeCommand` requests fail.

### Description
- Server: extended `_emit_lsp_progress` to include `done`, `analysis_state`, and `classification` fields and emit a terminal progress event on the success path (`succeeded`).
- Server: in timeout handling emit a terminal `$/progress` with final `analysis_state` and timeout `classification` before returning the timeout response.
- Server: added a defensive path that emits a terminal `$/progress` with `analysis_state="failed"` and `classification="failed"` for unexpected exceptions prior to re-raising.
- VS Code extension: added `progressLifecycle.resolveActiveProgress` and a `resolveProgress` implementation that resolves active progress entries.
- VS Code extension: updated `registerProgressNotifications` to treat `done`, `analysis_state`/`classification` timeout markers, and explicit `failed` states as terminal (not just `post + remaining=0`), and to resolve active entries accordingly.
- VS Code extension: added defensive cleanup in `executeServerCommand` so rejected command requests call `progressLifecycle.resolveActiveProgress` to avoid leaving stale notification UI.

### Testing
- Ran `python -m py_compile src/gabion/server.py` and it succeeded.
- Ran `node --check extensions/vscode/extension.js` and it succeeded.
- Attempted `mise exec -- python -m py_compile src/gabion/server.py` but the local `mise.toml` is not trusted in this environment, so that command was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699614a3f9348324b08cc31819b9510f)