### PR TITLE
Introduce governance_rules.yaml and policy-driven baseline/delta gating

### DIFF
--- a/docs/governance_control_loops.md
+++ b/docs/governance_control_loops.md
@@ -1,0 +1,52 @@
+---
+doc_revision: 1
+doc_id: governance_control_loops
+doc_role: governance
+doc_scope:
+  - repo
+  - policy
+  - tooling
+doc_authority: normative
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_owner: maintainer
+---
+
+# Governance control loops
+
+This document defines correction modes and transition criteria for baseline and delta governance loops.
+
+## Correction modes
+
+- `advisory`: emit diagnostics and summary only; do not block execution.
+- `ratchet`: allow bounded movement only toward tighter policy; block regressions.
+- `hard-fail`: block any blocking-threshold regression immediately.
+
+## Transition criteria
+
+Each loop transitions using `warning_threshold` and `blocking_threshold` values from `docs/governance_rules.yaml`:
+
+1. `advisory -> ratchet` when warning-threshold events recur and no override token is recorded.
+2. `ratchet -> hard-fail` when blocking-threshold events recur under ratchet mode.
+3. `hard-fail -> ratchet|advisory` only with an explicit policy override token and an annotated rationale in the change artifact.
+
+## Bounded-step correction rules
+
+Baseline updates are bounded by these invariants:
+
+1. Baseline writes require explicit `--write-*` flags.
+2. Strictness cannot be reduced unless both are present:
+   - an explicit policy override token (`GABION_POLICY_OVERRIDE_TOKEN`), and
+   - an annotated rationale (`GABION_POLICY_OVERRIDE_RATIONALE`).
+3. Delta gates use shared severity mapping from `docs/governance_rules.yaml`; ad-hoc threshold branching is prohibited.
+
+## Loop table
+
+| Loop | Correction mode | Warning threshold | Blocking threshold |
+| --- | --- | --- | --- |
+| obsolescence opaque | hard-fail | 0 | 1 |
+| obsolescence unmapped | ratchet | 0 | 1 |
+| annotation orphaned | ratchet | 0 | 1 |
+| ambiguity total | hard-fail | 0 | 1 |
+| docflow contradictions | advisory | 0 | 1 |
+
+The source of truth for loop thresholds, mode defaults, and transitions is `docs/governance_rules.yaml`.

