### PR TITLE
Add governance loop matrix doc and matrix-drift audit check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 97
+doc_revision: 98
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -110,6 +110,7 @@ that can be adopted when helpful.
 - `POLICY_SEED.md#policy_seed` defines execution and CI safety constraints.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
 - `docs/enforceable_rules_cheat_sheet.md#enforceable_rules_cheat_sheet` provides a day-to-day implementation checklist backed by canonical clauses.
+- `docs/governance_loop_matrix.md#governance_loop_matrix` provides a gate-by-gate control-loop matrix for sensors, artifacts, thresholds, and overrides.
 
 ## Dataflow grammar invariant
 Recurring parameter bundles are treated as type-level obligations. Any bundle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 73
+doc_revision: 74
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -381,6 +381,7 @@ LLM/agent behavior is governed by `AGENTS.md#agent_obligations`.
 - `POLICY_SEED.md#policy_seed` defines execution and CI safety constraints.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
 - `docs/enforceable_rules_cheat_sheet.md#enforceable_rules_cheat_sheet` provides an authoritative-by-proxy operator reference with clause-level source links.
+- `docs/governance_loop_matrix.md#governance_loop_matrix` maps governance gate entrypoints, artifacts, thresholds, and override controls in one matrix.
 
 ## License
 Apache-2.0. See `LICENSE`.

--- a/docs/enforceable_rules_cheat_sheet.md
+++ b/docs/enforceable_rules_cheat_sheet.md
@@ -129,6 +129,8 @@ Precedence stack for interpretation and enforcement:
 No rule in this cheat sheet is valid unless it is traceable to canonical
 clauses in the source documents above.
 
+Gate-level control-loop mapping lives in `docs/governance_loop_matrix.md#governance_loop_matrix`.
+
 ## Rule Matrix (Traceable)
 
 | Rule ID | Enforceable Rule | Source Clause(s) | Operational Check | Failure Signal |

