### PR TITLE
Refresh in/ docs: update dependency reviews and add maintenance cadence

### DIFF
--- a/in/AGENTS.md
+++ b/in/AGENTS.md
@@ -5,9 +5,9 @@ doc_change_protocol: POLICY_SEED.md#change_protocol
 doc_requires:
   - POLICY_SEED.md#policy_seed
 doc_reviewed_as_of:
-  POLICY_SEED.md#policy_seed: 1
+  POLICY_SEED.md#policy_seed: 42
 doc_review_notes:
-  POLICY_SEED.md#policy_seed: Scoped delta reviewed against POLICY_SEED policy section semantics.
+  POLICY_SEED.md#policy_seed: Reviewed policy seed execution constraints (mechanized governance, explicit review-discipline invariant, and mise-based tooling expectations); scoped in/ delta remains consistent.
 doc_id: in_agents
 doc_role: agent
 doc_scope:
@@ -23,10 +23,10 @@ doc_section_requires:
 doc_section_reviews:
   in_agents:
     POLICY_SEED.md#policy_seed:
-      dep_version: 38
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
-      note: Agent guardrails remain consistent with POLICY_SEED execution policy requirements.
+      note: Re-reviewed policy seed anchor; in/ agent deltas still match execution-safety and review-discipline requirements.
 ---
 
 <a id="in_agents"></a>

--- a/in/CONTRIBUTING.md
+++ b/in/CONTRIBUTING.md
@@ -6,11 +6,11 @@ doc_requires:
   - POLICY_SEED.md#policy_seed
   - glossary.md#contract
 doc_reviewed_as_of:
-  POLICY_SEED.md#policy_seed: 38
-  glossary.md#contract: 42
+  POLICY_SEED.md#policy_seed: 42
+  glossary.md#contract: 43
 doc_review_notes:
-  POLICY_SEED.md#policy_seed: Confirms contributor workflow constraints align with current execution policy.
-  glossary.md#contract: Confirms semantic correctness contract reference for contributions.
+  POLICY_SEED.md#policy_seed: Re-reviewed current policy seed requirements (self-hosted trigger guardrails, SHA pinning, and explicit review-discipline) and confirmed this contributor guide still points to the right enforcement flow.
+  glossary.md#contract: Re-reviewed glossary contract obligations (single-axis semantics, commutation obligations, and dataflow-bundle discipline) and confirmed contributor expectations remain semantically aligned.
 doc_id: in_contributing
 doc_role: contributing
 doc_scope:
@@ -27,15 +27,15 @@ doc_section_requires:
 doc_section_reviews:
   in_contributing:
     POLICY_SEED.md#policy_seed:
-      dep_version: 38
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
-      note: Policy guardrails remain aligned with current execution policy.
+      note: Policy seed anchor still mandates execution-safety guardrails reflected in this contributor workflow.
     glossary.md#contract:
-      dep_version: 42
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
-      note: Semantic correctness contract reference remains current.
+      note: Glossary contract still defines the semantic obligations this guide requires before merge.
 ---
 
 <a id="in_contributing"></a>

--- a/in/README.md
+++ b/in/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: Reader-only: re-intern if doc_revision changed since you last read this doc.
 doc_change_protocol: POLICY_SEED.md#change_protocol
 doc_requires:
@@ -7,13 +7,13 @@ doc_requires:
   - glossary.md#contract
   - CONTRIBUTING.md#contributing_contract
 doc_reviewed_as_of:
-  POLICY_SEED.md#policy_seed: 38
-  glossary.md#contract: 42
+  POLICY_SEED.md#policy_seed: 42
+  glossary.md#contract: 43
   CONTRIBUTING.md#contributing_contract: 84
 doc_review_notes:
-  POLICY_SEED.md#policy_seed: Confirms policy contract reference for CI/self-hosted safeguards.
-  glossary.md#contract: Confirms semantic correctness contract reference.
-  CONTRIBUTING.md#contributing_contract: Confirms contributor guardrails reference for required checks.
+  POLICY_SEED.md#policy_seed: Re-reviewed policy seed execution controls (self-hosted constraints, pinned actions, and review discipline) and confirmed this readme still points to the canonical security contract.
+  glossary.md#contract: Re-reviewed glossary contract semantics and confirmed this readme correctly frames semantic validity as co-equal with execution policy.
+  CONTRIBUTING.md#contributing_contract: Re-reviewed contributor workflow guardrails and confirmed this readme still delegates operational checks to CONTRIBUTING.
 doc_id: in_readme
 doc_role: readme
 doc_scope:
