### PR TITLE
Add controller-drift detection, audit scripts, PR-template enforcement, and CI advisory gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+- Describe the change.
+
+## Validation
+- List checks/tests run.
+
+## Governance (required for governance/tooling changes)
+- controller impact: <!-- required when touching governance/tooling; describe impacted controller anchors/sensors -->
+- loop updated?: <!-- yes/no; if yes explain what enforcement/reporting loop changed -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,15 @@ jobs:
         run: .venv/bin/python scripts/branchless_policy_check.py --root .
       - name: Policy check (defensive fallback)
         run: .venv/bin/python scripts/defensive_fallback_policy_check.py --root .
+      - name: Controller drift audit (advisory, ratchet-ready)
+        env:
+          CONTROLLER_DRIFT_FAIL_ON: ${{ vars.CONTROLLER_DRIFT_FAIL_ON || '' }}
+        run: |
+          args=(--out artifacts/out/controller_drift.json)
+          if [ -n "${CONTROLLER_DRIFT_FAIL_ON:-}" ]; then
+            args+=(--fail-on-severity "$CONTROLLER_DRIFT_FAIL_ON")
+          fi
+          .venv/bin/python scripts/governance_controller_audit.py "${args[@]}"
       - name: Tests
         run: |
           mkdir -p artifacts/test_runs

--- a/.github/workflows/pr-dataflow-grammar.yml
+++ b/.github/workflows/pr-dataflow-grammar.yml
@@ -96,6 +96,14 @@ jobs:
         run: mise exec -- python scripts/branchless_policy_check.py --root .
       - name: Policy check (defensive fallback)
         run: mise exec -- python scripts/defensive_fallback_policy_check.py --root .
+      - name: Governance PR template fields
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: mise exec -- python scripts/check_pr_governance_template.py
+      - name: Controller drift audit (advisory)
+        run: mise exec -- python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json
       - name: Select impacted tests
         env:
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 96
+doc_revision: 97
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -174,6 +174,8 @@ When sortedness is enforced, it must be treated as part of semantic behavior.
 - [ ] Confirm each ordered carrier consumes active sorting at most once, and
       that egress paths enforce order without serializer `sort_keys=True`
       fallback for canonical carriers.
+- [ ] For governance/tooling changes, include PR template fields `controller impact`
+      and `loop updated?`, and describe any controller-drift sensor/anchor changes.
 
 ## Branching model (normative)
 - Routine work goes to `stage`; CI runs on every `stage` push and must be green.

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 41
+doc_revision: 42
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -34,7 +34,7 @@ doc_review_notes:
   docs/coverage_semantics.md#coverage_semantics: "Reviewed docs/coverage_semantics.md#coverage_semantics v1 (glossary-lifted projection + explicit core anchors); policy references remain accurate."
 doc_sections:
   policy_seed: 1
-  change_protocol: 1
+  change_protocol: 2
 doc_section_requires:
   policy_seed:
     - README.md#repo_contract
@@ -656,6 +656,43 @@ Any proposed change to this file must:
    * how regressions are prevented.
 
 Repo-native agents must **refuse** to auto-apply changes that weaken this file.
+
+### 6.4 Controller Drift (Normative)
+
+Controller drift is any mismatch between governance text and enforcement code.
+This control loop MUST continuously detect and resolve drift.
+
+**Detection cycle (normative):**
+- Run `mise exec -- python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json`.
+- Emit a machine-readable report at `artifacts/out/controller_drift.json`.
+- Treat detected drift as policy-relevant evidence and surface it in CI logs.
+
+**Resolution cycle (normative):**
+1. If normative text has no enforcement, add/update the enforcing check before merge.
+2. If a check has no normative anchor, add an explicit anchor in governance docs or remove the orphaned check.
+3. If anchors contradict across normative docs, reconcile docs in one change-set and restamp review notes.
+4. If command references are stale, update both docs and automation in the same change-set.
+
+**Second-order sensors (normative):**
+- Policy clauses with no enforcing check.
+- Checks with no normative anchor.
+- Contradictory anchors across normative docs.
+- Stale command references (e.g. renamed CLI/script entry points).
+
+**Controller registry (machine-readable markers):**
+- `controller-anchor: CD-001 | doc: POLICY_SEED.md#change_protocol | sensor: policy_clauses_without_enforcing_check | check: scripts/governance_controller_audit.py | severity: high`
+- `controller-anchor: CD-002 | doc: POLICY_SEED.md#change_protocol | sensor: checks_without_normative_anchor | check: scripts/governance_controller_audit.py | severity: high`
+- `controller-anchor: CD-003 | doc: POLICY_SEED.md#change_protocol | sensor: contradictory_anchors_across_normative_docs | check: scripts/governance_controller_audit.py | severity: high`
+- `controller-anchor: CD-004 | doc: POLICY_SEED.md#change_protocol | sensor: stale_command_references | check: scripts/governance_controller_audit.py | severity: medium`
+
+**Controller command references (machine-readable markers):**
+- `controller-command: mise exec -- python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json`
+- `controller-command: mise exec -- python scripts/check_pr_governance_template.py`
+
+**CI ratchet policy (normative):**
+- Phase A (advisory): report high-severity drift but do not fail the pipeline.
+- Phase B (ratcheted): fail CI on any high-severity drift.
+- Ratchet enablement MUST be explicit (CI flag or workflow change); silent ratchets are forbidden.
 
 ---
 