--- a/docs/governance_rules.yaml
+++ b/docs/governance_rules.yaml
@@ -1,0 +1,113 @@
+version: 1
+override_token_env: GABION_POLICY_OVERRIDE_TOKEN
+gates:
+  obsolescence_opaque:
+    env_flag: GABION_GATE_OPAQUE_DELTA
+    enabled_mode: default_true
+    delta_keys: [summary, opaque_evidence, delta]
+    before_keys: [summary, opaque_evidence, baseline]
+    after_keys: [summary, opaque_evidence, current]
+    severity:
+      warning_threshold: 0
+      blocking_threshold: 1
+    correction:
+      mode: hard-fail
+      transitions: [advisory->ratchet, ratchet->hard-fail]
+      bounded_steps:
+        - baseline_write_requires_explicit_flag
+        - strictness_reduction_requires_override_token_and_rationale
+    disabled_message: Opaque obsolescence gate disabled by override; set GABION_GATE_OPAQUE_DELTA=1 to enforce.
+    missing_message: Test obsolescence delta missing; gate failed.
+    unreadable_message: Test obsolescence delta unreadable; gate failed.
+    warning_prefix: Opaque evidence delta warning
+    blocking_prefix: Opaque evidence delta increased
+    ok_prefix: Opaque evidence delta OK
+
+  obsolescence_unmapped:
+    env_flag: GABION_GATE_UNMAPPED_DELTA
+    enabled_mode: default_true
+    delta_keys: [summary, counts, delta, unmapped]
+    before_keys: [summary, counts, baseline, unmapped]
+    after_keys: [summary, counts, current, unmapped]
+    severity:
+      warning_threshold: 0
+      blocking_threshold: 1
+    correction:
+      mode: ratchet
+      transitions: [advisory->ratchet, ratchet->hard-fail]
+      bounded_steps:
+        - baseline_write_requires_explicit_flag
+        - strictness_reduction_requires_override_token_and_rationale
+    disabled_message: Unmapped delta gate disabled by override; set GABION_GATE_UNMAPPED_DELTA=1 to enforce.
+    missing_message: Test obsolescence delta missing; gate failed.
+    unreadable_message: Test obsolescence delta unreadable; gate failed.
+    warning_prefix: Unmapped evidence delta warning
+    blocking_prefix: Unmapped evidence delta increased
+    ok_prefix: Unmapped evidence delta OK
+
+  annotation_orphaned:
+    env_flag: GABION_GATE_ORPHANED_DELTA
+    enabled_mode: default_true
+    delta_keys: [summary, delta, orphaned]
+    before_keys: [summary, baseline, orphaned]
+    after_keys: [summary, current, orphaned]
+    severity:
+      warning_threshold: 0
+      blocking_threshold: 1
+    correction:
+      mode: ratchet
+      transitions: [advisory->ratchet, ratchet->hard-fail]
+      bounded_steps:
+        - baseline_write_requires_explicit_flag
+        - strictness_reduction_requires_override_token_and_rationale
+    disabled_message: Annotation drift gate disabled by override; set GABION_GATE_ORPHANED_DELTA=1 to enforce.
+    missing_message: Annotation drift delta missing; gate failed.
+    unreadable_message: Annotation drift delta unreadable; gate failed.
+    warning_prefix: Orphaned annotation delta warning
+    blocking_prefix: Orphaned annotation delta increased
+    ok_prefix: Orphaned annotation delta OK
+
+  ambiguity:
+    env_flag: GABION_GATE_AMBIGUITY_DELTA
+    enabled_mode: default_true
+    delta_keys: [summary, total, delta]
+    before_keys: [summary, total, baseline]
+    after_keys: [summary, total, current]
+    severity:
+      warning_threshold: 0
+      blocking_threshold: 1
+    correction:
+      mode: hard-fail
+      transitions: [advisory->ratchet, ratchet->hard-fail]
+      bounded_steps:
+        - baseline_write_requires_explicit_flag
+        - strictness_reduction_requires_override_token_and_rationale
+    disabled_message: Ambiguity delta gate disabled by override; set GABION_GATE_AMBIGUITY_DELTA=1 to enforce.
+    missing_message: Ambiguity delta missing; gate failed.
+    unreadable_message: Ambiguity delta unreadable; gate failed.
+    warning_prefix: Ambiguity delta warning
+    blocking_prefix: Ambiguity delta increased
+    ok_prefix: Ambiguity delta OK
+
+  docflow:
+    env_flag: GABION_GATE_DOCFLOW_DELTA
+    enabled_mode: truthy_only
+    delta_keys: [summary, delta, contradicts]
+    before_keys: [summary, baseline, contradicts]
+    after_keys: [summary, current, contradicts]
+    baseline_missing_key: [baseline_missing]
+    severity:
+      warning_threshold: 0
+      blocking_threshold: 1
+    correction:
+      mode: advisory
+      transitions: [advisory->ratchet]
+      bounded_steps:
+        - baseline_write_requires_explicit_flag
+        - strictness_reduction_requires_override_token_and_rationale
+    disabled_message: Docflow delta gate disabled; set GABION_GATE_DOCFLOW_DELTA=1 to enable.
+    missing_message: Docflow delta missing; gate skipped.
+    unreadable_message: Docflow delta unreadable; gate skipped.
+    warning_prefix: Docflow contradictions warning
+    blocking_prefix: Docflow contradictions increased
+    ok_prefix: Docflow delta OK

