### PR TITLE
Add architecture zones note for ambiguity boundaries and Tier-1 handoff

### DIFF
--- a/docs/architecture_zones.md
+++ b/docs/architecture_zones.md
@@ -1,0 +1,80 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: architecture_zones
+doc_role: architecture
+doc_scope:
+  - repo
+  - architecture
+  - analysis
+  - synthesis
+  - cli
+doc_authority: informative
+doc_requires:
+  - README.md#repo_contract
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+doc_reviewed_as_of:
+  README.md#repo_contract: 1
+  POLICY_SEED.md#policy_seed: 1
+  glossary.md#contract: 1
+doc_review_notes:
+  README.md#repo_contract: "Reviewed LSP-first repo contract; this note scopes boundaries for enforcement."
+  POLICY_SEED.md#policy_seed: "Reviewed dataflow grammar and execution invariants; boundary note must not weaken them."
+  glossary.md#contract: "Reviewed tier semantics; handoff contract uses Tier-1 reification at core ingress."
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_sections:
+  architecture_zones: 1
+doc_section_requires:
+  architecture_zones:
+    - README.md#repo_contract
+    - POLICY_SEED.md#policy_seed
+    - glossary.md#contract
+doc_section_reviews:
+  architecture_zones:
+    README.md#repo_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Architecture zoning stays aligned with LSP-first repository contract."
+    POLICY_SEED.md#policy_seed:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "No policy weakening; this note is a scoping aid."
+    glossary.md#contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Tier language is glossary-aligned."
+doc_erasure:
+  - formatting
+  - typos
+doc_owner: maintainer
+---
+
+<a id="architecture_zones"></a>
+# Architecture Zones
+
+## Ambiguity admission zones
+These zones are allowed to accept ambiguous, partial, or external shapes before normalization:
+
+- **CLI parsing boundary:** `src/gabion/cli.py` (arg parsing, CSV/string option lifting, env/default merge).
+- **External payload adapters:** `src/gabion/lsp_client.py` and `src/gabion/server.py` (JSON-RPC request/response transport and command payload intake).
+- **Serialization boundaries:** `src/gabion/schema.py` and `src/gabion/json_types.py` (DTO validation, JSON-like carrier typing, artifact wire shapes).
+
+## Deterministic core zones
+These zones are expected to run deterministic semantics once data is reified:
+
+- **Analysis semantics pipeline:** `src/gabion/analysis/` (dataflow graphing, evidence projection, decision/report surfaces).
+- **Synthesis semantics pipeline:** `src/gabion/synthesis/` (bundle merge, naming, scheduling, protocol plan construction).
+- **Refactor semantics engine:** `src/gabion/refactor/` (rewrite planning and edit synthesis driven by reified plans).
+
+## Boundary handoff contract
+Only **Tier-1 reified objects** cross from ambiguity zones into deterministic core zones.
+
+- Inputs must be promoted to typed DTO/model/config carriers before they enter `src/gabion/analysis/`, `src/gabion/synthesis/`, or `src/gabion/refactor/`.
+- Allowed cross-boundary forms are explicit objects (for example, schema DTOs/config dataclasses), not raw ad-hoc dictionaries or free-form tuples.
+- Review and tooling should enforce by package scope:
+  - outer adapters: `src/gabion/cli.py`, `src/gabion/lsp_client.py`, `src/gabion/server.py`, `src/gabion/schema.py`, `src/gabion/json_types.py`
+  - deterministic core: `src/gabion/analysis/`, `src/gabion/synthesis/`, `src/gabion/refactor/`


### PR DESCRIPTION
### Motivation
- Provide a short, enforceable architecture note that names ambiguity admission zones, deterministic core zones, and the boundary handoff contract so reviewers and tooling can use package scope for enforcement.

### Description
- Add `docs/architecture_zones.md` (with YAML frontmatter) that enumerates ambiguity admission zones (`src/gabion/cli.py`, `src/gabion/lsp_client.py`, `src/gabion/server.py`, `src/gabion/schema.py`, `src/gabion/json_types.py`), deterministic core zones (`src/gabion/analysis/`, `src/gabion/synthesis/`, `src/gabion/refactor/`), and a boundary handoff contract requiring only Tier-1 reified objects cross into the deterministic core.

### Testing
- Attempted to run `mise exec -- python -m gabion docflow` and `mise exec -- python -m pip install -e .` to validate docflow/install, but both runs failed due to local environment/tooling resolution and network/build-dependency issues (untrusted `mise.toml`, tool resolution errors, and missing build dependency `hatchling`), and the new file was committed to the branch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699938e36c30832498f20701249c238b)