### PR TITLE
Add canonical normative clause index and replace duplicated governance prose with clause links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 19
+doc_revision: 20
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: agents
 doc_role: agent
@@ -13,16 +13,19 @@ doc_requires:
   - CONTRIBUTING.md#contributing_contract
   - POLICY_SEED.md#policy_seed
   - glossary.md#contract
+  - docs/normative_clause_index.md#normative_clause_index
 doc_reviewed_as_of:
   README.md#repo_contract: 1
   CONTRIBUTING.md#contributing_contract: 1
   POLICY_SEED.md#policy_seed: 1
   glossary.md#contract: 1
+  docs/normative_clause_index.md#normative_clause_index: 1
 doc_review_notes:
   README.md#repo_contract: "Reviewed README.md rev1 (docflow audit now scans in/ by default); no conflicts with this document's scope."
   CONTRIBUTING.md#contributing_contract: "Reviewed CONTRIBUTING.md rev1 (docflow now fails on missing GH references for SPPF-relevant changes); no conflicts with this document's scope."
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance default; branch/tag CAS + check-before-use constraints); no conflicts with this document's scope."
   glossary.md#contract: "Reviewed glossary.md#contract rev1 (glossary contract + semantic typing discipline)."
+  docs/normative_clause_index.md#normative_clause_index: "Agent obligations now reference canonical clause IDs for repeated policy language."
 doc_sections:
   agent_obligations: 1
 doc_section_requires:
@@ -31,6 +34,7 @@ doc_section_requires:
     - CONTRIBUTING.md#contributing_contract
     - POLICY_SEED.md#policy_seed
     - glossary.md#contract
+    - docs/normative_clause_index.md#normative_clause_index
 doc_section_reviews:
   agent_obligations:
     README.md#repo_contract:
@@ -53,6 +57,11 @@ doc_section_reviews:
       self_version_at_review: 1
       outcome: no_change
       note: "Glossary contract reviewed; agent obligations unchanged."
+    docs/normative_clause_index.md#normative_clause_index:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Clause index reviewed; AGENTS links remain aligned with canonical obligations."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
 doc_invariants:
   - read_policy_glossary_first
@@ -77,16 +86,17 @@ Semantic correctness is governed by `[glossary.md#contract](glossary.md#contract
 - `CONTRIBUTING.md#contributing_contract` defines human+machine workflow guardrails.
 - `POLICY_SEED.md#policy_seed` defines execution and CI safety constraints.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
+- `docs/normative_clause_index.md#normative_clause_index` defines stable clause IDs for repeated obligations.
 
 ## Required behavior
 - Read `POLICY_SEED.md#policy_seed` and `[glossary.md#contract](glossary.md#contract)` before proposing or applying changes.
 - If a request conflicts with `POLICY_SEED.md#policy_seed`, stop and ask for guidance.
 - Do not weaken or bypass self-hosted runner protections.