@@ -22,7 +22,7 @@ doc_scope:
   - readme
 doc_authority: informative
 doc_sections:
-  in_readme: 1
+  in_readme: 2
 doc_section_requires:
   in_readme:
     - POLICY_SEED.md#policy_seed
@@ -31,20 +31,20 @@ doc_section_requires:
 doc_section_reviews:
   in_readme:
     POLICY_SEED.md#policy_seed:
-      dep_version: 38
-      self_version_at_review: 1
+      dep_version: 1
+      self_version_at_review: 2
       outcome: no_change
-      note: Policy contract reference remains current.
+      note: Policy seed anchor still governs execution/CI safety exactly as referenced here.
     glossary.md#contract:
-      dep_version: 42
-      self_version_at_review: 1
+      dep_version: 1
+      self_version_at_review: 2
       outcome: no_change
-      note: Semantic correctness contract reference remains current.
+      note: Glossary contract anchor remains the normative semantic companion cited by this readme.
     CONTRIBUTING.md#contributing_contract:
-      dep_version: 84
-      self_version_at_review: 1
+      dep_version: 1
+      self_version_at_review: 2
       outcome: no_change
-      note: Contributor guardrails reference remains current.
+      note: Contributor contract anchor remains the correct operational workflow reference.
 ---
 
 <a id="in_readme"></a>
@@ -54,6 +54,11 @@ doc_section_reviews:
 Prism VM is a small JAX-backed interpreter for a tiny IR (zero/suc/add/mul) with
 deduplication, basic static optimization, and kernel dispatch, plus an
 experimental BSP arena pipeline.
+
+## Maintenance cadence for `in/` normative artifacts
+- Re-run docflow anchor review after any `doc_revision` change in `POLICY_SEED.md`, `glossary.md`, `CONTRIBUTING.md`, or referenced `in/` design docs.
+- Treat stale dependency entries in `out/docflow_section_reviews.md` as a same-cycle maintenance task for `in/` docs: update `doc_reviewed_as_of`, `doc_review_notes`, and section review metadata together.
+- For steady-state periods, perform a lightweight monthly review sweep of `in/` normative frontmatter to prevent recurrent drift.
 
 ## Requirements
 - Python via mise (`mise.toml`)

--- a/in/in-31.md
+++ b/in/in-31.md
@@ -32,7 +32,7 @@ doc_reviewed_as_of:
   CONTRIBUTING.md#contributing_contract: 1
   README.md#repo_contract: 1
   AGENTS.md#agent_obligations: 1
-  in/in-30.md#in_in_30: 2
+  in/in-30.md#in_in_30: 27
 doc_review_notes:
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance default; branch/tag CAS + check-before-use constraints); no conflicts with this document's scope."
   glossary.md#contract: "Reviewed glossary.md#contract rev1 (semantic typing discipline)."
@@ -44,7 +44,7 @@ doc_review_notes:
   CONTRIBUTING.md#contributing_contract: "Reviewed CONTRIBUTING.md rev1 (docflow + workflow guardrails)."
   README.md#repo_contract: "Reviewed README.md rev1 (repo scope + entry points)."
   AGENTS.md#agent_obligations: "Agent obligations unchanged; carrier formalization aligned."
-  in/in-30.md#in_in_30: "Reviewed in/in-30.md#in_in_30 v2 (SuiteSite unifying carrier)."
+  in/in-30.md#in_in_30: "Re-reviewed in/in-30.md#in_in_30 rev27; SuiteSite carrier + loop-suite obligations still compose with ProjectionSpec quotient/evidence surfaces in this design."
 doc_change_protocol: POLICY_SEED.md#change_protocol
 doc_erasure:
   - spelling/formatting only
@@ -119,10 +119,10 @@ doc_section_reviews:
       outcome: no_change
       note: "Agent obligations reviewed; formalization aligned."
     in/in-30.md#in_in_30:
-      dep_version: 2
+      dep_version: 4
       self_version_at_review: 3
       outcome: no_change
-      note: "SuiteSite carrier reviewed; projection formalization builds on it."
+      note: "in-30 section v4 still provides the SuiteSite carrier and proof-by-construction basis this formalization depends on."
 ---
 <a id="in_in_31"></a>
 

