### PR TITLE
Add mise trust setup guidance and trust-failure guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 96
+doc_revision: 97
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -262,8 +262,13 @@ advisory outside this repo until the convergence checklist says otherwise.
 Local environment (via `mise`):
 ```
 mise install
+mise trust --yes
 mise exec -- python -m pip install -e .
 ```
+
+Trusting the repo config keeps local runs aligned with CI. In GitHub Actions we
+set `MISE_TRUSTED_CONFIG_PATHS=${{ github.workspace }}`, which pre-trusts the
+checked-out workspace for non-interactive `mise` execution.
 
 Bootstrap everything (toolchain + deps + smoke test):
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 72
+doc_revision: 73
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -119,7 +119,12 @@ Need practical remediation loops? See `docs/user_workflows.md#user_workflows`.
 Install toolchain with `mise` (once):
 ```
 mise install
+mise trust --yes
 ```
+
+`mise trust --yes` marks this repo's `mise.toml` as trusted so local `mise exec`
+matches CI behavior. CI sets `MISE_TRUSTED_CONFIG_PATHS=${{ github.workspace }}`
+in workflows, so the workspace is already trusted there.
 
 Install from source (editable):
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,7 +6,17 @@ if ! command -v mise >/dev/null 2>&1; then
   exit 1
 fi
 
+ensure_mise_trust() {
+  if ! mise trust --yes >/dev/null 2>&1; then
+    echo "Failed to trust this repository's mise config." >&2
+    echo "Run: mise trust --yes \"$PWD/mise.toml\"" >&2
+    echo "In CI, set MISE_TRUSTED_CONFIG_PATHS to include the workspace path." >&2
+    exit 1
+  fi
+}
+
 mise install
+ensure_mise_trust
 mise exec -- python -m pip install -e .
 mise exec -- python -m pip install pytest
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -36,6 +36,18 @@ if ! command -v mise >/dev/null 2>&1; then
   exit 1
 fi
 
+
+ensure_mise_trust() {
+  if ! mise trust --yes >/dev/null 2>&1; then
+    echo "Failed to trust this repository's mise config." >&2
+    echo "Run: mise trust --yes \"$PWD/mise.toml\"" >&2
+    echo "In CI, set MISE_TRUSTED_CONFIG_PATHS to include the workspace path." >&2
+    exit 1
+  fi
+}
+
+ensure_mise_trust
+
 if $run_dataflow; then
   baseline_arg=()
   if [ -f baselines/dataflow_baseline.txt ]; then


### PR DESCRIPTION
### Motivation
- Ensure local developer runs use the same trusted mise config as CI so `mise exec` behavior is coherent between local and CI environments.
- Surface a clear, actionable remediation when the repository’s `mise.toml` is not trusted so bootstrap/check scripts fail fast with guidance.
- Keep onboarding docs and contributor setup aligned with CI behavior (`MISE_TRUSTED_CONFIG_PATHS`) to reduce friction and surprises.

### Description
- Updated `README.md` (bumped `doc_revision`) to add `mise trust --yes` immediately after `mise install` in the Quick start and a short note explaining CI parity via `MISE_TRUSTED_CONFIG_PATHS`.
- Updated `CONTRIBUTING.md` (bumped `doc_revision`) to add `mise trust --yes` to the local setup flow and document the relation to CI.
- Added an `ensure_mise_trust()` guard to `scripts/bootstrap.sh` and call it before running any `mise exec` steps so a missing trust state fails with a remediation message (`mise trust --yes "$PWD/mise.toml"`).
- Added the same `ensure_mise_trust()` guard to `scripts/checks.sh` and invoke it early in the script to detect trust failures before running checks.

### Testing
- Ran `bash -n scripts/bootstrap.sh` to validate syntax, which succeeded.
- Ran `bash -n scripts/checks.sh` to validate syntax, which succeeded.
- Ran `scripts/checks.sh --list` to exercise the check discovery path and confirm the script runs and lists checks, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bdc6727708324ad67957ef377439d)