### PR TITLE
Expose resume checkpoint compatibility status in check output

### DIFF
--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -959,6 +959,30 @@ def test_dataflow_audit_retry_uses_fresh_cli_budget(
     assert calls["count"] == 2
 
 
+def test_emit_analysis_resume_summary(capsys) -> None:
+    cli._emit_analysis_resume_summary(
+        {
+            "analysis_resume": {
+                "checkpoint_path": "artifacts/audit_reports/resume.json",
+                "status": "checkpoint_loaded",
+                "reused_files": 3,
+                "total_files": 5,
+                "remaining_files": 2,
+            }
+        }
+    )
+    output = capsys.readouterr().out
+    assert "Resume checkpoint:" in output
+    assert "status=checkpoint_loaded" in output
+    assert "reused_files=3/5" in output
+
+
+def test_emit_analysis_resume_summary_skips_missing_payload(capsys) -> None:
+    cli._emit_analysis_resume_summary({"exit_code": 0})
+    output = capsys.readouterr().out
+    assert output == ""
+
+
 def test_render_timeout_progress_markdown_includes_incremental_obligations() -> None:
     progress = {
         "classification": "timed_out_progress_resume",

--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -3883,6 +3883,42 @@ def test_load_analysis_resume_checkpoint_without_expected_digest(tmp_path: Path)
     assert isinstance(loaded, dict)
 
 
+def test_analysis_resume_checkpoint_compatibility_manifest_mismatch(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "resume.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "format_version": server._ANALYSIS_RESUME_CHECKPOINT_FORMAT_VERSION,
+                "input_manifest_digest": "old-digest",
+                "collection_resume": {"completed_paths": []},
+            }
+        )
+    )
+    status = server._analysis_resume_checkpoint_compatibility(
+        path=checkpoint,
+        manifest_digest="new-digest",
+    )
+    assert status == "checkpoint_manifest_mismatch"
+
+
+def test_analysis_resume_checkpoint_compatibility_compatible(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "resume.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "format_version": server._ANALYSIS_RESUME_CHECKPOINT_FORMAT_VERSION,
+                "input_manifest_digest": "same-digest",
+                "collection_resume": {"completed_paths": []},
+            }
+        )
+    )
+    status = server._analysis_resume_checkpoint_compatibility(
+        path=checkpoint,
+        manifest_digest="same-digest",
+    )
+    assert status == "checkpoint_compatible"
+
+
 def test_analysis_resume_progress_allows_negative_total_files() -> None:
     progress = server._analysis_resume_progress(
         collection_resume={


### PR DESCRIPTION
### Motivation

- Users running repeated `gabion check` with resume checkpoints could not easily determine whether a checkpoint was being reused, seeded, or rejected due to manifest drift or corruption.
- The change aims to surface a stable, machine-readable reason code and a human-friendly summary so non-improving reruns can be diagnosed quickly.

### Description

- Add `_analysis_resume_checkpoint_compatibility` which inspects a checkpoint file and returns stable reason codes such as `checkpoint_missing`, `checkpoint_unreadable`, `checkpoint_format_mismatch`, `checkpoint_manifest_mismatch`, `checkpoint_missing_collection_resume`, and `checkpoint_compatible`.
- Thread a `analysis_resume_checkpoint_status` through `_execute_command_total` and include it as `analysis_resume.status` in the response, and set explicit outcomes `checkpoint_loaded` and `checkpoint_seeded` where appropriate.
- Add a CLI helper `_emit_analysis_resume_summary` which prints `path`, `reused_files/total_files`, `remaining_files` and `status`, and call it from both the raw dataflow runner and the `check` command so users see the checkpoint summary on stdout.
- Add focused unit tests for the CLI summary and for checkpoint compatibility classification to exercise the new behavior.

### Testing

- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_cli_helpers.py -k "emit_analysis_resume_summary"`, and the selected CLI tests passed (`2 passed`).
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_server_execute_command_edges.py -k "analysis_resume_checkpoint_compatibility"`, and the selected server tests passed (`2 passed`).
- Note: `mise` emitted a non-fatal warning about resolving pyenv metadata in this environment, but the test runs completed successfully despite that warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996441e88c48324be02fcb34de128c1)