### PR TITLE
Include work_done/work_total in execute-command LSP progress and add notification tests

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -3342,6 +3342,8 @@ def _execute_command_total(
             collection_progress: Mapping[str, JSONValue],
             semantic_progress: Mapping[str, JSONValue] | None,
             include_timing: bool = False,
+            work_done: int | None = None,
+            work_total: int | None = None,
         ) -> None:
             semantic_payload: JSONObject = {}
             if isinstance(semantic_progress, Mapping):
@@ -3366,6 +3368,17 @@ def _execute_command_total(
                 "total_files": int(collection_progress.get("total_files", 0)),
                 "semantic_deltas": semantic_payload,
             }
+            if (
+                phase != "collection"
+                and isinstance(work_done, int)
+                and isinstance(work_total, int)
+            ):
+                normalized_total = max(work_total, 0)
+                normalized_done = max(work_done, 0)
+                if normalized_total > 0:
+                    normalized_done = min(normalized_done, normalized_total)
+                progress_value["work_done"] = normalized_done
+                progress_value["work_total"] = normalized_total
             if include_timing:
                 progress_value["profiling_v1"] = {
                     "format_version": 1,
@@ -3597,6 +3610,8 @@ def _execute_command_total(
                 collection_progress=latest_collection_progress,
                 semantic_progress=semantic_progress_cumulative,
                 include_timing=profile_enabled,
+                work_done=work_done,
+                work_total=work_total,
             )
             if not report_output_path or not projection_rows:
                 return


### PR DESCRIPTION
### Motivation

- Ensure non-collection phase progress notifications emitted by the execute-command flow include explicit `work_done`/`work_total` counters so language clients can display phase-level progress. 
- Add test coverage that captures `send_notification` calls so progress emissions (success and timeout) can be asserted end-to-end.

### Description

- Extended `_emit_lsp_progress` in `src/gabion/server.py` to accept `work_done` and `work_total` parameters and include them in the emitted `$/progress` payload for phases other than `collection` when integer values are provided. 
- Wired the projection checkpoint emitter to forward `work_done`/`work_total` when invoking `_emit_lsp_progress` during phase projection checkpointing. 
- Added a lightweight dummy server in `tests/test_server_execute_command_edges.py` that records `send_notification` calls and a helper `_progress_notifications` to filter `$/progress` notifications with token `gabion.dataflowAudit/progress-v1`. 
- Added two tests in `tests/test_server_execute_command_edges.py`: a success-path test that asserts the presence and shape of progress notifications and that the terminal `post` notification carries `work_done`/`work_total`; and a timeout-path test that asserts a closing progress notification is still emitted and has the expected progress payload fields.

### Testing

- Attempted `mise` invocation for the repo-local toolchain but it failed to resolve/trust tool metadata in this environment and was skipped; see the local `mise` warning.  
- Ran the focused pytest invocation `PYTHONPATH=src python -m pytest -o addopts='' tests/test_server_execute_command_edges.py -k "lsp_progress_notifications_on_success or closing_lsp_progress_notification_on_timeout or writes_phase_checkpoint_when_incremental_enabled"` and the selected tests passed (`3 passed, 148 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699614ac0c408324abcc741867857211)