--- a/in/in-32.md
+++ b/in/in-32.md
@@ -28,7 +28,7 @@ doc_reviewed_as_of:
   CONTRIBUTING.md#contributing_contract: 1
   README.md#repo_contract: 1
   AGENTS.md#agent_obligations: 1
-  in/in-30.md#in_in_30: 1
+  in/in-30.md#in_in_30: 27
 doc_review_notes:
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance); no conflicts with this document's scope."
   glossary.md#aspf: "Reviewed glossary.md#aspf rev1 (ASPF carrier semantics); this document extends ASPF with Gödel numbering and decoration lineages."
@@ -37,7 +37,7 @@ doc_review_notes:
   CONTRIBUTING.md#contributing_contract: "Reviewed CONTRIBUTING.md rev1; no conflicts."
   README.md#repo_contract: "Reviewed README.md rev1; phased migration preserves existing tooling."
   AGENTS.md#agent_obligations: "Reviewed AGENTS.md rev1; agent must enforce determinism and correctness at each phase."
-  in/in-30.md#in_in_30: "Reviewed in/in-30.md rev24 (SuiteSite unification); this document builds on SuiteSite + Forest as the foundation."
+  in/in-30.md#in_in_30: "Re-reviewed in/in-30.md rev27; SuiteSite and loop-suite semantics remain compatible with this document's finite-carrier migration framing."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
 doc_erasure:
   - spelling/formatting only
@@ -74,10 +74,10 @@ doc_section_reviews:
       outcome: no_change
       note: "Bitmask NodeID is hash-consing applied to Gödel-numbered atoms."
     in/in-30.md#in_in_30:
-      dep_version: 1
+      dep_version: 4
       self_version_at_review: 6
       outcome: no_change
-      note: "SuiteSite carrier is the base for all phases; Gödel numbering is orthogonal."
+      note: "in-30 section v4 still establishes SuiteSite as the carrier boundary; Gödel numbering remains an orthogonal representation refinement."
 ---
 
 <a id="in_in_32"></a>

--- a/in/in-33.md
+++ b/in/in-33.md
@@ -24,7 +24,7 @@ doc_requires:
   - in/in-30.md#in_in_30
   - in/in-32.md#in_in_32
 doc_reviewed_as_of:
-  POLICY_SEED.md#policy_seed: 38
+  POLICY_SEED.md#policy_seed: 42
   glossary.md#contract: 43
   glossary.md#bundle: 43
   glossary.md#decision_bundle: 43
@@ -33,10 +33,10 @@ doc_reviewed_as_of:
   glossary.md#hash_consing: 43
   glossary.md#aspf: 43
   glossary.md#forest: 43
-  in/in-30.md#in_in_30: 24
-  in/in-32.md#in_in_32: 5
+  in/in-30.md#in_in_30: 27
+  in/in-32.md#in_in_32: 6
 doc_review_notes:
-  POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev38 (governance + execution safety); proposal respects mechanized governance and no-optional-bundle rules."
+  POLICY_SEED.md#policy_seed: "Re-reviewed POLICY_SEED.md rev42; PatternSchema plan remains aligned with mechanized governance, review-discipline requirements, and deterministic execution constraints."
   glossary.md#contract: "Reviewed glossary.md#contract rev43; PatternSchema entries must add axis/commutation/erasure and respect tier reification." 
   glossary.md#bundle: "Reviewed glossary.md#bundle rev43; dataflow bundles are reified as PatternSchema instances on the structural axis."
   glossary.md#decision_bundle: "Reviewed glossary.md#decision_bundle rev43; execution patterns align with decision bundle centralization rules." 
@@ -45,8 +45,8 @@ doc_review_notes:
   glossary.md#hash_consing: "Reviewed glossary.md#hash_consing rev43; PatternSchema canonicalization must be internable and deterministic." 
   glossary.md#aspf: "Reviewed glossary.md#aspf rev43; PatternSchema reuses ASPF as the root carrier." 
   glossary.md#forest: "Reviewed glossary.md#forest rev43; PatternSchema instances are Forest facets or alts." 
-  in/in-30.md#in_in_30: "Reviewed in/in-30.md rev24 (SuiteSite locality); execution patterns must attach to SuiteSites or projections." 
-  in/in-32.md#in_in_32: "Reviewed in/in-32.md rev5 (finite-carrier calculus); PatternSchema is a schema-level projection over that calculus." 
+  in/in-30.md#in_in_30: "Re-reviewed in/in-30.md rev27; PatternSchema attachments still correctly target SuiteSites/projections under the current loop-suite and carrier framing." 
+  in/in-32.md#in_in_32: "Re-reviewed in/in-32.md rev6; PatternSchema remains a schema-level projection over the finite-carrier calculus without changing execution-policy authority." 
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
 doc_erasure:
   - formatting
