### PR TITLE
Add governance control-loop registry and enforce loop-entry docflow invariant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 96
+doc_revision: 97
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -318,6 +318,8 @@ Run the docflow audit (governance docs; `in/` is included for dependency resolut
 ```
 mise exec -- python -m gabion docflow
 ```
+Control-loop declarations are normative: `docs/governance_control_loops.md#governance_control_loops` must declare every governed domain loop entry.
+
 Run governance graph/status checks through the same CLI entrypoint:
 ```
 mise exec -- python -m gabion sppf-graph

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 41
+doc_revision: 42
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -161,6 +161,7 @@ The governance layer is a bundle of documents that must remain coherent:
 - `AGENTS.md#agent_obligations` defines LLM/agent obligations and refusal rules.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
 - `docs/publishing_practices.md#publishing_practices` reifies release best practices (advisory).
+- `docs/governance_control_loops.md#governance_control_loops` defines the normalized governance control-loop registry and required loop fields.
 
 Any change to one must be checked for consistency with the others.
 

--- a/docs/governance_control_loops.md
+++ b/docs/governance_control_loops.md
@@ -1,0 +1,157 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: governance_control_loops
+doc_role: policy
+doc_scope:
+  - repo
+  - governance
+  - ci
+  - tooling
+doc_authority: normative
+doc_requires:
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - POLICY_SEED.md#policy_seed
+  - CONTRIBUTING.md#contributing_contract
+  - glossary.md#contract
+doc_reviewed_as_of:
+  README.md#repo_contract: 1
+  AGENTS.md#agent_obligations: 1
+  POLICY_SEED.md#policy_seed: 1
+  CONTRIBUTING.md#contributing_contract: 1
+doc_review_notes:
+  README.md#repo_contract: "Repo contract reviewed; loop registry aligns with governance scope and entry points."
+  AGENTS.md#agent_obligations: "Agent obligations reviewed; loop enforcement remains mechanized and refusal-safe."
+  POLICY_SEED.md#policy_seed: "Policy seed reviewed; governance loops reify mechanized control surfaces."
+  CONTRIBUTING.md#contributing_contract: "Contributor workflow reviewed; loop verification commands align with required local checks."
+doc_sections:
+  governance_control_loops: 1
+doc_section_requires:
+  governance_control_loops:
+    - README.md#repo_contract
+    - AGENTS.md#agent_obligations
+    - POLICY_SEED.md#policy_seed
+    - CONTRIBUTING.md#contributing_contract
+    - glossary.md#contract
+doc_section_reviews:
+  governance_control_loops:
+    README.md#repo_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Repo contract reviewed; governed domains map to declared loop entries."
+    AGENTS.md#agent_obligations:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Agent obligations reviewed; loop declarations stay machine-checkable."
+    POLICY_SEED.md#policy_seed:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Policy constraints map cleanly onto loop schema fields."
+    CONTRIBUTING.md#contributing_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Contributor commands remain valid loop verification operators."
+    glossary.md#contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Glossary contract reviewed; loop predicates remain semantically aligned."
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+loop_domains:
+  - security/workflows
+  - docs/docflow
+  - LSP architecture
+  - dataflow grammar
+  - baseline ratchets
+doc_invariants:
+  - mechanized_governance_invariant
+  - lsp_first_invariant
+  - tier2_reification
+  - tier3_documentation
+doc_erasure:
+  - formatting
+  - typos
+doc_owner: maintainer
+---
+
+<a id="governance_control_loops"></a>
+# Governance control loops
+
+This file defines normalized control-loop entries for every governed normative domain.
+Docflow treats `loop_domains` as the declared registry used by `scripts/audit_tools.py`
+for loop-entry completeness checks. Canonical governance anchors: `README.md#repo_contract`, `AGENTS.md#agent_obligations`, `CONTRIBUTING.md#contributing_contract`, and `glossary.md#contract`.
+
+## Normalized schema
+
+Each loop entry MUST define:
+
+- `sensor`
+- `state artifact`
+- `target predicate`
+- `error signal`
+- `actuator`
+- `max correction step`
+- `verification command`
+- `escalation threshold`
+
+## Loop registry
+
+### 1) security/workflows
+
+- **sensor:** workflow YAML + policy posture probes from `scripts/policy_check.py --workflows` and `scripts/policy_check.py --posture`.
+- **state artifact:** `.github/workflows/*.yml`, plus policy snapshots under `artifacts/out/policy_posture*.json` when emitted.
+- **target predicate:** all workflow actions pinned to allow-listed full SHAs; self-hosted trust boundaries satisfy `POLICY_SEED.md#policy_seed` Prime Invariant.
+- **error signal:** `policy_check` non-zero exit or posture violation rows.
+- **actuator:** patch workflow files; refresh allow-list expectations; re-run policy checks.
+- **max correction step:** one workflow/guardrail patchset per loop iteration.
+- **verification command:** `mise exec -- python scripts/policy_check.py --workflows && mise exec -- python scripts/policy_check.py --posture`.
+- **escalation threshold:** any Prime Invariant contradiction or unresolved posture failure after one correction step.
+
+### 2) docs/docflow
+
+- **sensor:** docflow compliance emitters in `scripts/audit_tools.py` and `gabion docflow`.
+- **state artifact:** `artifacts/out/docflow_compliance.json`, `artifacts/out/docflow_compliance_delta.json`, and `artifacts/audit_reports/docflow_compliance.md`.
+- **target predicate:** normative docs satisfy frontmatter/review invariants; contradictions delta remains zero; every normative domain has a loop registry entry.
+- **error signal:** docflow violations or positive contradiction delta.
+- **actuator:** update governance docs, references, review pins, and loop declarations.
+- **max correction step:** one doc revision cycle affecting the minimum coherent set of governance files.
+- **verification command:** `mise exec -- python -m gabion docflow --fail-on-violations`.
+- **escalation threshold:** repeated docflow violation after one coherent doc revision cycle.
+
+### 3) LSP architecture
+
+- **sensor:** code-path checks over server/CLI split plus governance contract references.
+- **state artifact:** `src/gabion/server.py`, `src/gabion/cli.py`, and generated check artifacts under `artifacts/audit_reports/`.
+- **target predicate:** LSP-first invariant holds: server remains semantic core and CLI is a thin LSP client.
+- **error signal:** architecture drift findings in checks/tests or violations against policy text.
+- **actuator:** move semantics from CLI to server boundary; restore thin-client behavior.
+- **max correction step:** one refactor slice that removes one architectural drift source at a time.
+- **verification command:** `scripts/checks.sh --no-docflow`.
+- **escalation threshold:** semantic logic remains duplicated or CLI-owned after one refactor slice.
+
+### 4) dataflow grammar
+
+- **sensor:** `gabion check` dataflow audit and synthesis outputs.
+- **state artifact:** `artifacts/audit_reports/dataflow_report.md`, `artifacts/out/dataflow_raw.json`, and related synthesis outputs.
+- **target predicate:** recurring cross-boundary bundles are reified (Protocol/dataclass) or explicitly documented with `# dataflow-bundle:` markers.
+- **error signal:** bundle-tier violations, decision-surface lint findings, or failed check contract.
+- **actuator:** reify bundles, tighten contracts, and remove sentinel control outcomes.
+- **max correction step:** one bundle family reification (or equivalent Tier-3 documentation set) per loop.
+- **verification command:** `mise exec -- python -m gabion check`.
+- **escalation threshold:** unresolved Tier-2 bundle violations after one reification step.
+
+### 5) baseline ratchets
+
+- **sensor:** baseline delta guards and refresh tooling.
+- **state artifact:** `baselines/docflow_compliance_baseline.json`, `artifacts/out/docflow_compliance.json`, `artifacts/out/docflow_compliance_delta.json`.
+- **target predicate:** baseline refresh never masks new contradictions; ratchet movement is monotone toward stricter compliance.
+- **error signal:** baseline refresh refusal, positive contradiction delta, or baseline drift inconsistent with current audit output.
+- **actuator:** run guarded refresh via `scripts/refresh_baselines.py`; inspect and reduce deltas before update.
+- **max correction step:** one baseline refresh transaction per loop with guard checks passing.
+- **verification command:** `mise exec -- python scripts/refresh_baselines.py --docflow --timeout 600`.
+- **escalation threshold:** guard rejects refresh twice consecutively for the same unresolved contradiction source.

--- a/tests/test_docflow_governance_control_loops.py
+++ b/tests/test_docflow_governance_control_loops.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+
+def _load_audit_tools():
+    from scripts import audit_tools
+
+    return audit_tools
+
+
+# gabion:evidence E:call_footprint::tests/test_docflow_governance_control_loops.py::test_docflow_loop_registry_violation_when_domain_missing::audit_tools.py::scripts.audit_tools._docflow_invariant_rows::test_docflow_governance_control_loops.py::tests.test_docflow_governance_control_loops._load_audit_tools
+def test_docflow_loop_registry_violation_when_domain_missing() -> None:
+    audit_tools = _load_audit_tools()
+    docs = {
+        "docs/governance_control_loops.md": audit_tools.Doc(
+            frontmatter={
+                "doc_id": "governance_control_loops",
+                "loop_domains": ["security/workflows"],
+            },
+            body="",
+        )
+    }
+
+    rows, _warnings = audit_tools._docflow_invariant_rows(
+        docs=docs,
+        revisions={},
+        core_set=set(audit_tools.CORE_GOVERNANCE_DOCS),
+        missing_frontmatter=set(),
+    )
+    violations = audit_tools._evaluate_docflow_invariants(
+        rows,
+        invariants=audit_tools.DOCFLOW_AUDIT_INVARIANTS,
+    )
+
+    assert any("missing governance control-loop declaration" in item for item in violations)
+
+
+# gabion:evidence E:call_footprint::tests/test_docflow_governance_control_loops.py::test_docflow_loop_registry_satisfied_when_all_domains_declared::audit_tools.py::scripts.audit_tools._docflow_invariant_rows::test_docflow_governance_control_loops.py::tests.test_docflow_governance_control_loops._load_audit_tools
+def test_docflow_loop_registry_satisfied_when_all_domains_declared() -> None:
+    audit_tools = _load_audit_tools()
+    docs = {
+        "docs/governance_control_loops.md": audit_tools.Doc(
+            frontmatter={
+                "doc_id": "governance_control_loops",
+                "loop_domains": list(audit_tools.NORMATIVE_LOOP_DOMAINS),
+            },
+            body="",
+        )
+    }
+
+    rows, _warnings = audit_tools._docflow_invariant_rows(
+        docs=docs,
+        revisions={},
+        core_set=set(audit_tools.CORE_GOVERNANCE_DOCS),
+        missing_frontmatter=set(),
+    )
+    violations = audit_tools._evaluate_docflow_invariants(
+        rows,
+        invariants=audit_tools.DOCFLOW_AUDIT_INVARIANTS,
+    )
+
+    assert not any("missing governance control-loop declaration" in item for item in violations)


### PR DESCRIPTION
### Motivation
- Make governance control loops explicit and machine-checkable by normalizing a loop schema for each governed domain so docflow can enforce completeness. 
- Ensure every normative governance domain is anchored to a declared loop entry so automation (and reviewers) can detect missing control surfaces.

### Description
- Add `docs/governance_control_loops.md` containing a normalized loop schema and concrete entries for `security/workflows`, `docs/docflow`, `LSP architecture`, `dataflow grammar`, and `baseline ratchets`, and link to existing scripts/artifacts (for example `scripts/policy_check.py`, `scripts/audit_tools.py`, and `artifacts/out/docflow_compliance*.json`).
- Extend `scripts/audit_tools.py` to include the new doc in `GOVERNANCE_DOCS`, introduce `NORMATIVE_LOOP_DOMAINS`, emit `doc_loop_entry` rows, add the `_missing_loop_entry` predicate, and add the `docflow:missing_governance_control_loop` invariant with a specific violation message.
- Cross-link the new governance document from `POLICY_SEED.md` and make loop declarations normative in `CONTRIBUTING.md`, and bump the `doc_revision` fields accordingly.
- Add unit tests `tests/test_docflow_governance_control_loops.py` covering the missing-loop violation and the satisfied (all-domains-declared) case.

### Testing
- Ran the new unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_docflow_governance_control_loops.py tests/test_docflow_sppf_gh_refs.py` and all tests passed (6 passed).
- Ran `PYTHONPATH=src python -m gabion docflow --sppf-gh-ref-mode advisory` to exercise docflow end-to-end; this reported pre-existing GH-reference/remote-ref issues in this execution environment (missing `origin/stage`) that are unrelated to the new invariant, so docflow execution failed for environmental reasons rather than because of the change.
- Note: `mise exec -- python` validation was not used here because `mise.toml` is not trusted in this environment; local validation used `PYTHONPATH=src` instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c69bb6ae08324a2a7532081a6a426)