### PR TITLE
Add normalized analysis resume cache verdict and expose in CLI

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -1506,11 +1506,13 @@ def _emit_analysis_resume_summary(result: JSONObject) -> None:
     reused_files = int(resume.get("reused_files", 0) or 0)
     total_files = int(resume.get("total_files", 0) or 0)
     remaining_files = int(resume.get("remaining_files", 0) or 0)
+    cache_verdict = str(resume.get("cache_verdict", "") or "")
     status_suffix = f" status={status}" if status else ""
+    verdict_suffix = f" cache_verdict={cache_verdict}" if cache_verdict else ""
     typer.echo(
         "Resume checkpoint: "
         f"path={path or '<none>'} reused_files={reused_files}/{total_files} "
-        f"remaining_files={remaining_files}{status_suffix}"
+        f"remaining_files={remaining_files}{status_suffix}{verdict_suffix}"
     )
 
 

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -959,7 +959,8 @@ def test_dataflow_audit_retry_uses_fresh_cli_budget(
     assert calls["count"] == 2
 
 
-def test_emit_analysis_resume_summary(capsys) -> None:
+@pytest.mark.parametrize("cache_verdict", ["hit", "miss", "invalidated", "seeded"])
+def test_emit_analysis_resume_summary(cache_verdict: str, capsys) -> None:
     cli._emit_analysis_resume_summary(
         {
             "analysis_resume": {
@@ -968,6 +969,7 @@ def test_emit_analysis_resume_summary(capsys) -> None:
                 "reused_files": 3,
                 "total_files": 5,
                 "remaining_files": 2,
+                "cache_verdict": cache_verdict,
             }
         }
     )
@@ -975,6 +977,7 @@ def test_emit_analysis_resume_summary(capsys) -> None:
     assert "Resume checkpoint:" in output
     assert "status=checkpoint_loaded" in output
     assert "reused_files=3/5" in output
+    assert f"cache_verdict={cache_verdict}" in output
 
 
 def test_emit_analysis_resume_summary_skips_missing_payload(capsys) -> None:

--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -3919,6 +3919,30 @@ def test_analysis_resume_checkpoint_compatibility_compatible(tmp_path: Path) -> 
     assert status == "checkpoint_compatible"
 
 
+@pytest.mark.parametrize(
+    ("status", "reused_files", "compatibility_status", "expected"),
+    [
+        ("checkpoint_loaded", 2, "checkpoint_compatible", "hit"),
+        ("checkpoint_loaded", 0, "checkpoint_compatible", "miss"),
+        ("checkpoint_seeded", 0, "checkpoint_manifest_mismatch", "invalidated"),
+        ("checkpoint_seeded", 0, "checkpoint_missing", "seeded"),
+        ("checkpoint_seeded", 0, "checkpoint_unreadable", "invalidated"),
+    ],
+)
+def test_analysis_resume_cache_verdict_mapping(
+    status: str,
+    reused_files: int,
+    compatibility_status: str,
+    expected: str,
+) -> None:
+    verdict = server._analysis_resume_cache_verdict(
+        status=status,
+        reused_files=reused_files,
+        compatibility_status=compatibility_status,
+    )
+    assert verdict == expected
+
+
 def test_analysis_resume_progress_allows_negative_total_files() -> None:
     progress = server._analysis_resume_progress(
         collection_resume={


### PR DESCRIPTION
### Motivation
- Provide a single, deterministic cache verdict derived from resume checkpoint status, reuse counters, and compatibility checks to make client output and downstream logic simpler and more consistent.
- Surface compatibility information and a normalized verdict so the CLI and other consumers can render a concise summary like `cache_verdict=hit` or `cache_verdict=invalidated`.

### Description
- Added `_analysis_resume_cache_verdict` in `src/gabion/server.py` which maps `status`, `reused_files`, and `compatibility_status` into one of `"hit" | "miss" | "invalidated" | "seeded"` with clear rules for seeded/loaded/invalidation cases.
- Threaded a `analysis_resume_checkpoint_compatibility_status` local into the execute flow and included both `compatibility_status` and derived `cache_verdict` in the `analysis_resume` response payload returned by `execute_command`.
- Updated the CLI `_emit_analysis_resume_summary` in `src/gabion/cli.py` to append a concise `cache_verdict=<value>` suffix when present.
- Added tests: a parametrized CLI helper test in `tests/test_cli_helpers.py` to validate rendering for `hit`, `miss`, `invalidated`, and `seeded`, and server-side tests in `tests/test_server_execute_command_edges.py` to validate the mapping for loaded+reused>0, loaded+reused=0, manifest mismatch/unreadable, and seeded cases.

### Testing
- Ran the targeted tests with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_cli_helpers.py::test_emit_analysis_resume_summary tests/test_server_execute_command_edges.py::test_analysis_resume_cache_verdict_mapping` and the test cases passed.
- The project test run reported all exercised cases as green for the modified tests (no failures in the invoked test set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699654cf970c8324bba1c9192d70c0a2)