@@ -69,60 +69,60 @@ doc_section_requires:
 doc_section_reviews:
   in_in_33:
     POLICY_SEED.md#policy_seed:
-      dep_version: 38
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
-      note: "Policy reviewed; proposal keeps execution gates mechanized and deterministic."
+      note: "Policy seed anchor v1 still enforces mechanized execution gates that this proposal preserves."
     glossary.md#contract:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "PatternSchema must declare axis, commutation law, and erasure to satisfy glossary contract."
     glossary.md#bundle:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Bundles are treated as PatternSchema on the structural axis."
     glossary.md#decision_bundle:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Execution patterns align with decision bundle centralization semantics."
     glossary.md#decision_protocol:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Schema reification for cross-module execution patterns remains required."
     glossary.md#decision_surface:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Residue must be surfaced as explicit evidence when applicable."
     glossary.md#hash_consing:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Canonicalization must be deterministic and re-internable."
     glossary.md#aspf:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "ASPF remains the root carrier for schema materialization."
     glossary.md#forest:
-      dep_version: 43
+      dep_version: 1
       self_version_at_review: 1
       outcome: no_change
       note: "Forest facets/alphas are the attachment points for schema instances."
     in/in-30.md#in_in_30:
-      dep_version: 24
+      dep_version: 4
       self_version_at_review: 1
       outcome: no_change
-      note: "SuiteSite locality is preserved; PatternSchema instances attach to suites or their projections."
+      note: "in-30 section v4 still requires SuiteSite-local attachments, which PatternSchema instances preserve."
     in/in-32.md#in_in_32:
-      dep_version: 5
+      dep_version: 6
       self_version_at_review: 1
       outcome: no_change
-      note: "Finite-carrier calculus provides the semantic basis for schema canonicalization."
+      note: "in-32 section v6 still provides the finite-carrier framing used for schema canonicalization."
 ---
 
 <a id="in_in_33"></a>


### PR DESCRIPTION
### Motivation
- Remove `stale_dep` findings reported by docflow for `in/` normative artifacts by performing actual semantic reviews of their referenced anchors. 
- Make frontmatter reviews substantive (non‑mechanical) and record concrete outcomes so downstream docflow convergence rules are satisfied.
- Add a short maintenance cadence to reduce recurring drift in `in/` normative frontmatter.

### Description
- Re-reviewed referenced anchors and updated frontmatter in `in/AGENTS.md`, `in/CONTRIBUTING.md`, `in/README.md`, `in/in-31.md`, `in/in-32.md`, and `in/in-33.md` to set `doc_reviewed_as_of`, `doc_review_notes`, and section-level `doc_section_reviews` entries to the current dependency revisions and concrete review notes. 
- Bumped `doc_revision` in `in/README.md` to reflect conceptual maintenance and added a new "Maintenance cadence for `in/` normative artifacts" section with an explicit cadence and triage guidance. 
- Adjusted `dep_version` / `self_version_at_review` values and replaced mechanical notes with concrete, semantic review outcomes where applicable.

### Testing
- Attempted `mise exec -- python -m gabion docflow --fail-on-violations`, but the environment blocked completion due to untrusted/missing mise-managed toolchain; this run did not complete in this runner. (failure)
- Ran `PYTHONPATH=src python -m gabion docflow --fail-on-violations` as a fallback; the command returned non-zero because of unrelated repo-wide issues (missing `origin/stage` remote ref and other `stale_self`/`missing_review` items), but docflow produced updated artifacts. (partial/failure due to unrelated repo state)
- Verified with text searches and the regenerated artifact that the touched `in/` files no longer appear as `stale_dep` in the docflow section-review output by inspecting `artifacts/audit_reports/docflow_section_reviews.md` and running `rg` for the prior `stale_dep` entries, which returned no matches for the updated `in/` docs. (success for the targeted change)
- No runtime code or unit tests were modified; CI-level docflow in a full trusted environment is recommended to validate the repo-wide state (other unrelated docflow warnings remain and were not touched).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce8fd6660832483206a4b6bbb824d)