### PR TITLE
CI hotfix: preserve dataflow checkpoint persistence under timeout pressure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       # ~= 1 hour at current CI throughput (~18k ticks/ms in timeout profiles).
       GABION_LSP_TIMEOUT_TICKS: "65000000"
       GABION_LSP_TIMEOUT_TICK_NS: "1000000"
+      # Keep enough wall-clock budget for finalize/report upload if stage retries time out.
+      GABION_DATAFLOW_STAGE_MAX_WALL_SECONDS: "3300"
+      GABION_DATAFLOW_STAGE_FINALIZE_RESERVE_SECONDS: "240"
     steps:
       # Allow-listed actions: actions/checkout, jdx/mise-action
       - name: Checkout
@@ -39,6 +42,28 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip uv
           .venv/bin/uv pip sync requirements.lock
           .venv/bin/uv pip install -e .
+      - name: Seed version-controlled dataflow resume checkpoint (best effort)
+        run: |
+          target_dir="artifacts/audit_reports"
+          seed_checkpoint="baselines/dataflow_resume_checkpoint_ci.json"
+          seed_chunks="baselines/dataflow_resume_checkpoint_ci.json.chunks"
+          mkdir -p "$target_dir"
+          restored=0
+          if [ -f "$seed_checkpoint" ]; then
+            cp "$seed_checkpoint" "$target_dir/dataflow_resume_checkpoint_ci.json"
+            restored=1
+          fi
+          if [ -d "$seed_chunks" ]; then
+            rm -rf "$target_dir/dataflow_resume_checkpoint_ci.json.chunks"
+            mkdir -p "$target_dir/dataflow_resume_checkpoint_ci.json.chunks"
+            cp -R "$seed_chunks"/. "$target_dir/dataflow_resume_checkpoint_ci.json.chunks/"
+            restored=1
+          fi
+          if [ "$restored" = "1" ]; then
+            echo "Seeded checkpoint from version-controlled baseline."
+          else
+            echo "No version-controlled checkpoint seed found; continuing."
+          fi
       - name: Restore previous dataflow resume checkpoint (best effort)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -55,7 +80,11 @@ jobs:
         env:
           GABION_DIRECT_RUN: "1"
         run: |
-          .venv/bin/python scripts/run_dataflow_stage.py --max-attempts 3 --stage-strictness-profile "a=low,b=high,c=low"
+          .venv/bin/python scripts/run_dataflow_stage.py \
+            --max-attempts 3 \
+            --stage-strictness-profile "a=low,b=high,c=low" \
+            --max-wall-seconds "${GABION_DATAFLOW_STAGE_MAX_WALL_SECONDS}" \
+            --finalize-reserve-seconds "${GABION_DATAFLOW_STAGE_FINALIZE_RESERVE_SECONDS}"
       - name: Finalize dataflow audit outcome
         if: always()
         env:

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -2305,7 +2305,7 @@ def _restore_dataflow_resume_checkpoint_from_github_artifacts(
     current_run_id: str = "",
     artifact_name: str = "dataflow-report",
     checkpoint_name: str = "dataflow_resume_checkpoint_ci.json",
-    per_page: int = 20,
+    per_page: int = 100,
     urlopen_fn: Callable[..., object] = urllib.request.urlopen,
 ) -> int:
     token = token.strip()
@@ -2351,7 +2351,8 @@ def _restore_dataflow_resume_checkpoint_from_github_artifacts(
             return False
         if ref_name and str(workflow_run.get("head_branch", "")) != ref_name:
             return False
-        if str(workflow_run.get("event", "")) != "push":
+        event_name = str(workflow_run.get("event", ""))
+        if event_name not in {"push", "workflow_dispatch"}:
             return False
         return True
 


### PR DESCRIPTION
## Summary
- add staged-runner wall-clock guard + finalize reserve so retries stop before job timeout and artifacts still upload
- wire CI dataflow job to pass wall-budget knobs to `scripts/run_dataflow_stage.py`
- add best-effort seed from version-controlled checkpoint path (`baselines/dataflow_resume_checkpoint_ci.json*`)
- broaden checkpoint restore selection to include `workflow_dispatch` artifacts and query a deeper page window
- add DI-based tests for wall-budget skip behavior and workflow_dispatch artifact restore

## Validation
- `mise exec -- python scripts/policy_check.py --workflows`
- `mise exec -- python -m pytest -q tests/test_run_dataflow_stage.py`
- `mise exec -- python -m pytest -q tests/test_cli_helpers.py -k "restore_resume_checkpoint"`
