### PR TITLE
docs(vscode): document live analysis progress behavior

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -27,6 +27,32 @@ analysis logic on the server side.
 - **Result panels** are emitted into the **Gabion** output channel for synthesis,
   refactor, and structure diff command responses.
 
+## Live analysis progress
+
+The extension remains a thin wrapper: it listens for server-side progress and
+renders status in VS Code without running analysis logic in the client.
+
+- The client subscribes to server `$/progress` notifications and reacts to the
+  `gabion.dataflowAudit/progress-v1` token.
+- During longer-running server analysis, VS Code shows a progress notification
+  so users can see that work is still in flight.
+- Progress notifications close when terminal markers are received (`done`,
+  timeout classifications, and failure states), and also when request-failure
+  cleanup runs.
+- The **Gabion** output channel includes progress log lines in addition to
+  command result payloads.
+
+### Troubleshooting timeouts
+
+If an analysis times out:
+
+1. Open the **Gabion** output channel to inspect timeout context and the report
+   artifact paths emitted by the server.
+2. Review the referenced timeout report artifact(s) to confirm whether the
+   timeout classification was expected for the current file/workspace size.
+3. Retry the command after narrowing scope (for example, smaller target set or
+   less competing editor activity) so the server can complete within budget.
+
 ## Command Palette actions
 
 The extension wires these server commands directly:


### PR DESCRIPTION
### Motivation

- Clarify how the VS Code extension surfaces long-running server analysis status while preserving the "thin wrapper" client model.
- Provide users with guidance on where progress logs and timeout artifacts appear and how to retry when analysis times out.

### Description

- Add a new `Live analysis progress` section to `extensions/vscode/README.md` describing client behavior and UI affordances.
- Document that the client subscribes to `$/progress` notifications and reacts to the `gabion.dataflowAudit/progress-v1` token, that VS Code shows a progress notification during long-running analysis, and that progress closes on terminal markers (`done`, timeout classifications, failure states) and request-failure cleanup.
- Note that the **Gabion** output channel now includes progress log lines in addition to command result payloads and add a short `Troubleshooting timeouts` subsection explaining where to inspect timeout context/report artifacts and how to retry.
- Preserve the thin-wrapper framing and avoid implying client-side analysis logic.

### Testing

- Documentation-only change; no code-path or unit tests were required or run.
- File update and commit were performed and verified locally (`git` operations and file inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996329e76dc8324b662fe51dc38030f)