--- a/docs/governance_loop_matrix.md
+++ b/docs/governance_loop_matrix.md
@@ -1,0 +1,102 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: governance_loop_matrix
+doc_role: policy
+doc_scope:
+  - repo
+  - governance
+  - ci
+  - tooling
+doc_authority: normative
+doc_requires:
+  - docs/governance_control_loops.md#governance_control_loops
+  - docs/governance_rules.yaml
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - CONTRIBUTING.md#contributing_contract
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+doc_reviewed_as_of:
+  docs/governance_control_loops.md#governance_control_loops: 1
+  README.md#repo_contract: 1
+  AGENTS.md#agent_obligations: 1
+  CONTRIBUTING.md#contributing_contract: 1
+  POLICY_SEED.md#policy_seed: 1
+  glossary.md#contract: 1
+doc_review_notes:
+  docs/governance_control_loops.md#governance_control_loops: "Control-loop domain registry reviewed; matrix rows align to declared first-order loops and correction semantics."
+  README.md#repo_contract: "Repo contract and cross-reference structure reviewed; matrix linked from governance references."
+  AGENTS.md#agent_obligations: "Agent obligations reviewed; matrix keeps mechanized-governance and override language aligned with agent constraints."
+  CONTRIBUTING.md#contributing_contract: "Contributor contract reviewed; matrix commands align with repo-local tooling execution norms."
+  POLICY_SEED.md#policy_seed: "Policy seed reviewed; bounded-step and override mechanics are preserved in per-gate rows."
+  glossary.md#contract: "Glossary contract reviewed; gate identifiers and loop-domain labels are semantically stable."
+doc_sections:
+  governance_loop_matrix: 1
+doc_section_requires:
+  governance_loop_matrix:
+    - docs/governance_control_loops.md#governance_control_loops
+    - README.md#repo_contract
+    - AGENTS.md#agent_obligations
+    - CONTRIBUTING.md#contributing_contract
+    - POLICY_SEED.md#policy_seed
+    - glossary.md#contract
+doc_section_reviews:
+  governance_loop_matrix:
+    docs/governance_control_loops.md#governance_control_loops:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Domain/correction model remains compatible with matrix columns."
+    README.md#repo_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Repo governance cross-reference expectations remain unchanged."
+    AGENTS.md#agent_obligations:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Agent obligations remain aligned with matrix override and enforcement semantics."
+    CONTRIBUTING.md#contributing_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Contributor command discipline remains compatible with matrix sensors."
+    POLICY_SEED.md#policy_seed:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Override and correction ratchet requirements unchanged."
+    glossary.md#contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Loop and gate terms remain semantically consistent with glossary contract."
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_invariants:
+  - mechanized_governance_invariant
+  - lsp_first_invariant
+doc_erasure:
+  - formatting
+  - typos
+doc_owner: maintainer
+---
+
+<a id="governance_loop_matrix"></a>
+# Governance loop matrix
+
+Semi-generated from:
+- `docs/governance_control_loops.md`
+- `docs/governance_rules.yaml`
+- gate entrypoints in `src/gabion/tooling/*gate*.py`
+
+Cross-reference anchors used by this matrix: `docs/governance_control_loops.md#governance_control_loops`, `README.md#repo_contract`, `CONTRIBUTING.md#contributing_contract`, `AGENTS.md#agent_obligations`, `POLICY_SEED.md#policy_seed`, and `glossary.md#contract`.
+
+| loop domain | gate ID | sensor command | state artifact path | correction mode | warning/blocking thresholds | override mechanism |
+| --- | --- | --- | --- | --- | --- | --- |
+| baseline ratchets | `obsolescence_opaque` | `mise exec -- python -m gabion.tooling.obsolescence_delta_gate` | `artifacts/out/test_obsolescence_delta.json` | `hard-fail` | `warning=0, block=1` | Gate toggle: `GABION_GATE_OPAQUE_DELTA` (`default_true`); strictness reductions require `GABION_POLICY_OVERRIDE_TOKEN` + `GABION_POLICY_OVERRIDE_RATIONALE`. |
+| baseline ratchets | `obsolescence_unmapped` | `mise exec -- python -m gabion.tooling.obsolescence_delta_unmapped_gate` | `artifacts/out/test_obsolescence_delta.json` | `ratchet` | `warning=0, block=1` | Gate toggle: `GABION_GATE_UNMAPPED_DELTA` (`default_true`); strictness reductions require `GABION_POLICY_OVERRIDE_TOKEN` + `GABION_POLICY_OVERRIDE_RATIONALE`. |
+| baseline ratchets | `annotation_orphaned` | `mise exec -- python -m gabion.tooling.annotation_drift_orphaned_gate` | `artifacts/out/test_annotation_drift_delta.json` | `ratchet` | `warning=0, block=1` | Gate toggle: `GABION_GATE_ORPHANED_DELTA` (`default_true`); strictness reductions require `GABION_POLICY_OVERRIDE_TOKEN` + `GABION_POLICY_OVERRIDE_RATIONALE`. |
+| baseline ratchets | `ambiguity` | `mise exec -- python -m gabion.tooling.ambiguity_delta_gate` | `artifacts/out/ambiguity_delta.json` | `hard-fail` | `warning=0, block=1` | Gate toggle: `GABION_GATE_AMBIGUITY_DELTA` (`default_true`); strictness reductions require `GABION_POLICY_OVERRIDE_TOKEN` + `GABION_POLICY_OVERRIDE_RATIONALE`. |
+| docs/docflow | `docflow` | `mise exec -- python -m gabion.tooling.docflow_delta_gate` | `artifacts/out/docflow_compliance_delta.json` | `advisory` | `warning=0, block=1` | Gate toggle: `GABION_GATE_DOCFLOW_DELTA` (`truthy_only`); strictness reductions require `GABION_POLICY_OVERRIDE_TOKEN` + `GABION_POLICY_OVERRIDE_RATIONALE`. |

--- a/src/gabion_governance/governance_audit_impl.py
+++ b/src/gabion_governance/governance_audit_impl.py
@@ -31,6 +31,7 @@ from gabion.analysis.obligation_registry import (
 )
 from gabion.invariants import never
 from gabion.order_contract import ordered_or_sorted
+from gabion.tooling.governance_rules import load_governance_rules
 
 _DEFAULT_AUDIT_TIMEOUT_TICKS = 120_000
 _DEFAULT_AUDIT_TIMEOUT_TICK_NS = 1_000_000