--- a/scripts/check_pr_governance_template.py
+++ b/scripts/check_pr_governance_template.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Require governance PR template fields when governance/tooling files change."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIELD_LABELS = ("controller impact", "loop updated?")
+GOVERNANCE_PATH_PREFIXES = (
+    "POLICY_SEED.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "AGENTS.md",
+    "glossary.md",
+    ".github/workflows/",
+    ".github/actions/",
+    "scripts/",
+)
+
+
+def _changed_files(base: str, head: str) -> list[str]:
+    cmd = ["git", "diff", "--name-only", f"{base}..{head}"]
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, check=True, text=True, capture_output=True)
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _is_governance_change(path: str) -> bool:
+    return any(path == prefix or path.startswith(prefix) for prefix in GOVERNANCE_PATH_PREFIXES)
+
+
+def _body_has_required_fields(body: str) -> tuple[bool, list[str]]:
+    missing: list[str] = []
+    lower = body.lower()
+    for label in FIELD_LABELS:
+        pattern = re.compile(rf"(^|\n)\s*[-*]?\s*{re.escape(label)}\s*:", re.IGNORECASE)
+        if not pattern.search(lower):
+            missing.append(label)
+    return (len(missing) == 0), missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.getenv("GITHUB_BASE_SHA", ""))
+    parser.add_argument("--head", default=os.getenv("GITHUB_HEAD_SHA", ""))
+    parser.add_argument("--body-file", type=Path, default=None)
+    args = parser.parse_args()
+
+    if not args.base or not args.head:
+        print("pr-template-check: missing base/head SHA; skipping.")
+        return 0
+
+    changed = _changed_files(args.base, args.head)
+    if not any(_is_governance_change(path) for path in changed):
+        print("pr-template-check: no governance/tooling changes detected; skipping.")
+        return 0
+
+    if args.body_file is not None and args.body_file.exists():
+        body = args.body_file.read_text(encoding="utf-8")
+    else:
+        body = os.getenv("PR_BODY", "")
+
+    ok, missing = _body_has_required_fields(body)
+    if ok:
+        print("pr-template-check: required governance fields present.")
+        return 0
+
+    print(
+        "pr-template-check: governance/tooling changes require PR fields: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a self-stabilizing control loop to detect and resolve mismatches between normative governance text and enforcement scripts (controller drift). 
- Surface second-order drift sensors (policy clauses without checks, checks without anchors, contradictory anchors, stale command refs) as machine-readable evidence and make CI ratchetable from advisory → fail-on-high-severity.

### Description
- Add a `controller_drift` subsection to `POLICY_SEED.md#change_protocol` that defines the detection/resolution cycle, enumerates second-order sensors, and records machine-readable controller-anchor/command markers and a CI ratchet policy. 
- Implement `scripts/governance_controller_audit.py` to scan normative docs and workflows, evaluate the four sensors, and emit `artifacts/out/controller_drift.json` (supports `--fail-on-severity`).
- Implement `scripts/check_pr_governance_template.py` to require PR fields `controller impact` and `loop updated?` when governance/tooling paths change, and add `.github/pull_request_template.md` with the required governance fields.
- Wire CI and PR workflows to run the audit and template checks: `ci.yml` runs an advisory/ratchet-ready controller-drift audit (controlled by `CONTROLLER_DRIFT_FAIL_ON`), and `pr-dataflow-grammar.yml` runs the governance PR template check and advisory audit; update `CONTRIBUTING.md` and bump `POLICY_SEED.md`/`CONTRIBUTING.md` revisions accordingly.

### Testing
- Ran the audit end-to-end with `mise exec -- python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json`, which produced `artifacts/out/controller_drift.json` (report present) and returned success in advisory mode while emitting a `mise` tool-resolution warning in this environment.
- Exercised the PR-template check with `GITHUB_BASE_SHA=$(git rev-parse HEAD~1) GITHUB_HEAD_SHA=$(git rev-parse HEAD) PR_BODY=$'controller impact: ...\nloop updated?: yes' mise exec -- python scripts/check_pr_governance_template.py` which passed, and with `PR_BODY='no fields here'` which produced the expected non-zero exit (`EXIT:2`).
- Verified both scripts compile with `python -m py_compile scripts/governance_controller_audit.py scripts/check_pr_governance_template.py` (success).
- The CI wiring was updated to run the audit in advisory mode by default and can be ratcheted to fail on high-severity findings via the `CONTROLLER_DRIFT_FAIL_ON` workflow variable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c69c87064832498beae7b19fe8d26)