-- Keep workflow actions pinned to full commit SHAs and allow-listed.
+- Action pinning: [`NCI-ACTIONS-PINNED`](docs/normative_clause_index.md#clause-actions-pinned).
+- Action allow-list: [`NCI-ACTIONS-ALLOWLIST`](docs/normative_clause_index.md#clause-actions-allowlist).
 - When changing workflows, run the policy checks (once the scripts exist) and
   surface any violations explicitly.
-- Preserve the LSP-first invariant: the server is the semantic core and the
-  CLI remains a thin LSP client.
+- Preserve [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first).
 - Use `mise exec -- python` for repo-local tooling to ensure the pinned
   interpreter and dependencies are used.
 - Prefer impossible-by-construction contracts over sentinel parse outcomes;
@@ -97,12 +107,8 @@ Semantic correctness is governed by `[glossary.md#contract](glossary.md#contract
   `doc_review_notes` based on a real content review.
 
 ## Dataflow grammar invariant
-- Recurring parameter bundles are type-level obligations.
-- Any bundle that crosses function boundaries must be promoted to a Protocol
-  (dataclass config/local bundle) or explicitly documented with a
-  `# dataflow-bundle:` marker.
-- Tier-2 bundles must be reified before merge (see `[glossary.md#contract](glossary.md#contract)`).
-- Tier-3 bundles must be documented or reified (see `[glossary.md#contract](glossary.md#contract)`).
+- Canonical rule: [`NCI-DATAFLOW-BUNDLE-TIERS`](docs/normative_clause_index.md#clause-dataflow-bundle-tiers).
+- Tier-3 documentation marker: `# dataflow-bundle:`.
 
 ## Doc hygiene
 - Markdown docs include a YAML front-matter block with `doc_revision`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 97
+doc_revision: 98
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -13,6 +13,7 @@ doc_requires:
   - README.md#repo_contract
   - AGENTS.md#agent_obligations
   - POLICY_SEED.md#policy_seed
+  - docs/normative_clause_index.md#normative_clause_index
   - glossary.md#contract
   - docs/coverage_semantics.md#coverage_semantics
 doc_reviewed_as_of:
@@ -20,6 +21,7 @@ doc_reviewed_as_of:
   CONTRIBUTING.md#contributing_contract: 1
   AGENTS.md#agent_obligations: 1
   POLICY_SEED.md#policy_seed: 1
+  docs/normative_clause_index.md#normative_clause_index: 1
   glossary.md#contract: 1
   docs/coverage_semantics.md#coverage_semantics: 1
 doc_review_notes:
@@ -27,6 +29,7 @@ doc_review_notes:
   CONTRIBUTING.md#contributing_contract: "Self-review via Grothendieck analysis (cofibration/dedup/contrast); docflow now fails on missing GH references for SPPF-relevant changes; baseline guardrail + ci_cycle helper affirmed."
   AGENTS.md#agent_obligations: "Agent review discipline aligns with contributor workflow."
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance default; branch/tag CAS + check-before-use constraints); no conflicts with this document's scope."
+  docs/normative_clause_index.md#normative_clause_index: "Canonical clause IDs adopted for repeated obligations (LSP-first, policy pinning/allow-list, bundle tiers, baseline ratchet)."
   glossary.md#contract: "Reviewed glossary.md#contract rev1 (glossary contract + semantic typing discipline)."
   docs/coverage_semantics.md#coverage_semantics: "Reviewed docs/coverage_semantics.md#coverage_semantics v1 (glossary-lifted projection + explicit core anchors); contributor guidance unchanged."
 doc_sections:
@@ -36,6 +39,7 @@ doc_section_requires:
     - README.md#repo_contract
     - AGENTS.md#agent_obligations
     - POLICY_SEED.md#policy_seed
+    - docs/normative_clause_index.md#normative_clause_index
     - glossary.md#contract
     - docs/coverage_semantics.md#coverage_semantics
 doc_section_reviews:
@@ -55,6 +59,11 @@ doc_section_reviews:
       self_version_at_review: 1
       outcome: no_change
       note: "Policy seed reviewed; contributor contract unchanged."
+    docs/normative_clause_index.md#normative_clause_index:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Clause IDs reviewed; contributing guidance now links canonical obligations."
     glossary.md#contract:
       dep_version: 1
       self_version_at_review: 1
@@ -95,8 +104,7 @@ valid.
 - Mechanical version stamping is prohibited and treated as a governance breach.
 
 ## Architectural invariants (normative)
-- **LSP-first invariant:** the language server is the semantic core; the CLI is
-  a thin LSP client and must not import or reimplement analysis logic.
+- **LSP-first invariant:** [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first).
 - **Single source of truth:** diagnostics and code actions must be derived from
   the server, not duplicated in client code.
 
@@ -109,19 +117,16 @@ that can be adopted when helpful.
 - `AGENTS.md#agent_obligations` defines LLM/agent obligations and refusal rules.
 - `POLICY_SEED.md#policy_seed` defines execution and CI safety constraints.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
+- `docs/normative_clause_index.md#normative_clause_index` defines stable clause IDs used by this guide.
 - `docs/enforceable_rules_cheat_sheet.md#enforceable_rules_cheat_sheet` provides a day-to-day implementation checklist backed by canonical clauses.
 
 ## Dataflow grammar invariant
-Recurring parameter bundles are treated as type-level obligations. Any bundle
-that crosses function boundaries must be promoted to a Protocol (dataclass
-config/local bundle), or explicitly documented in-place with:
+- Canonical rule: [`NCI-DATAFLOW-BUNDLE-TIERS`](docs/normative_clause_index.md#clause-dataflow-bundle-tiers).
+- In-place Tier-3 marker format remains:
 
 ```
 # dataflow-bundle: a1, a2, a3
 ```
-
-Tier-2 bundles must be reified before merge (see `[glossary.md#contract](glossary.md#contract)`).
-Tier-3 bundles must be documented with `# dataflow-bundle:` or reified.
 
 ## Refactor Under Ambiguity Pressure (normative)
 When ambiguity appears during refactors, contributors must apply the following
@@ -482,9 +487,7 @@ mise exec -- python scripts/refresh_baselines.py --all
 ```
 
 Baseline refresh guardrail (normative):
-- **Never** refresh a baseline to bypass a ratchet. `refresh_baselines.py` will
-  refuse to refresh when the corresponding gate is enabled and the delta is
-  positive. Clear the delta via real fixes first, then refresh at a checkpoint.
+- [`NCI-BASELINE-RATCHET`](docs/normative_clause_index.md#clause-baseline-ratchet).
 - Use `--timeout <seconds>` if a baseline refresh risks hanging.
 
 No-op CI cycle helper:
@@ -547,7 +550,8 @@ If `POLICY_GITHUB_TOKEN` is set, the CI workflow also runs the posture check
 
 ## Policy guardrails
 - Workflow changes must preserve the Prime Invariant in `POLICY_SEED.md#policy_seed`.
-- Actions must be pinned to full commit SHAs and allow-listed.
+- Action pinning: [`NCI-ACTIONS-PINNED`](docs/normative_clause_index.md#clause-actions-pinned).
+- Action allow-list: [`NCI-ACTIONS-ALLOWLIST`](docs/normative_clause_index.md#clause-actions-allowlist).
 - Self-hosted jobs must use the required labels and actor guard.
 Allow-listed actions are defined in `docs/allowed_actions.txt` and enforced by
 `scripts/policy_check.py`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 73
+doc_revision: 74
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -13,16 +13,19 @@ doc_requires:
   - glossary.md#contract
   - AGENTS.md#agent_obligations
   - CONTRIBUTING.md#contributing_contract
+  - docs/normative_clause_index.md#normative_clause_index
 doc_reviewed_as_of:
   POLICY_SEED.md#policy_seed: 1
   glossary.md#contract: 1
   AGENTS.md#agent_obligations: 1
   CONTRIBUTING.md#contributing_contract: 1
+  docs/normative_clause_index.md#normative_clause_index: 1
 doc_review_notes:
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance default; branch/tag CAS + check-before-use constraints); no conflicts with this document's scope."
   glossary.md#contract: "Reviewed glossary.md#contract rev1 (glossary contract + semantic typing discipline)."
   AGENTS.md#agent_obligations: "Agent obligations updated; README references remain valid."
   CONTRIBUTING.md#contributing_contract: "Reviewed CONTRIBUTING.md rev1 (docflow now fails on missing GH references for SPPF-relevant changes); no conflicts with this document's scope."
+  docs/normative_clause_index.md#normative_clause_index: "Clause IDs adopted as canonical obligation references to reduce duplicated prose drift."
 doc_sections:
   repo_contract: 1
 doc_section_requires:
@@ -31,6 +34,7 @@ doc_section_requires:
     - glossary.md#contract
     - AGENTS.md#agent_obligations
     - CONTRIBUTING.md#contributing_contract
+    - docs/normative_clause_index.md#normative_clause_index
 doc_section_reviews:
   repo_contract:
     POLICY_SEED.md#policy_seed:
@@ -53,6 +57,11 @@ doc_section_reviews:
       self_version_at_review: 1
       outcome: no_change
       note: "Contributor contract reviewed; repo contract unchanged."
+    docs/normative_clause_index.md#normative_clause_index:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Clause index reviewed; summary links remain aligned with canonical obligations."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
 doc_erasure:
   - formatting
@@ -75,7 +84,7 @@ conservative.
 
 ## Why Gabion
 - **Find implicit structure:** detect “dataflow grammar” bundles that repeatedly
-  travel together across function boundaries.
+  travel together across function boundaries ([`NCI-DATAFLOW-BUNDLE-TIERS`](docs/normative_clause_index.md#clause-dataflow-bundle-tiers)).
 - **Refactor safely:** promote bundles into explicit dataclass Protocols.
 - **Govern meaning:** enforce semantics via a normative glossary.
 
@@ -151,7 +160,8 @@ mise exec -- python -m gabion check
 `artifacts/audit_reports/dataflow_report.md` by default.
 Violation enforcement remains independent of report generation.
 Use `--baseline path/to/baseline.txt` to ratchet existing violations and
-`--baseline-write` to generate/update the baseline file.
+`--baseline-write` to generate/update the baseline file
+([`NCI-BASELINE-RATCHET`](docs/normative_clause_index.md#clause-baseline-ratchet)).
 
 For iterative local cleanup, keep a warm resume checkpoint between runs:
 ```
@@ -342,7 +352,8 @@ reuse one default checkpoint artifact safely even when each run touches a
 different chunk of the repository. The loader only hydrates paths present in
 the current run's file set *and* only when cache identities match.
 
-Allow-listed actions are defined in `docs/allowed_actions.txt`.
+Allow-listed actions are defined in `docs/allowed_actions.txt` and governed by
+[`NCI-ACTIONS-ALLOWLIST`](docs/normative_clause_index.md#clause-actions-allowlist).
 
 Pull requests also get a dataflow-grammar report artifact (and a comment on
 same-repo PRs) via `.github/workflows/pr-dataflow-grammar.yml`.
@@ -356,9 +367,8 @@ Example workflow (with pinned SHA placeholders):
 Pinning guide: `docs/pinning_actions.md`.
 
 ## Architecture (planned shape)
-- **LSP-first:** the language server is the semantic core; the CLI is a thin
-  LSP client. Editor integrations remain thin wrappers over the same server.
-  The server is the single source of truth for diagnostics and code actions.
+- **LSP-first:** [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first).
+  Editor integrations remain thin wrappers over the same server.
 - **Analysis:** import resolution, alias-aware identity tracking, fixed-point
   bundle propagation, and tiering. Type-flow, constant-flow, and unused-argument
   audits are part of the prototype coverage.
@@ -379,6 +389,7 @@ LLM/agent behavior is governed by `AGENTS.md#agent_obligations`.
 - `CONTRIBUTING.md#contributing_contract` defines workflow guardrails and dataflow grammar rules.
 - `AGENTS.md#agent_obligations` defines LLM/agent obligations.
 - `POLICY_SEED.md#policy_seed` defines execution and CI safety constraints.
+- `docs/normative_clause_index.md#normative_clause_index` defines stable clause IDs for repeated obligations.
 - `[glossary.md#contract](glossary.md#contract)` defines semantic meanings, axes, and commutation obligations.
 - `docs/enforceable_rules_cheat_sheet.md#enforceable_rules_cheat_sheet` provides an authoritative-by-proxy operator reference with clause-level source links.
 

--- a/docs/normative_clause_index.md
+++ b/docs/normative_clause_index.md
@@ -1,0 +1,119 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: normative_clause_index
+doc_role: normative_index
+doc_scope:
+  - repo
+  - ci
+  - agents
+  - governance
+doc_authority: normative
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - README.md#repo_contract
+  - CONTRIBUTING.md#contributing_contract
+  - AGENTS.md#agent_obligations
+  - glossary.md#contract
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 1
+  README.md#repo_contract: 1
+  CONTRIBUTING.md#contributing_contract: 1
+  AGENTS.md#agent_obligations: 1
+  glossary.md#contract: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Clause index derived from policy invariants to reduce duplicated prose drift."
+  README.md#repo_contract: "README obligation references consolidated to stable clause IDs."
+  CONTRIBUTING.md#contributing_contract: "Contributor-facing obligations consolidated behind stable clause IDs."
+  AGENTS.md#agent_obligations: "Agent obligations mapped to canonical clause anchors."
+  glossary.md#contract: "Dataflow tier references remain governed by glossary contract."
+doc_sections:
+  normative_clause_index: 1
+doc_section_requires:
+  normative_clause_index:
+    - POLICY_SEED.md#policy_seed
+    - README.md#repo_contract
+    - CONTRIBUTING.md#contributing_contract
+    - AGENTS.md#agent_obligations
+    - glossary.md#contract
+doc_section_reviews:
+  normative_clause_index:
+    POLICY_SEED.md#policy_seed:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Policy clauses indexed without changing normative meaning."
+    README.md#repo_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "README summary references verified against canonical clause IDs."
+    CONTRIBUTING.md#contributing_contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Contributor obligations reduced to clause references."
+    AGENTS.md#agent_obligations:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Agent obligations reduced to clause references."
+    glossary.md#contract:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Dataflow tier clauses stay glossary-aligned."
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_erasure:
+  - formatting
+  - typos
+doc_owner: maintainer
+---
+
+<a id="normative_clause_index"></a>
+# Normative Clause Index
+
+This document provides stable clause IDs for high-signal obligations that are
+repeated across governance-facing documents. Other docs should summarize and
+link to clause IDs instead of duplicating long-form normative prose.
+
+## Canonical clauses
+
+<a id="clause-lsp-first"></a>
+### `NCI-LSP-FIRST` — LSP-first semantic core
+- The language server is the semantic core.
+- The CLI must remain a thin LSP client and must not duplicate core analysis.
+- Canonical sources: `POLICY_SEED.md#policy_seed`, `CONTRIBUTING.md#contributing_contract`.
+
+<a id="clause-actions-pinned"></a>
+### `NCI-ACTIONS-PINNED` — Workflow action pinning
+- Workflow actions must be pinned to full commit SHAs.
+- Canonical sources: `POLICY_SEED.md#policy_seed`, `README.md#repo_contract`.
+
+<a id="clause-actions-allowlist"></a>
+### `NCI-ACTIONS-ALLOWLIST` — Workflow action allow-list
+- Workflow actions must be allow-listed.
+- Canonical source of allow-listed entries: `docs/allowed_actions.txt`.
+- Canonical policy source: `POLICY_SEED.md#policy_seed`.
+
+<a id="clause-dataflow-bundle-tiers"></a>
+### `NCI-DATAFLOW-BUNDLE-TIERS` — Dataflow bundle tier obligations
+- Recurring parameter bundles crossing function boundaries are type-level obligations.
+- Tier-2 bundles must be reified before merge.
+- Tier-3 bundles must be reified or documented with `# dataflow-bundle:`.
+- Canonical sources: `[glossary.md#contract](../glossary.md#contract)`, `AGENTS.md#agent_obligations`, `CONTRIBUTING.md#contributing_contract`.
+
+<a id="clause-baseline-ratchet"></a>
+### `NCI-BASELINE-RATCHET` — Baseline ratchet integrity
+- Baselines are ratchet checkpoints, not bypass levers.
+- Do not refresh baselines to bypass positive deltas while gates are enabled.
+- Canonical source: `CONTRIBUTING.md#contributing_contract`.
+
+## Usage rule
+
+When referencing one of these obligations in `README.md`, `CONTRIBUTING.md`,
+or `AGENTS.md`, use a short summary with direct clause links, for example:
+
+- `NCI-LSP-FIRST` (`docs/normative_clause_index.md#clause-lsp-first`)
+- `NCI-DATAFLOW-BUNDLE-TIERS` (`docs/normative_clause_index.md#clause-dataflow-bundle-tiers`)
+

--- a/src/gabion_governance/governance_audit_impl.py
+++ b/src/gabion_governance/governance_audit_impl.py
@@ -86,6 +86,7 @@ GOVERNANCE_DOCS = CORE_GOVERNANCE_DOCS + [
     "docs/publishing_practices.md",
     "docs/influence_index.md",
     "docs/coverage_semantics.md",
+    "docs/normative_clause_index.md",
     "docs/matrix_acceptance.md",
     "docs/sppf_checklist.md",
 ]


### PR DESCRIPTION
### Motivation
- Reduce semantic drift caused by duplicated long-form governance prose across docs by centralizing high-signal obligations behind stable clause IDs. 
- Provide concise, linkable anchors for repeated obligations (LSP-first, action pinning, allow-listing, dataflow-bundle tiers, baseline ratchet) so docflow reviews resolve deterministically.

### Description
- Add `docs/normative_clause_index.md` with canonical clause IDs: `NCI-LSP-FIRST`, `NCI-ACTIONS-PINNED`, `NCI-ACTIONS-ALLOWLIST`, `NCI-DATAFLOW-BUNDLE-TIERS`, and `NCI-BASELINE-RATCHET`, and usage guidance. 
- Replace repeated long-form obligation text in `README.md`, `CONTRIBUTING.md`, and `AGENTS.md` with short summaries that link to the new clause IDs and update each file's front-matter to declare the new dependency. 
- Wire the clause index into the docflow discovery set by adding `docs/normative_clause_index.md` to `GOVERNANCE_DOCS` in `src/gabion_governance/governance_audit_impl.py` so `doc_reviewed_as_of` and docflow invariant checks resolve. 
- Update in-file review metadata (`doc_reviewed_as_of` / `doc_review_notes`) entries to record that the clause index was adopted and verified against the referenced governance documents.

### Testing
- Ran the docflow audit with the repo-installed module via `PYTHONPATH=src python -m gabion docflow --fail-on-violations`, and the audit completed with warnings but no new violations after wiring the clause index (pass). 
- Ran the targeted governance unit test `tests/test_audit_tools_obligations.py` with `pytest -q -o addopts='' tests/test_audit_tools_obligations.py`, and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cee973f088324a969ac4b46f3f8c8)