### PR TITLE
Wave2 W2-0: CI hotfix for dataflow-grammar artifact flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,25 +39,6 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip uv
           .venv/bin/uv pip sync requirements.lock
           .venv/bin/uv pip install -e .
-      - name: Download dataflow report artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: dataflow-report
-          path: .
-      - name: Require dataflow resume checkpoint artifact
-        run: |
-          checkpoint="artifacts/audit_reports/dataflow_resume_checkpoint_ci.json"
-          alt_checkpoint="dataflow-report/${checkpoint}"
-          if [ -f "$checkpoint" ]; then
-            exit 0
-          fi
-          if [ -f "$alt_checkpoint" ]; then
-            mkdir -p "$(dirname "$checkpoint")"
-            cp "$alt_checkpoint" "$checkpoint"
-            exit 0
-          fi
-          echo "Missing required dataflow resume checkpoint artifact: $checkpoint"
-          exit 1
       - name: Restore previous dataflow resume checkpoint (best effort)
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- remove same-run artifact download requirement from `dataflow-grammar`
- remove hard-fail checkpoint requirement that blocked cold-start runs
- keep `restore-resume-checkpoint` as best-effort warm-cache bootstrap

## Why
`stage` CI currently fails in `dataflow-grammar` when no prior `dataflow-report` artifact is available in-run. This restores cold-start safety while preserving warm-cache behavior when checkpoints exist.

## Validation (local CI-equivalent)
- `mise exec -- python scripts/policy_check.py --workflows`
- `mise exec -- python -m gabion docflow --root . --fail-on-violations --sppf-gh-ref-mode required`
- `mise exec -- python scripts/sppf_status_audit.py --root .`
- `mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json && git diff --exit-code out/test_evidence.json`
- `mise exec -- python -m pytest --cov=src/gabion --cov-report=term-missing --cov-fail-under=100`
- `GABION_DIRECT_RUN=1 GABION_LSP_TIMEOUT_TICKS=65000000 GABION_LSP_TIMEOUT_TICK_NS=1000000 mise exec -- python scripts/delta_state_emit.py`
- `GABION_DIRECT_RUN=1 GABION_LSP_TIMEOUT_TICKS=65000000 GABION_LSP_TIMEOUT_TICK_NS=1000000 mise exec -- python scripts/delta_triplets.py`