@@ -83,6 +84,7 @@ CORE_GOVERNANCE_DOCS = [
 
 GOVERNANCE_DOCS = CORE_GOVERNANCE_DOCS + [
     "docs/governance_control_loops.md",
+    "docs/governance_loop_matrix.md",
     "docs/publishing_practices.md",
     "docs/influence_index.md",
     "docs/coverage_semantics.md",
@@ -341,6 +343,23 @@ DECLARATION_TO_CHECKLIST_MAP = {
 }
 
 
+def _matrix_gate_ids_from_markdown(body: str) -> set[str]:
+    gate_ids: set[str] = set()
+    for line in body.splitlines():
+        check_deadline()
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        gate_cell = cells[1].strip("`").strip()
+        if not gate_cell or gate_cell == "gate ID" or gate_cell.startswith("---"):
+            continue
+        gate_ids.add(gate_cell)
+    return gate_ids
+
+
 def _parse_sppf_tag(payload: str) -> dict[str, str]:
     items: dict[str, str] = {}
     for chunk in payload.split(";"):
@@ -478,6 +497,13 @@ def _docflow_predicates() -> dict[str, Callable[[Mapping[str, JSONValue], Mappin
             return False
         return row.get("declared") is not True
 
+    def _missing_matrix_gate_entry(row: Mapping[str, JSONValue], params: Mapping[str, JSONValue]) -> bool:
+        if not _is_row(row, "doc_loop_matrix_gate"):
+            return False
+        if row.get("required") is not True:
+            return False
+        return row.get("declared") is not True
+
     return {
         "missing_frontmatter": _missing_frontmatter,
         "missing_required_field": _missing_required_field,
@@ -492,6 +518,7 @@ def _docflow_predicates() -> dict[str, Callable[[Mapping[str, JSONValue], Mappin
         "evidence_id": _evidence_id,
         "evidence_source": _evidence_source,
         "missing_loop_entry": _missing_loop_entry,
+        "missing_matrix_gate_entry": _missing_matrix_gate_entry,
     }
 
 
@@ -540,6 +567,11 @@ DOCFLOW_AUDIT_INVARIANTS = [
         name="docflow:missing_governance_control_loop",
         kind="never",
         spec=_make_invariant_spec("docflow:missing_governance_control_loop", ["missing_loop_entry"]),
+    ),
+    DocflowInvariant(
+        name="docflow:governance_loop_matrix_drift",
+        kind="never",
+        spec=_make_invariant_spec("docflow:governance_loop_matrix_drift", ["missing_matrix_gate_entry"]),
     ),
 ]
 
@@ -1849,6 +1881,28 @@ def _docflow_invariant_rows(
                 "declared": domain in declared_domains,
             }
         )
+
+    matrix_doc_rel = "docs/governance_loop_matrix.md"
+    matrix_doc = docs.get(matrix_doc_rel)
+    matrix_gate_ids = _matrix_gate_ids_from_markdown(matrix_doc.body) if matrix_doc is not None else set()
+    matrix_doc_id = (
+        matrix_doc.frontmatter.get("doc_id")
+        if matrix_doc is not None and isinstance(matrix_doc.frontmatter.get("doc_id"), str)
+        else None
+    )
+    matrix_base = base_meta(matrix_doc_rel, matrix_doc_id)
+    for gate_id in _sorted(load_governance_rules().gates.keys()):
+        check_deadline()
+        rows.append(
+            {
+                "row_kind": "doc_loop_matrix_gate",
+                **matrix_base,
+                "gate_id": gate_id,
+                "required": True,
+                "declared": gate_id in matrix_gate_ids,
+            }
+        )
+
     return rows, warnings
 
 
@@ -1955,6 +2009,9 @@ def _format_docflow_violation(row: Mapping[str, JSONValue]) -> str:
     if kind == "doc_loop_entry":
         domain = row.get("domain", "?")
         return f"{path}: missing governance control-loop declaration for domain: {domain}"
+    if kind == "doc_loop_matrix_gate":
+        gate_id = row.get("gate_id", "?")
+        return f"{path}: governance loop matrix drift; missing gate row for: {gate_id}"
     return f"{path}: docflow invariant violation"
 
 

--- a/tests/test_docflow_governance_control_loops.py
+++ b/tests/test_docflow_governance_control_loops.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from gabion.tooling.governance_rules import load_governance_rules
+
 
 def _load_audit_tools():
     from gabion.tooling import governance_audit as audit_tools
@@ -59,3 +61,78 @@ def test_docflow_loop_registry_satisfied_when_all_domains_declared() -> None:
     )
 
     assert not any("missing governance control-loop declaration" in item for item in violations)
+
+
+# gabion:evidence E:call_footprint::tests/test_docflow_governance_control_loops.py::test_docflow_governance_loop_matrix_drift_detected_when_gate_missing::governance_audit.py::gabion.tooling.governance_audit._docflow_invariant_rows
+def test_docflow_governance_loop_matrix_drift_detected_when_gate_missing() -> None:
+    audit_tools = _load_audit_tools()
+    docs = {
+        "docs/governance_control_loops.md": audit_tools.Doc(
+            frontmatter={
+                "doc_id": "governance_control_loops",
+                "loop_domains": list(audit_tools.NORMATIVE_LOOP_DOMAINS),
+            },
+            body="",
+        ),
+        "docs/governance_loop_matrix.md": audit_tools.Doc(
+            frontmatter={"doc_id": "governance_loop_matrix"},
+            body=(
+                "| loop domain | gate ID | sensor command | state artifact path | correction mode | warning/blocking thresholds | override mechanism |\n"
+                "| --- | --- | --- | --- | --- | --- | --- |\n"
+                "| baseline ratchets | `obsolescence_opaque` | `mise exec -- python -m gabion.tooling.obsolescence_delta_gate` | `artifacts/out/test_obsolescence_delta.json` | `hard-fail` | `warning=0, block=1` | `GABION_GATE_OPAQUE_DELTA` |\n"
+            ),
+        ),
+    }
+
+    rows, _warnings = audit_tools._docflow_invariant_rows(
+        docs=docs,
+        revisions={},
+        core_set=set(audit_tools.CORE_GOVERNANCE_DOCS),
+        missing_frontmatter=set(),
+    )
+    violations = audit_tools._evaluate_docflow_invariants(
+        rows,
+        invariants=audit_tools.DOCFLOW_AUDIT_INVARIANTS,
+    )
+
+    assert any("governance loop matrix drift" in item for item in violations)
+
+
+# gabion:evidence E:call_footprint::tests/test_docflow_governance_control_loops.py::test_docflow_governance_loop_matrix_registry_satisfied_for_all_gate_rows::governance_audit.py::gabion.tooling.governance_audit._docflow_invariant_rows
+def test_docflow_governance_loop_matrix_registry_satisfied_for_all_gate_rows() -> None:
+    audit_tools = _load_audit_tools()
+    gate_rows = "\n".join(
+        f"| baseline ratchets | `{gate_id}` | `sensor` | `artifact` | `mode` | `warning=0, block=1` | `override` |"
+        for gate_id in sorted(load_governance_rules().gates)
+    )
+    docs = {
+        "docs/governance_control_loops.md": audit_tools.Doc(
+            frontmatter={
+                "doc_id": "governance_control_loops",
+                "loop_domains": list(audit_tools.NORMATIVE_LOOP_DOMAINS),
+            },
+            body="",
+        ),
+        "docs/governance_loop_matrix.md": audit_tools.Doc(
+            frontmatter={"doc_id": "governance_loop_matrix"},
+            body=(
+                "| loop domain | gate ID | sensor command | state artifact path | correction mode | warning/blocking thresholds | override mechanism |\n"
+                "| --- | --- | --- | --- | --- | --- | --- |\n"
+                + gate_rows
+                + "\n"
+            ),
+        ),
+    }
+
+    rows, _warnings = audit_tools._docflow_invariant_rows(
+        docs=docs,
+        revisions={},
+        core_set=set(audit_tools.CORE_GOVERNANCE_DOCS),
+        missing_frontmatter=set(),
+    )
+    violations = audit_tools._evaluate_docflow_invariants(
+        rows,
+        invariants=audit_tools.DOCFLOW_AUDIT_INVARIANTS,
+    )
+
+    assert not any("governance loop matrix drift" in item for item in violations)


### PR DESCRIPTION
### Motivation
- Provide a single, semi-generated matrix that maps governed loop domains to gate IDs, sensors, artifacts, correction modes, thresholds, and override controls to improve discoverability and reduce drift risk. 
- Detect and prevent silent drift between the human-maintained matrix and the canonical gate definitions in `docs/governance_rules.yaml` via the docflow audit. 

### Description
- Added `docs/governance_loop_matrix.md` containing a gate-by-gate matrix with the requested columns (loop domain, gate ID, sensor command, state artifact path, correction mode, warning/blocking thresholds, override mechanism). 
- Linked the new matrix from `README.md#repo_contract`, `CONTRIBUTING.md#contributing_contract`, and `docs/enforceable_rules_cheat_sheet.md`. 
- Extended the docflow governance audit (`src/gabion_governance/governance_audit_impl.py`) with a markdown table parser (`_matrix_gate_ids_from_markdown`), a new invariant predicate (`missing_matrix_gate_entry`), a new invariant `docflow:governance_loop_matrix_drift`, rows generation for per-gate coverage (`doc_loop_matrix_gate` rows), and violation formatting for matrix drift. 
- Added tests in `tests/test_docflow_governance_control_loops.py` to validate (a) drift detection when a gate row is missing and (b) success when the matrix includes all gate IDs from `docs/governance_rules.yaml`.

### Testing
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_docflow_governance_control_loops.py tests/test_governance_rules_policy.py` and observed all tests passed (`8 passed`). 
- Ran the docflow audit `PYTHONPATH=src mise exec -- python -m gabion docflow --root . --fail-on-violations --sppf-gh-ref-mode required`, which completed and produced non-blocking warnings (missing in/* references and a few stale self-review notes) but no blocking gate failures after updates; the new matrix drift invariant exercised both failure and success paths in tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce94f4350832492068cdfde5d0aab)