### PR TITLE
Docs: formalize in-38 archive projection and link GH-196

### DIFF
--- a/docs/influence_index.md
+++ b/docs/influence_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 50
+doc_revision: 51
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: influence_index
 doc_role: index
@@ -135,3 +135,4 @@ Status legend:
 - in/in-35.md — [**partial**](docs/sppf_checklist.md#in-35-dict-key-carrier-tracking) (dict key normalization now supports name-bound constants and records explicit unknown-key carrier evidence for non-recoverable keys; supported key grammar remains deliberately conservative.)
 - in/in-36.md — [**adopted**](docs/sppf_checklist.md#in-36-starred-dataclass-call-bundles) (dataclass call-bundle extraction now decodes deterministic starred literals for `*` and `**` and emits unresolved-starred witnesses for dynamic payloads.)
 - in/in-37.md — [**adopted**](docs/sppf_checklist.md#in-37-dynamic-dispatch-uncertainty) (callee resolution now distinguishes `unresolved_dynamic` from unresolved internal/external states and emits a dedicated `unresolved_dynamic_callee` obligation kind.)
+- in/in-38.md — **queued** (formalized future design: ASPF mutation log-structured persistence with protobuf payloads, a protobuf-defined filesystem envelope projection, and tar-packaged archive transport; deferred implementation tracked in the checklist; SPPF/GH-196.)

--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 156
+doc_revision: 157
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -219,6 +219,7 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - <a id="in-35-dict-key-carrier-tracking"></a>[~] Dict carrier tracking beyond literal subscript aliases (name-bound constant keys + unknown-key carrier evidence). (in-35) sppf{doc=partial; impl=done; doc_ref=in-35@1}
 - <a id="in-36-starred-dataclass-call-bundles"></a>[x] Conservative starred dataclass constructor argument handling (`*` list/tuple/set, `**` dict literal) with unresolved-starred witnesses for dynamic payloads. (in-36) sppf{doc=done; impl=done; doc_ref=in-36@1}
 - <a id="in-37-dynamic-dispatch-uncertainty"></a>[x] Dynamic-dispatch uncertainty classification in call resolution (`unresolved_dynamic`) plus dedicated call-resolution obligation kind. (in-37) sppf{doc=done; impl=done; doc_ref=in-37@1}
+- <a id="in-38-aspf-log-structured-archive-projection"></a>[ ] ASPF mutation log-structured archive projection (protobuf payload records + protobuf-defined filesystem envelope projection + tar-packaged transport container + snapshot/tail replay). (in-38, GH-196) sppf{doc=done; impl=planned; doc_ref=in-38@1}
 
 ## Reporting & visualization nodes
 - [x] Component isolation (connected components in bundle graph).

--- a/in/in-38.md
+++ b/in/in-38.md
@@ -1,0 +1,208 @@
+---
+doc_revision: 1
+reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
+doc_id: in_38
+doc_role: in_step
+doc_scope:
+  - repo
+  - analysis
+  - semantics
+  - storage
+  - tooling
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - glossary.md#aspf
+  - glossary.md#forest
+  - glossary.md#ambiguity_set
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-30.md#in_in_30
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 1
+  glossary.md#contract: 1
+  glossary.md#aspf: 1
+  glossary.md#forest: 1
+  glossary.md#ambiguity_set: 2
+  CONTRIBUTING.md#contributing_contract: 1
+  README.md#repo_contract: 1
+  AGENTS.md#agent_obligations: 1
+  in/in-30.md#in_in_30: 4
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: Reviewed policy constraints; no conflict.
+  glossary.md#contract: Reviewed semantic replay and witness obligations.
+  glossary.md#aspf: Reviewed packed-forest mutation carrier semantics.
+  glossary.md#forest: Reviewed forest-level determinism expectations.
+  glossary.md#ambiguity_set: Reviewed multiplicity-preserving ambiguity semantics.
+  CONTRIBUTING.md#contributing_contract: Workflow constraints unchanged.
+  README.md#repo_contract: Scope unchanged.
+  AGENTS.md#agent_obligations: Agent obligations unchanged.
+  in/in-30.md#in_in_30: Template reused.
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_sections:
+  in_in_38: 1
+doc_section_requires:
+  in_in_38:
+    - POLICY_SEED.md#policy_seed
+    - glossary.md#contract
+    - glossary.md#aspf
+    - glossary.md#forest
+    - glossary.md#ambiguity_set
+    - in/in-30.md#in_in_30
+doc_section_reviews:
+  in_in_38:
+    POLICY_SEED.md#policy_seed:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Execution-policy constraints preserved."
+    glossary.md#contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Semantic replay obligations preserved."
+    glossary.md#aspf:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "ASPF mutation scope aligned with forest semantics."
+    glossary.md#forest:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Forest determinism obligations preserved."
+    glossary.md#ambiguity_set:
+      dep_version: 2
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Ambiguity multiplicity retained as first-class event evidence."
+    in/in-30.md#in_in_30:
+      dep_version: 4
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Template constraints adopted."
+---
+
+<a id="in_in_38"></a>
+
+# in/in-38.md
+## Formalize an ASPF mutation log-structured archive projection
+
+### Purpose
+Define a future persistence model where ASPF mutation events are the primary durable stream, with protobuf payloads, a protobuf-defined archive envelope, and a deterministic filesystem/tar projection for transport and replay.
+
+### Non-goals
+- No immediate replacement of current JSON resume checkpoint behavior.
+- No requirement to migrate CI/runtime in this step.
+- No commitment to a specific compression/encryption profile yet.
+
+### Status
+planned — design formalized and set aside for future implementation.
+
+Normative pointers: [POLICY_SEED.md#policy_seed](POLICY_SEED.md#policy_seed), [glossary.md#contract](glossary.md#contract), [glossary.md#aspf](glossary.md#aspf), [glossary.md#forest](glossary.md#forest), [glossary.md#ambiguity_set](glossary.md#ambiguity_set), [in/in-30.md#in_in_30](in/in-30.md#in_in_30), [docs/sppf_checklist.md#in-38-aspf-log-structured-archive-projection](docs/sppf_checklist.md#in-38-aspf-log-structured-archive-projection).
+
+### Design summary
+- Treat ASPF mutations as the write-model source of truth (append-only).
+- Materialize resume/progress/report read models from `snapshot + tail replay`.
+- Encode all record payloads as protobuf.
+- Describe archive layout with a protobuf root schema, projected to a filesystem hierarchy.
+- Package filesystem projection as tar (reader-owned semantics, deterministic ordering).
+
+---
+
+## Face / Kit / Solver
+
+### Face (obligations)
+- **F1:** Replay is deterministic and preserves ambiguity witness multiplicity.
+- **F2:** Recovery is crash-safe and can ignore partial tail writes.
+- **F3:** Schema evolution is additive and forward-compatible.
+- **F4:** Warm-resume startup is bounded by snapshot load + short tail replay.
+- **F5:** Containerization remains lossless and transport-friendly.
+
+### Kit (existing machinery)
+- Current resume checkpoint and staged retry flow:
+  - `src/gabion/server.py` (analysis resume checkpoint + progress emission)
+  - `scripts/run_dataflow_stage.py` (staged retries and checkpoint usage)
+  - `src/gabion/cli.py` (`restore-resume-checkpoint`)
+- Existing determinism and ordering contracts:
+  - `src/gabion/order_contract.py`
+  - snapshot and delta scripts under `scripts/`
+
+### Solver (future implementation plan)
+1. **Define protobuf contracts**
+   - `EventEnvelope` (sequence, run id, oneof mutation payloads).
+   - `SnapshotEnvelope` (materialized ASPF state + replay cursor).
+   - `ArchiveManifest` (schema/projection versions, segment inventory, integrity metadata).
+   - `CommitMarker` (last durable sequence/segment boundary).
+
+2. **Define filesystem projection of the protobuf root**
+   - Top-level protobuf fields map to top-level folders.
+   - Use field-number-prefixed folder names for rename-stable decoding.
+   - Repeated fields map to zero-padded index entries for deterministic order.
+   - Leaf payloads use protobuf binary files (e.g. `*.pb`).
+   - Optional sidecars (`*.crc`, `*.meta.pb`) carry record-level integrity and metadata.
+
+3. **Define tar packaging contract**
+   - Deterministic tar build (sorted paths, normalized metadata).
+   - Reader explicitly supports multi-archive concatenation when used as segment chaining.
+   - Manifest-level integrity remains authoritative even when tar is concatenated.
+
+4. **Define replay/compaction contract**
+   - On resume: load latest snapshot, replay events after snapshot cursor.
+   - Ignore tail entries past the last valid commit marker.
+   - Compact periodically into a new snapshot and truncate/resegment tail.
+
+5. **Define CQRS read-model injectors**
+   - Resume checkpoint read model.
+   - Incremental progress read model.
+   - Partial/final report read model.
+   - All injectors are deterministic projections from the same event stream.
+
+6. **Define migration path**
+   - Shadow-write event stream alongside current checkpoint format.
+   - Add parity checks between legacy checkpoint and projected read model.
+   - Flip reads only after parity confidence reaches acceptance threshold.
+
+---
+
+## Example projection sketch
+
+```text
+001_manifest/manifest.pb
+010_events/000000000001.data.pb
+010_events/000000000001.crc
+010_events/000000000001.meta.pb
+020_snapshots/000000000120.data.pb
+020_snapshots/000000000120.meta.pb
+099_commit/commit.pb
+```
+
+Notes:
+- Names are illustrative; canonical naming rules are part of the future projection spec.
+- Field-number prefixes are stable identifiers; friendly labels are advisory.
+
+---
+
+## Acceptance criteria (future)
+
+1. A written proto contract exists for envelope, events, snapshot, and commit marker.
+2. A written projection contract exists from proto root to filesystem hierarchy.
+3. Replay determinism is testable with stable state hash under repeated runs.
+4. Recovery semantics explicitly define partial-write handling and commit boundaries.
+5. Snapshot+tail replay latency budget is defined for CI warm-cache scenarios.
+
+---
+
+## Risks and mitigations
+
+- **Risk:** over-complexity versus current JSON checkpoint path.
+  - **Mitigation:** stage via shadow-write and parity audits before any read-path flip.
+- **Risk:** schema drift or extension hazards.
+  - **Mitigation:** additive protobuf evolution rules + manifest-declared format versions.
+- **Risk:** nondeterministic replay order.
+  - **Mitigation:** fixed-width sequence ids + deterministic ordering contract tests.
+- **Risk:** container-reader portability confusion.
+  - **Mitigation:** explicitly document reader-owned tar semantics and keep manifest authoritative.


### PR DESCRIPTION
## Summary
- add `in/in-38.md` as a formal future design step for ASPF mutation log-structured archive projection
- add a planned SPPF checklist node with explicit tracker linkage `(in-38, GH-196)`
- add influence-index entry for `in/in-38.md` as queued and linked to the tracker

## Validation
- `mise exec -- python scripts/sppf_status_audit.py --root .`
- `mise exec -- python -m gabion docflow --root . --fail-on-violations --sppf-gh-ref-mode required`

## Tracking
- GH-196
