### PR TITLE
Server: emit checkpoint intro timeline on checkpoint writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
             artifacts/audit_reports/timeout_progress_stage_*.json
             artifacts/audit_reports/dataflow_resume_checkpoint_ci.json
             artifacts/audit_reports/dataflow_resume_checkpoint_ci.json.chunks/**
+            artifacts/audit_reports/dataflow_checkpoint_intro_timeline.md
             artifacts/out/deadline_profile.json
             artifacts/out/deadline_profile.md
             artifacts/out/deadline_profile_stage_*.json


### PR DESCRIPTION
## Summary\n- emit a markdown timeline row for checkpoint intro state on each checkpoint serialization\n- enable in CI by default and upload timeline artifact\n- add server edge tests for table write and seed/flush row emission\n\n## Validation\n- mise exec -- python -m pytest -q tests/test_server_execute_command_edges.py\n- mise exec -- python scripts/policy_check.py --workflows