### PR TITLE
Add Shift-Ambiguity-Left directive to policy seed

### DIFF
--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 38
+doc_revision: 39
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -486,6 +486,37 @@ allow-listed in this policy.
 Agda installs in CI MUST pin a specific version (no floating latest).
 Agda CI checks SHOULD run inside a digest-pinned container image to avoid
 toolchain drift.
+
+### 4.8 Shift-Ambiguity-Left Directive
+
+Ambiguity discovered during implementation MUST be handled as a boundary-first
+typing problem, not as a local control-flow patch in semantic core modules.
+
+Required behavior when ambiguity appears:
+
+1. **Identify the ambiguity source** as one of:
+   * input shape,
+   * decision predicate, or
+   * cross-boundary bundle.
+2. **Move the ambiguity to the nearest ingress/boundary layer** where inputs are
+   parsed, normalized, or admitted.
+3. **Reify the ambiguity as a Tier-1 structure** (Protocol/dataclass or Decision
+   Protocol) at that boundary.
+4. **Pass only deterministic values into downstream suites**; semantic core
+   execution MUST consume resolved values, not unresolved alternation.
+5. **Reject patches** that resolve local errors by adding new dynamic
+   alternation in core flow.
+
+Anti-shortcut rule (explicitly disallowed as first response inside semantic
+core modules):
+
+* local branch insertion,
+* sentinel injection, and
+* type alternation.
+
+Any of the above patterns discovered in semantic core changes MUST be treated as
+a policy violation unless accompanied by boundary-level reification that removes
+the ambiguity before core-flow execution.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Clarify and enforce a boundary-first workflow for handling implementation ambiguity so core semantic modules remain deterministic and auditable.
- Prevent ad-hoc runtime alternation patterns that obscure dataflow contracts and violate the repository's Tier reification invariants.

### Description
- Added a new normative subsection `4.8 Shift-Ambiguity-Left Directive` to `POLICY_SEED.md` that prescribes a five-step ambiguity handling workflow: identify source, move to ingress/boundary, reify as a Tier-1 structure, pass only deterministic values downstream, and reject local alternation fixes.
- Added explicit anti-shortcut language disallowing `local branch insertion`, `sentinel injection`, and `type alternation` as first responses inside semantic core modules.
- Bumped `doc_revision` from `38` to `39` to reflect the conceptual policy update.

### Testing
- Verified the change with `git diff -- POLICY_SEED.md` which shows the inserted `4.8` section and `doc_revision` bump and the diff was as expected (success).
- Confirmed working tree state with `git status --short` and committed the change using `git add` + `git commit -m "Add shift-ambiguity-left policy directive"` which recorded commit `a4ff7cb` (success).
- Created PR metadata via the repo `make_pr` helper with title `Add Shift-Ambiguity-Left directive to policy seed` (metadata creation succeeded); no CI test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993895dfa083248592f01ff081e146)