### PR TITLE
Add agent_instruction_graph docflow audit and Agent Control Surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 72
+doc_revision: 73
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -107,6 +107,14 @@ Bottom-up convergence targets live in `docs/sppf_checklist.md`.
 
 ## Governance addenda (optional)
 See `docs/doer_judge_witness.md` for optional role framing.
+
+## Agent Control Surface
+The canonical agent instruction graph is emitted by docflow at:
+- `artifacts/out/agent_instruction_drift.json` (machine-readable)
+- `artifacts/audit_reports/agent_instruction_drift.md` (human-readable)
+
+Use this graph as the single source of truth for mandatory directive deduping,
+scoped-delta validation, and precedence/conflict checks.
 
 ## Non-goals (for now)
 - Docflow is a repo-local convenience feature, not a Gabion product feature.

--- a/tests/test_agent_instruction_graph.py
+++ b/tests/test_agent_instruction_graph.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import audit_tools
+
+
+def _doc(*, revision: int, reviewed: dict[str, int], body: str) -> audit_tools.Doc:
+    return audit_tools.Doc(
+        frontmatter={
+            "doc_revision": revision,
+            "doc_reviewed_as_of": reviewed,
+        },
+        body=body,
+    )
+
+
+def test_agent_instruction_graph_reports_drift_categories(tmp_path: Path) -> None:
+    docs = {
+        "AGENTS.md": _doc(
+            revision=2,
+            reviewed={"POLICY_SEED.md#policy_seed": 1},
+            body=(
+                "## Required behavior\n"
+                "- Do not weaken runner protections.\n"
+                "- Use `mise exec -- python` for tooling.\n"
+            ),
+        ),
+        "POLICY_SEED.md": _doc(
+            revision=2,
+            reviewed={},
+            body=(
+                "## Policy\n"
+                "- Use `--policy-override` only for emergency workflows.\n"
+            ),
+        ),
+        "CONTRIBUTING.md": _doc(
+            revision=1,
+            reviewed={},
+            body=(
+                "## Contributing\n"
+                "- Do not weaken runner protections.\n"
+            ),
+        ),
+        "in/AGENTS.md": _doc(
+            revision=1,
+            reviewed={"POLICY_SEED.md#policy_seed": 1},
+            body=(
+                "## Required behavior\n"
+                "- Weaken runner protections.\n"
+            ),
+        ),
+    }
+
+    warnings, violations = audit_tools._agent_instruction_graph(
+        root=tmp_path,
+        docs=docs,
+        json_output=tmp_path / "out.json",
+        md_output=tmp_path / "out.md",
+    )
+
+    assert warnings
+    assert violations
+
+    payload = json.loads((tmp_path / "out.json").read_text(encoding="utf-8"))
+    assert payload["summary"]["duplicate_mandatory"] == 1
+    assert payload["summary"]["precedence_conflicts"] == 1
+    assert payload["summary"]["stale_dependency_revisions"] == 2
+    assert payload["summary"]["hidden_operational_toggles"] == 1
+    assert payload["summary"]["scoped_delta_violations"] == 1
+
+
+def test_agent_instruction_graph_allows_explicit_scoped_delta(tmp_path: Path) -> None:
+    docs = {
+        "AGENTS.md": _doc(
+            revision=1,
+            reviewed={"POLICY_SEED.md#policy_seed": 1},
+            body="## Required behavior\n- Keep workflows pinned.\n",
+        ),
+        "POLICY_SEED.md": _doc(revision=1, reviewed={}, body="# Policy\n"),
+        "CONTRIBUTING.md": _doc(revision=1, reviewed={}, body="# Contributing\n"),
+        "in/AGENTS.md": _doc(
+            revision=1,
+            reviewed={"POLICY_SEED.md#policy_seed": 1},
+            body="## Required behavior\n- [delta] Run additional local checks.\n",
+        ),
+    }
+
+    warnings, violations = audit_tools._agent_instruction_graph(
+        root=tmp_path,
+        docs=docs,
+        json_output=tmp_path / "out.json",
+        md_output=tmp_path / "out.md",
+    )
+
+    assert warnings == []
+    assert "scoped AGENTS directives must be canonical or explicit deltas" not in "\n".join(violations)


### PR DESCRIPTION
### Motivation
- Provide a single canonical instruction graph for repository agent directives and detect instruction drift across `AGENTS.md`, `CONTRIBUTING.md`, `POLICY_SEED.md`, and scoped `*/AGENTS.md` files. 
- Surface duplicate mandatory directives, precedence conflicts, stale review pins, and undocumented operational toggles so docflow can enforce canonicality and scoped-delta rules.

### Description
- Added an `AgentDirective` dataclass and directive extraction/normalization helpers to `scripts/audit_tools.py`, plus `_agent_instruction_graph` which detects duplicates, precedence conflicts (positive vs negative polarity), stale `doc_reviewed_as_of` pins, hidden operational toggles, and scoped-delta violations.  
- `_agent_instruction_graph` emits machine-readable and human-readable artifacts to `artifacts/out/agent_instruction_drift.json` and `artifacts/audit_reports/agent_instruction_drift.md`.  
- Wired the new audit into the `docflow` command and added CLI flags `--agent-instruction-graph-json` and `--agent-instruction-graph-md`.  
- Added an "Agent Control Surface" section to `README.md#repo_contract` pointing to the canonical graph and added tests in `tests/test_agent_instruction_graph.py` covering drift detection and explicit scoped-delta behavior.

### Testing
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_agent_instruction_graph.py`, which executed the new tests successfully (2 passed).  
- Executed `PYTHONPATH=src python scripts/audit_tools.py docflow --root . --sppf-gh-ref-mode advisory`, which completed and returned a docflow summary that included the new graph warnings/violations (operation succeeded and emitted expected artifacts).  
- An attempt to run the tests via `mise exec` failed due to local `mise` trust/tool-resolution/network configuration in this environment and not due to the introduced code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c69f32668832492b573e6232ef555)