--- a/src/gabion/tooling/delta_gate.py
+++ b/src/gabion/tooling/delta_gate.py
@@ -138,7 +138,7 @@ def _check_standard_gate(
         after = _nested_int(payload, spec.after_keys)
         print(f"{spec.blocking_prefix}: {before} -> {after} (+{delta_value}).")
         return 1
-    if delta_value > gate_policy.severity.warning_threshold:
+    if delta_value >= gate_policy.severity.warning_threshold:
         before = _nested_int(payload, spec.before_keys)
         after = _nested_int(payload, spec.after_keys)
         print(f"{spec.warning_prefix}: {before} -> {after} (+{delta_value}).")

--- a/src/gabion/tooling/delta_gate.py
+++ b/src/gabion/tooling/delta_gate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Mapping
 
 from gabion.runtime import env_policy, json_io
+from gabion.tooling.governance_rules import GatePolicy, load_governance_rules
 
 OBSOLESCENCE_OPAQUE_ENV_FLAG = "GABION_GATE_OPAQUE_DELTA"
 OBSOLESCENCE_UNMAPPED_ENV_FLAG = "GABION_GATE_UNMAPPED_DELTA"
@@ -28,69 +29,31 @@ class StandardGateSpec:
     delta_keys: tuple[str, ...]
     before_keys: tuple[str, ...]
     after_keys: tuple[str, ...]
-    increased_prefix: str
+    warning_prefix: str
+    blocking_prefix: str
     ok_prefix: str
 
 
-_OBSOLESCENCE_OPAQUE_SPEC = StandardGateSpec(
-    env_flag=OBSOLESCENCE_OPAQUE_ENV_FLAG,
-    disabled_message=(
-        "Opaque obsolescence gate disabled by override; "
-        f"set {OBSOLESCENCE_OPAQUE_ENV_FLAG}=1 to enforce."
-    ),
-    missing_message="Test obsolescence delta missing; gate failed.",
-    unreadable_message="Test obsolescence delta unreadable; gate failed.",
-    delta_keys=("summary", "opaque_evidence", "delta"),
-    before_keys=("summary", "opaque_evidence", "baseline"),
-    after_keys=("summary", "opaque_evidence", "current"),
-    increased_prefix="Opaque evidence delta increased",
-    ok_prefix="Opaque evidence delta OK",
-)
+def _standard_spec_from_policy(policy: GatePolicy) -> StandardGateSpec:
+    return StandardGateSpec(
+        env_flag=policy.env_flag,
+        disabled_message=policy.disabled_message,
+        missing_message=policy.missing_message,
+        unreadable_message=policy.unreadable_message,
+        delta_keys=policy.delta_keys,
+        before_keys=policy.before_keys,
+        after_keys=policy.after_keys,
+        warning_prefix=policy.warning_prefix,
+        blocking_prefix=policy.blocking_prefix,
+        ok_prefix=policy.ok_prefix,
+    )
 
-_OBSOLESCENCE_UNMAPPED_SPEC = StandardGateSpec(
-    env_flag=OBSOLESCENCE_UNMAPPED_ENV_FLAG,
-    disabled_message=(
-        "Unmapped delta gate disabled by override; "
-        f"set {OBSOLESCENCE_UNMAPPED_ENV_FLAG}=1 to enforce."
-    ),
-    missing_message="Test obsolescence delta missing; gate failed.",
-    unreadable_message="Test obsolescence delta unreadable; gate failed.",
-    delta_keys=("summary", "counts", "delta", "unmapped"),
-    before_keys=("summary", "counts", "baseline", "unmapped"),
-    after_keys=("summary", "counts", "current", "unmapped"),
-    increased_prefix="Unmapped evidence delta increased",
-    ok_prefix="Unmapped evidence delta OK",
-)
 
-_ANNOTATION_ORPHANED_SPEC = StandardGateSpec(
-    env_flag=ANNOTATION_ORPHANED_ENV_FLAG,
-    disabled_message=(
-        "Annotation drift gate disabled by override; "
-        f"set {ANNOTATION_ORPHANED_ENV_FLAG}=1 to enforce."
-    ),
-    missing_message="Annotation drift delta missing; gate failed.",
-    unreadable_message="Annotation drift delta unreadable; gate failed.",
-    delta_keys=("summary", "delta", "orphaned"),
-    before_keys=("summary", "baseline", "orphaned"),
-    after_keys=("summary", "current", "orphaned"),
-    increased_prefix="Orphaned annotation delta increased",
-    ok_prefix="Orphaned annotation delta OK",
-)
-
-_AMBIGUITY_SPEC = StandardGateSpec(
-    env_flag=AMBIGUITY_DELTA_ENV_FLAG,
-    disabled_message=(
-        "Ambiguity delta gate disabled by override; "
-        f"set {AMBIGUITY_DELTA_ENV_FLAG}=1 to enforce."
-    ),
-    missing_message="Ambiguity delta missing; gate failed.",
-    unreadable_message="Ambiguity delta unreadable; gate failed.",
-    delta_keys=("summary", "total", "delta"),
-    before_keys=("summary", "total", "baseline"),
-    after_keys=("summary", "total", "current"),
-    increased_prefix="Ambiguity delta increased",
-    ok_prefix="Ambiguity delta OK",
-)
+def _policy_spec(gate_id: str) -> StandardGateSpec:
+    policy = load_governance_rules().gates.get(gate_id)
+    if policy is None:
+        raise ValueError(f"governance policy missing gate: {gate_id}")
+    return _standard_spec_from_policy(policy)
 
 
 def _enabled_default_true(env_flag: str, value: str | None = None) -> bool:
@@ -134,6 +97,20 @@ def _load_payload(path: Path) -> tuple[Mapping[str, object] | None, str | None]:
     return None, None
 
 
+def _gate_id_for_env_flag(env_flag: str) -> str:
+    mapping = {
+        OBSOLESCENCE_OPAQUE_ENV_FLAG: "obsolescence_opaque",
+        OBSOLESCENCE_UNMAPPED_ENV_FLAG: "obsolescence_unmapped",
+        ANNOTATION_ORPHANED_ENV_FLAG: "annotation_orphaned",
+        AMBIGUITY_DELTA_ENV_FLAG: "ambiguity",
+        DOCFLOW_DELTA_ENV_FLAG: "docflow",
+    }
+    gate_id = mapping.get(env_flag)
+    if gate_id is None:
+        raise ValueError(f"unsupported env flag for governance mapping: {env_flag}")
+    return gate_id
+
+
 def _check_standard_gate(
     spec: StandardGateSpec,
     path: Path,
@@ -154,12 +131,18 @@ def _check_standard_gate(
         else:
             print(spec.unreadable_message)
         return 2
+    gate_policy = load_governance_rules().gates[_gate_id_for_env_flag(spec.env_flag)]
     delta_value = _nested_int(payload, spec.delta_keys)
-    if delta_value > 0:
+    if delta_value >= gate_policy.severity.blocking_threshold:
         before = _nested_int(payload, spec.before_keys)
         after = _nested_int(payload, spec.after_keys)
-        print(f"{spec.increased_prefix}: {before} -> {after} (+{delta_value}).")
+        print(f"{spec.blocking_prefix}: {before} -> {after} (+{delta_value}).")
         return 1
+    if delta_value > gate_policy.severity.warning_threshold:
+        before = _nested_int(payload, spec.before_keys)
+        after = _nested_int(payload, spec.after_keys)
+        print(f"{spec.warning_prefix}: {before} -> {after} (+{delta_value}).")
+        return 0
     print(f"{spec.ok_prefix} ({delta_value}).")
     return 0
 
@@ -185,19 +168,19 @@ def docflow_enabled(value: str | None = None) -> bool:
 
 
 def obsolescence_opaque_delta_value(payload: Mapping[str, object]) -> int:
-    return _nested_int(payload, _OBSOLESCENCE_OPAQUE_SPEC.delta_keys)
+    return _nested_int(payload, _policy_spec("obsolescence_opaque").delta_keys)
 
 
 def obsolescence_unmapped_delta_value(payload: Mapping[str, object]) -> int:
-    return _nested_int(payload, _OBSOLESCENCE_UNMAPPED_SPEC.delta_keys)
+    return _nested_int(payload, _policy_spec("obsolescence_unmapped").delta_keys)
 
 
 def annotation_orphaned_delta_value(payload: Mapping[str, object]) -> int:
-    return _nested_int(payload, _ANNOTATION_ORPHANED_SPEC.delta_keys)
+    return _nested_int(payload, _policy_spec("annotation_orphaned").delta_keys)
 
 
 def ambiguity_delta_value(payload: Mapping[str, object]) -> int:
-    return _nested_int(payload, _AMBIGUITY_SPEC.delta_keys)
+    return _nested_int(payload, _policy_spec("ambiguity").delta_keys)
 
 
 def docflow_delta_value(payload: Mapping[str, object], key: str) -> int:
@@ -205,35 +188,36 @@ def docflow_delta_value(payload: Mapping[str, object], key: str) -> int:
 
 
 def check_obsolescence_opaque_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return _check_standard_gate(_OBSOLESCENCE_OPAQUE_SPEC, path, enabled=enabled)
+    return _check_standard_gate(_policy_spec("obsolescence_opaque"), path, enabled=enabled)
 
 
 def check_obsolescence_unmapped_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return _check_standard_gate(_OBSOLESCENCE_UNMAPPED_SPEC, path, enabled=enabled)
+    return _check_standard_gate(_policy_spec("obsolescence_unmapped"), path, enabled=enabled)
 
 
 def check_annotation_orphaned_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return _check_standard_gate(_ANNOTATION_ORPHANED_SPEC, path, enabled=enabled)
+    return _check_standard_gate(_policy_spec("annotation_orphaned"), path, enabled=enabled)
 
 
 def check_ambiguity_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return _check_standard_gate(_AMBIGUITY_SPEC, path, enabled=enabled)
+    return _check_standard_gate(_policy_spec("ambiguity"), path, enabled=enabled)
 
 
 def check_docflow_gate(path: Path, *, enabled: bool | None = None) -> int:
+    policy = load_governance_rules().gates["docflow"]
     gate_enabled = docflow_enabled() if enabled is None else enabled
     if not gate_enabled:
-        print(f"Docflow delta gate disabled; set {DOCFLOW_DELTA_ENV_FLAG}=1 to enable.")
+        print(policy.disabled_message)
         return 0
     if not path.exists():
-        print("Docflow delta missing; gate skipped.")
+        print(policy.missing_message)
         return 0
     payload, decode_error = _load_payload(path)
     if payload is None:
         if isinstance(decode_error, str) and decode_error:
-            print(f"Docflow delta unreadable; gate skipped: {decode_error}")
+            print(f"{policy.unreadable_message}: {decode_error}")
         else:
-            print("Docflow delta unreadable; gate skipped.")
+            print(policy.unreadable_message)
         return 0
     baseline_missing = bool(payload.get("baseline_missing"))
     if baseline_missing:
@@ -242,16 +226,16 @@ def check_docflow_gate(path: Path, *, enabled: bool | None = None) -> int:
     contradicts_delta = docflow_delta_value(payload, "contradicts")
     excess_delta = docflow_delta_value(payload, "excess")
     proposed_delta = docflow_delta_value(payload, "proposed")
-    if contradicts_delta > 0:
+    if contradicts_delta >= policy.severity.blocking_threshold:
         before = _nested_int(payload, ("summary", "baseline", "contradicts"))
         after = _nested_int(payload, ("summary", "current", "contradicts"))
         print(
-            "Docflow contradictions increased: "
+            f"{policy.blocking_prefix}: "
             f"{before} -> {after} (+{contradicts_delta})."
         )
         return 1
     print(
-        "Docflow delta OK "
+        f"{policy.ok_prefix} "
         f"(contradicts {contradicts_delta}, excess {excess_delta}, proposed {proposed_delta})."
     )
     return 0

--- a/src/gabion/tooling/governance_rules.py
+++ b/src/gabion/tooling/governance_rules.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Mapping
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dependency is pinned in pyproject
+    yaml = None
+
+
+@dataclass(frozen=True)
+class SeverityPolicy:
+    warning_threshold: int
+    blocking_threshold: int
+
+
+@dataclass(frozen=True)
+class CorrectionPolicy:
+    mode: str
+    transitions: tuple[str, ...]
+    bounded_steps: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GatePolicy:
+    gate_id: str
+    env_flag: str
+    enabled_mode: str
+    delta_keys: tuple[str, ...]
+    before_keys: tuple[str, ...]
+    after_keys: tuple[str, ...]
+    baseline_missing_key: tuple[str, ...] | None
+    severity: SeverityPolicy
+    correction: CorrectionPolicy
+    disabled_message: str
+    missing_message: str
+    unreadable_message: str
+    warning_prefix: str
+    blocking_prefix: str
+    ok_prefix: str
+
+
+@dataclass(frozen=True)
+class GovernanceRules:
+    override_token_env: str
+    gates: Mapping[str, GatePolicy]
+
+
+def _yaml_loader():
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load docs/governance_rules.yaml")
+
+    class Loader(yaml.SafeLoader):
+        pass
+
+    for key, values in list(Loader.yaml_implicit_resolvers.items()):
+        Loader.yaml_implicit_resolvers[key] = [
+            (tag, regexp) for tag, regexp in values if tag != "tag:yaml.org,2002:bool"
+        ]
+    return Loader
+
+
+def _tuple_path(raw: object, *, field_name: str) -> tuple[str, ...]:
+    if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+        raise ValueError(f"governance_rules invalid {field_name}: expected list[str]")
+    return tuple(raw)
+
+
+def _as_int(raw: object, *, field_name: str) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"governance_rules invalid {field_name}: expected int") from exc
+
+
+def _gate_from_mapping(gate_id: str, payload: Mapping[str, object]) -> GatePolicy:
+    severity_raw = payload.get("severity")
+    if not isinstance(severity_raw, Mapping):
+        raise ValueError(f"governance_rules invalid gates.{gate_id}.severity")
+    correction_raw = payload.get("correction")
+    if not isinstance(correction_raw, Mapping):
+        raise ValueError(f"governance_rules invalid gates.{gate_id}.correction")
+
+    baseline_missing_value = payload.get("baseline_missing_key")
+    baseline_missing_key = None
+    if isinstance(baseline_missing_value, list):
+        baseline_missing_key = _tuple_path(
+            baseline_missing_value,
+            field_name=f"gates.{gate_id}.baseline_missing_key",
+        )
+
+    mode = correction_raw.get("mode")
+    if not isinstance(mode, str):
+        raise ValueError(f"governance_rules invalid gates.{gate_id}.correction.mode")
+
+    transitions = correction_raw.get("transitions")
+    if not isinstance(transitions, list) or any(not isinstance(item, str) for item in transitions):
+        raise ValueError(f"governance_rules invalid gates.{gate_id}.correction.transitions")
+
+    bounded_steps = correction_raw.get("bounded_steps")
+    if not isinstance(bounded_steps, list) or any(not isinstance(item, str) for item in bounded_steps):
+        raise ValueError(f"governance_rules invalid gates.{gate_id}.correction.bounded_steps")
+
+    return GatePolicy(
+        gate_id=gate_id,
+        env_flag=str(payload.get("env_flag", "")),
+        enabled_mode=str(payload.get("enabled_mode", "default_true")),
+        delta_keys=_tuple_path(payload.get("delta_keys"), field_name=f"gates.{gate_id}.delta_keys"),
+        before_keys=_tuple_path(payload.get("before_keys"), field_name=f"gates.{gate_id}.before_keys"),
+        after_keys=_tuple_path(payload.get("after_keys"), field_name=f"gates.{gate_id}.after_keys"),
+        baseline_missing_key=baseline_missing_key,
+        severity=SeverityPolicy(
+            warning_threshold=_as_int(
+                severity_raw.get("warning_threshold"),
+                field_name=f"gates.{gate_id}.severity.warning_threshold",
+            ),
+            blocking_threshold=_as_int(
+                severity_raw.get("blocking_threshold"),
+                field_name=f"gates.{gate_id}.severity.blocking_threshold",
+            ),
+        ),
+        correction=CorrectionPolicy(
+            mode=mode,
+            transitions=tuple(transitions),
+            bounded_steps=tuple(bounded_steps),
+        ),
+        disabled_message=str(payload.get("disabled_message", "Gate disabled by policy override.")),
+        missing_message=str(payload.get("missing_message", "Delta payload missing; gate failed.")),
+        unreadable_message=str(payload.get("unreadable_message", "Delta payload unreadable; gate failed.")),
+        warning_prefix=str(payload.get("warning_prefix", "Delta warning")),
+        blocking_prefix=str(payload.get("blocking_prefix", "Delta blocking")),
+        ok_prefix=str(payload.get("ok_prefix", "Delta OK")),
+    )
+
+
+@lru_cache(maxsize=1)
+def load_governance_rules(path: Path | None = None) -> GovernanceRules:
+    default_path = Path(__file__).resolve().parents[3] / "docs" / "governance_rules.yaml"
+    rule_path = default_path if path is None else path
+    loader = _yaml_loader()
+    with rule_path.open("r", encoding="utf-8") as handle:
+        raw = yaml.load(handle, Loader=loader) or {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("governance_rules root must be a mapping")
+
+    gates_raw = raw.get("gates")
+    if not isinstance(gates_raw, Mapping):
+        raise ValueError("governance_rules must define gates")
+
+    gates: dict[str, GatePolicy] = {}
+    for gate_id, gate_payload in gates_raw.items():
+        if isinstance(gate_id, str) and isinstance(gate_payload, Mapping):
+            gates[gate_id] = _gate_from_mapping(gate_id, gate_payload)
+
+    return GovernanceRules(
+        override_token_env=str(raw.get("override_token_env", "GABION_POLICY_OVERRIDE_TOKEN")),
+        gates=gates,
+    )

--- a/tests/test_governance_rules_policy.py
+++ b/tests/test_governance_rules_policy.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from gabion.tooling import governance_rules
+
+
+# gabion:evidence E:function_site::tests/test_governance_rules_policy.py::test_governance_rules_define_required_gates
+def test_governance_rules_define_required_gates() -> None:
+    rules = governance_rules.load_governance_rules()
+    assert {"obsolescence_opaque", "obsolescence_unmapped", "annotation_orphaned", "ambiguity", "docflow"}.issubset(rules.gates)
+
+
+# gabion:evidence E:function_site::tests/test_governance_rules_policy.py::test_governance_severity_thresholds_are_monotonic
+def test_governance_severity_thresholds_are_monotonic() -> None:
+    rules = governance_rules.load_governance_rules()
+    for policy in rules.gates.values():
+        assert policy.severity.warning_threshold <= policy.severity.blocking_threshold
+        assert policy.correction.transitions
+        assert "baseline_write_requires_explicit_flag" in policy.correction.bounded_steps

--- a/tests/test_refresh_baselines.py
+++ b/tests/test_refresh_baselines.py
@@ -107,3 +107,29 @@ def test_main_uses_cli_timeout_overrides_for_refresh_operations() -> None:
     assert captured
     assert captured[0].ticks == 222
     assert captured[0].tick_ns == 333
+
+
+# gabion:evidence E:function_site::tests/test_refresh_baselines.py::test_requires_block_is_monotonic_without_override
+def test_requires_block_is_monotonic_without_override() -> None:
+    module = _load_refresh_baselines()
+    with _env_scope(
+        {
+            "GABION_POLICY_OVERRIDE_TOKEN": None,
+            "GABION_POLICY_OVERRIDE_RATIONALE": None,
+        }
+    ):
+        assert module._requires_block("obsolescence_opaque", 0) is False
+        assert module._requires_block("obsolescence_opaque", 1) is True
+        assert module._requires_block("obsolescence_opaque", 2) is True
+
+
+# gabion:evidence E:function_site::tests/test_refresh_baselines.py::test_requires_block_allows_override_token_with_rationale
+def test_requires_block_allows_override_token_with_rationale() -> None:
+    module = _load_refresh_baselines()
+    with _env_scope(
+        {
+            "GABION_POLICY_OVERRIDE_TOKEN": "policy-override-123",
+            "GABION_POLICY_OVERRIDE_RATIONALE": "temporary strictness reduction for controlled migration",
+        }
+    ):
+        assert module._requires_block("obsolescence_opaque", 1) is False


### PR DESCRIPTION
### Motivation

- Provide a shared, auditable registry for severity → action mappings and explicit correction modes (`advisory`, `ratchet`, `hard-fail`) so delta gates and baseline refreshes follow a single source of truth.
- Bound baseline-write and strictness-change steps to explicit rules (explicit `--write-*` flags and override token + rationale) to prevent accidental reductions in policy strictness.
- Replace ad-hoc threshold branching in refresh and gate tooling with policy-driven decisions so transitions and actions are mechanized and easier to review.

### Description

- Add `docs/governance_control_loops.md` describing correction modes, transition criteria, and bounded-step baseline rules.  
- Add `docs/governance_rules.yaml` as the shared severity/action registry defining per-loop `warning_threshold` / `blocking_threshold`, `correction` metadata, and messages.  
- Add `src/gabion/tooling/governance_rules.py` to load and validate the YAML registry into typed dataclasses (`GatePolicy`, `SeverityPolicy`, `CorrectionPolicy`).  
- Refactor `src/gabion/tooling/delta_gate.py` to consume registry-backed specs and severity thresholds and to emit warning vs blocking outputs per policy instead of hard-coded branching.  
- Update `scripts/refresh_baselines.py` to consult the policy registry for gate enablement and blocking decisions and to require an explicit override token + rationale to suppress blocking behavior for strictness reductions.  
- Add tests: `tests/test_governance_rules_policy.py` and extensions to `tests/test_refresh_baselines.py` to assert registry shape, monotonic severity thresholds, and override-token behavior.

### Testing

- Attempted CI-style runs via `mise exec` failed in this environment due to local `mise.toml` trust/resolution and pinned interpreter fetch constraints, which prevented use of the pinned toolchain (automated failure observed).  
- Ran the targeted pytest suite with repository sources on the local interpreter using `PYTHONPATH=src python -m pytest -o addopts='' tests/test_delta_gates.py tests/test_refresh_baselines.py tests/test_refresh_baselines_run_check.py tests/test_governance_rules_policy.py`, and all tests passed (`33 passed`).  
- The added tests verify: registry loading and required gate keys, severity monotonicity (warning ≤ blocking), and `_requires_block` monotonic behavior with and without the override token+rationale.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c69d1ae9c8324aef8feae1752ce01)