### PR TITLE
cache: share warm checkpoints across strictness-stage retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GABION_DIRECT_RUN: "1"
         run: |
-          .venv/bin/python scripts/run_dataflow_stage.py --max-attempts 3
+          .venv/bin/python scripts/run_dataflow_stage.py --max-attempts 3 --stage-strictness-profile "a=low,b=high,c=low"
       - name: Finalize dataflow audit outcome
         if: always()
         env:


### PR DESCRIPTION
### Motivation
- Allow CI and iterative runs that switch `strictness` to reuse prior index hydration instead of forcing cold reparses. 
- Make staged retries (A->B->C) operate as strictness refinements/fallbacks against a single checkpoint so indexing work is shared.
- Keep resume behavior identity-gated and safe while allowing bounded multi-variant resume state to improve warm-cache hit rates.

### Description
- Added multi-variant analysis-index resume support in `src/gabion/analysis/dataflow_audit.py` by storing a bounded `resume_variants` map (max 4 variants) alongside the primary payload and a `_with_analysis_index_resume_variants` helper to merge prior variants into new payloads.
- Updated `_load_analysis_index_resume_payload` so a matching variant keyed by `expected_index_cache_identity` is selected when the top-level `index_cache_identity` differs, while still enforcing `projection_cache_identity` compatibility before hydration.
- Extended `scripts/run_dataflow_stage.py` to accept a per-stage strictness profile via `--stage-strictness-profile`, parse positional and named forms, and pass `--strictness` into each `gabion check` invocation so different stages can run with different strictness while sharing `--resume-checkpoint`.
- Wired CI (`.github/workflows/ci.yml`) to run staged retries with the profile `a=low,b=high,c=low` and updated `README.md` guidance to document safe strictness alternation and the same-checkpoint reuse pattern.
- Added and updated unit tests in `tests/test_dataflow_audit_helpers.py` and `tests/test_run_dataflow_stage.py` to cover variant selection, serialized variant retention, strictness-profile parsing, and strictness plumbing into staged commands.

### Testing
- Ran focused pytest selection: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_run_dataflow_stage.py tests/test_dataflow_audit_helpers.py -k "strictness_profile or projection_identity_mismatch or uses_variant or keeps_recent_variants"` which passed (4 passed, others deselected).
- Ran the stage-specific test: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_run_dataflow_stage.py -k "stage_specific_strictness"` which passed (1 selected, 1 passed).
- All modified unit tests executed locally and passed in the targeted selections; no integration CI run was executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962eab614883249b82ca60a42b31a8)