### PR TITLE
Server hotfix: stabilize resume manifest digest across mtimes

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -644,7 +644,6 @@ def _analysis_input_manifest(
             entry["missing"] = True
         else:
             entry["size"] = int(stat.st_size)
-            entry["mtime_ns"] = int(stat.st_mtime_ns)
         files.append(entry)
     return {
         "format_version": _ANALYSIS_INPUT_MANIFEST_FORMAT_VERSION,
@@ -679,10 +678,11 @@ def _analysis_manifest_digest_from_witness(input_witness: JSONObject) -> str | N
         if isinstance(missing_value, bool):
             manifest_entry["missing"] = missing_value
         size_value = raw_entry.get("size")
-        mtime_value = raw_entry.get("mtime_ns")
-        if isinstance(size_value, int) and isinstance(mtime_value, int):
+        if isinstance(size_value, int):
             manifest_entry["size"] = size_value
-            manifest_entry["mtime_ns"] = mtime_value
+        content_sha1_value = raw_entry.get("content_sha1")
+        if isinstance(content_sha1_value, str) and content_sha1_value:
+            manifest_entry["content_sha1"] = content_sha1_value
         manifest_files.append(manifest_entry)
     config = input_witness.get("config")
     if not isinstance(config, Mapping):


### PR DESCRIPTION
## Summary
- make analysis input manifest digest stable across checkout mtime changes
- stop including `mtime_ns` in manifest digest payload
- keep manifest witness fallback tolerant (`size` and optional `content_sha1`)
- add regression test proving digest invariance under mtime-only file updates

## Why
CI checkout rewrites mtimes, which was causing `checkpoint_manifest_mismatch` on every run even for identical commit content. That prevented warm-cache reuse from ever loading.

## Validation
- `mise exec -- python -m pytest -q tests/test_server_execute_command_edges.py -k "analysis_input_manifest or analysis_manifest_digest_from_witness or analysis_resume_checkpoint_compatibility_uses_witness_manifest_fallback"`
