### PR TITLE
CI hotfix: grant actions read for artifact checkpoint restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   dataflow-grammar:
+    permissions:
+      contents: read
+      actions: read
     if: github.event_name != 'workflow_dispatch' || (github.ref == 'refs/heads/stage' && github.actor == github.repository_owner)
     runs-on: ubuntu-latest
     timeout-minutes: 70


### PR DESCRIPTION
## Summary
- grant `actions: read` permission to `dataflow-grammar`
- keep permission scope minimal (`contents: read` + `actions: read` only on this job)

## Why
`restore-resume-checkpoint` needs to download prior workflow artifacts. Without `actions: read`, restore can fail with HTTP 401 during artifact download and force cold starts.

## Validation
- `mise exec -- python scripts/policy_check.py --workflows`
