### PR TITLE
Add LSP maturity/parity governance and `gabion lsp-parity-gate` subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,8 @@ jobs:
             args+=(--fail-on-severity "$CONTROLLER_DRIFT_FAIL_ON")
           fi
           .venv/bin/python scripts/governance_controller_audit.py "${args[@]}"
+      - name: LSP parity gate
+        run: .venv/bin/python -m gabion lsp-parity-gate --command gabion.check
       - name: Tests
         run: |
           mkdir -p artifacts/test_runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 19
+doc_revision: 20
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: agents
 doc_role: agent
@@ -87,6 +87,8 @@ Semantic correctness is governed by `[glossary.md#contract](glossary.md#contract
   surface any violations explicitly.
 - Preserve the LSP-first invariant: the server is the semantic core and the
   CLI remains a thin LSP client.
+- Enforce maturity transport policy: `experimental`/`debug` may use direct diagnostics, but `beta`/`production` must be validated over the LSP carrier and cannot rely on direct-only validation.
+- Keep semantic behavior in server command handlers exposed via `gabion` subcommands; treat `scripts/` as orchestration wrappers only.
 - Use `mise exec -- python` for repo-local tooling to ensure the pinned
   interpreter and dependencies are used.
 - Prefer impossible-by-construction contracts over sentinel parse outcomes;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 97
+doc_revision: 98
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -97,6 +97,8 @@ valid.
 ## Architectural invariants (normative)
 - **LSP-first invariant:** the language server is the semantic core; the CLI is
   a thin LSP client and must not import or reimplement analysis logic.
+- **Maturity/transport policy:** `experimental` and `debug` may use direct-path diagnostics; `beta` and `production` require LSP-carrier validation and cannot treat direct path as the only normative route.
+- **Semantic ownership boundary:** user-facing semantics must live in server command handlers and be exposed as `gabion` subcommands. `scripts/` are orchestration wrappers (CI/bootstrap/audit), never canonical semantic engines.
 - **Single source of truth:** diagnostics and code actions must be derived from
   the server, not duplicated in client code.
 

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 42
+doc_revision: 43
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -149,6 +149,14 @@ MUST be preserved throughout functional code; and data leaving functional code
 MUST be order-enforced at the boundary without serializer-level re-sorting for
 already-canonical carriers. Any explicit sort enforcement MUST disclose its sort
 key/function (or comparator shape) and rationale.
+
+
+**Maturity/transport invariant:** `experimental` and `debug` commands may allow
+direct-path diagnostics; `beta` and `production` commands MUST require validated
+LSP-carrier execution, and direct dispatch MUST NOT be the normative-only path.
+
+**Readiness invariant:** A feature MUST NOT be classified as `beta` or
+`production` unless it has been validated over the LSP carrier.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 73
+doc_revision: 74
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: readme
 doc_role: readme
@@ -81,6 +81,8 @@ conservative.
 
 ## Status
 - CLI uses the LSP server as its semantic core.
+- Transport maturity policy: `experimental`/`debug` commands may use direct diagnostics, while `beta`/`production` commands require validated LSP-carrier execution.
+- A feature is not `beta`/`production` unless it has passed LSP-carrier validation.
 - Dataflow grammar audit is implemented (prototype).
 - Type-flow, constant-flow, and unused-argument smells are implemented (prototype).
 - Refactor engine can rewrite signatures/call sites for targeted functions (prototype).

--- a/docs/governance_rules.yaml
+++ b/docs/governance_rules.yaml
@@ -111,3 +111,47 @@ gates:
     warning_prefix: Docflow contradictions warning
     blocking_prefix: Docflow contradictions increased
     ok_prefix: Docflow delta OK
+
+command_policies:
+  gabion.check:
+    maturity: beta
+    require_lsp_carrier: true
+    parity_required: true
+    probe_payload:
+      paths: [src/gabion/commands/command_ids.py]
+      fail_on_violations: false
+      analysis_timeout_ticks: 200
+      analysis_timeout_tick_ns: 1000000
+    parity_ignore_keys: [timeout_context]
+  gabion.dataflowAudit:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.decisionDiff:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.impactQuery:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.lspParityGate:
+    maturity: debug
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.refactorProtocol:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.structureDiff:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.structureReuse:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false
+  gabion.synthesisPlan:
+    maturity: experimental
+    require_lsp_carrier: false
+    parity_required: false

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -25,6 +25,7 @@ done
 
 if $list_only; then
   echo "Checks to run:" >&2
+  $run_dataflow && echo "- lsp parity gate (gabion lsp-parity-gate --command gabion.check)" >&2
   $run_dataflow && echo "- dataflow (gabion check)" >&2
   $run_docflow && echo "- docflow (gabion docflow --fail-on-violations --sppf-gh-ref-mode $docflow_mode)" >&2
   $run_tests && echo "- tests (pytest)" >&2
@@ -37,6 +38,7 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 
 if $run_dataflow; then
+  mise exec -- python -m gabion lsp-parity-gate --command gabion.check
   baseline_arg=()
   if [ -f baselines/dataflow_baseline.txt ]; then
     baseline_arg+=(--baseline baselines/dataflow_baseline.txt)

--- a/src/gabion/commands/command_ids.py
+++ b/src/gabion/commands/command_ids.py
@@ -5,6 +5,7 @@ CHECK_COMMAND = "gabion.check"
 DATAFLOW_COMMAND = "gabion.dataflowAudit"
 DECISION_DIFF_COMMAND = "gabion.decisionDiff"
 IMPACT_COMMAND = "gabion.impactQuery"
+LSP_PARITY_GATE_COMMAND = "gabion.lspParityGate"
 REFACTOR_COMMAND = "gabion.refactorProtocol"
 STRUCTURE_DIFF_COMMAND = "gabion.structureDiff"
 STRUCTURE_REUSE_COMMAND = "gabion.structureReuse"
@@ -17,6 +18,7 @@ SEMANTIC_COMMAND_IDS: tuple[str, ...] = (
     DATAFLOW_COMMAND,
     DECISION_DIFF_COMMAND,
     IMPACT_COMMAND,
+    LSP_PARITY_GATE_COMMAND,
     REFACTOR_COMMAND,
     STRUCTURE_DIFF_COMMAND,
     STRUCTURE_REUSE_COMMAND,

--- a/src/gabion/commands/direct_dispatch.py
+++ b/src/gabion/commands/direct_dispatch.py
@@ -17,6 +17,7 @@ _UNORDERED_DIRECT_EXECUTORS: dict[str, DirectExecutor] = {
     command_ids.SYNTHESIS_COMMAND: server.execute_synthesis,
     command_ids.REFACTOR_COMMAND: server.execute_refactor,
     command_ids.IMPACT_COMMAND: server.execute_impact,
+    command_ids.LSP_PARITY_GATE_COMMAND: server.execute_lsp_parity_gate,
 }
 
 

--- a/src/gabion/commands/payload_codec.py
+++ b/src/gabion/commands/payload_codec.py
@@ -133,3 +133,13 @@ def _positive_int(value: object, *, field: str) -> int:
     if parsed <= 0:
         never(f"invalid {field}", value=value)
     return parsed
+
+
+def normalized_command_id_list(payload: Mapping[str, object], *, key: str) -> tuple[str, ...]:
+    raw = payload.get(key)
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        never("invalid command id list", key=key, value_type=type(raw).__name__)
+    normalized = [str(item) for item in raw]
+    return tuple(sort_once(normalized, source=f"payload_codec.normalized_command_id_list.{key}"))

--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -149,3 +149,19 @@ class StructureReuseResponseDTO(BaseModel):
     reuse: Optional[Dict[str, Any]] = None
     lemma_stubs: Optional[str] = None
     errors: List[str] = []
+
+
+class LspParityCommandResultDTO(BaseModel):
+    command_id: str
+    maturity: str
+    require_lsp_carrier: bool
+    parity_required: bool
+    lsp_validated: bool
+    parity_ok: bool
+    error: Optional[str] = None
+
+
+class LspParityGateResponseDTO(BaseModel):
+    exit_code: int = 0
+    checked_commands: List[LspParityCommandResultDTO] = []
+    errors: List[str] = []

--- a/src/gabion/server_core/command_contract.py
+++ b/src/gabion/server_core/command_contract.py
@@ -34,3 +34,21 @@ class ProgressEvent:
 class CommandRuntimeOutcome:
     response: dict[str, object]
     terminal_phase: str
+
+
+@dataclass(frozen=True)
+class LspParityCommandResult:
+    command_id: str
+    maturity: str
+    require_lsp_carrier: bool
+    parity_required: bool
+    lsp_validated: bool
+    parity_ok: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class LspParityGateOutcome:
+    exit_code: int
+    checked_commands: tuple[LspParityCommandResult, ...]
+    errors: tuple[str, ...]

--- a/tests/test_lsp_parity_gate.py
+++ b/tests/test_lsp_parity_gate.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from gabion import cli, server
+from gabion.tooling.governance_rules import CommandPolicy, GovernanceRules
+
+
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_beta_command_fails_gate_when_lsp_validation_missing::server.py::gabion.server._execute_lsp_parity_gate_total
+def test_beta_command_fails_gate_when_lsp_validation_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        server,
+        "load_governance_rules",
+        lambda: GovernanceRules(
+            override_token_env="TOKEN",
+            gates={},
+            command_policies={
+                "gabion.check": CommandPolicy(
+                    command_id="gabion.check",
+                    maturity="beta",
+                    require_lsp_carrier=True,
+                    parity_required=True,
+                    probe_payload=None,
+                    parity_ignore_keys=(),
+                )
+            },
+        ),
+    )
+    ls = SimpleNamespace(workspace=SimpleNamespace(root_path="."))
+    result = server._execute_lsp_parity_gate_total(ls, {})
+    assert result["exit_code"] == 1
+    assert "requires LSP validation" in result["errors"][0]
+
+
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_parity_gate_normalizes_payload_and_is_deterministic::server.py::gabion.server._execute_lsp_parity_gate_total
+def test_parity_gate_normalizes_payload_and_is_deterministic(monkeypatch) -> None:
+    monkeypatch.setattr(
+        server,
+        "load_governance_rules",
+        lambda: GovernanceRules(
+            override_token_env="TOKEN",
+            gates={},
+            command_policies={
+                "gabion.check": CommandPolicy(
+                    command_id="gabion.check",
+                    maturity="beta",
+                    require_lsp_carrier=True,
+                    parity_required=True,
+                    probe_payload={"z": 1, "a": 2},
+                    parity_ignore_keys=(),
+                )
+            },
+        ),
+    )
+
+    def _lsp(_ls, payload):
+        return {"k": payload.get("a"), "m": payload.get("z")}
+
+    def _direct(_ls, payload):
+        return {"m": payload.get("z"), "k": payload.get("a")}
+
+    monkeypatch.setattr(server, "_lsp_command_executor", lambda _command: _lsp)
+    monkeypatch.setattr(server.direct_dispatch, "direct_executor", lambda _command: _direct)
+
+    ls = SimpleNamespace(workspace=SimpleNamespace(root_path="."))
+    first = server._execute_lsp_parity_gate_total(ls, {})
+    second = server._execute_lsp_parity_gate_total(ls, {})
+    assert first == second
+    assert first["exit_code"] == 0
+    assert first["checked_commands"][0]["parity_ok"] is True
+
+
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_cli_lsp_parity_gate_is_thin_dispatcher::cli.py::gabion.cli.lsp_parity_gate
+def test_cli_lsp_parity_gate_is_thin_dispatcher(monkeypatch) -> None:
+    calls: list[tuple[list[str] | None, object]] = []
+
+    def _run(*, commands=None, root=None, runner=None):
+        calls.append((commands, root))
+        return {"exit_code": 0, "checked_commands": [], "errors": []}
+
+    monkeypatch.setattr(cli, "run_lsp_parity_gate", _run)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["lsp-parity-gate", "--command", "gabion.check"])
+    assert result.exit_code == 0
+    assert calls == [(["gabion.check"], None)]

--- a/tests/test_runtime_kernel_contracts.py
+++ b/tests/test_runtime_kernel_contracts.py
@@ -132,6 +132,7 @@ def test_delta_gate_error_and_ok_branches(tmp_path: Path, capsys: pytest.Capture
         delta_gate.load_governance_rules = lambda: governance_rules.GovernanceRules(
             override_token_env="TOKEN",
             gates={},
+            command_policies={},
         )
         with pytest.raises(ValueError):
             delta_gate._policy_spec("missing_gate")
@@ -172,6 +173,7 @@ def test_delta_gate_error_and_ok_branches(tmp_path: Path, capsys: pytest.Capture
         delta_gate.load_governance_rules = lambda: governance_rules.GovernanceRules(
             override_token_env="TOKEN",
             gates={"obsolescence_opaque": policy},
+            command_policies={},
         )
         assert delta_gate._check_standard_gate(spec, path, enabled=True) == 0
     finally:


### PR DESCRIPTION
### Motivation
- Make maturity and transport policy explicit and enforceable so `beta`/`production` features must be validated over the LSP carrier while `experimental`/`debug` retain direct diagnostic paths. 
- Encode per-command maturity/parity metadata in the governed config so tooling can gate readiness deterministically. 
- Provide a server-owned, carrier-aware parity gate exposed as a `gabion` subcommand to keep semantic logic in the LSP server and avoid adding standalone scripts. 

### Description
- Normative docs updated to codify the transport/maturity rules and ownership boundary in `POLICY_SEED.md`, `README.md`, `CONTRIBUTING.md`, and `AGENTS.md` (bumped doc revisions and added the readiness/maturity clauses). 
- Governance schema extended to include `command_policies` and a `CommandPolicy` type (fields: `maturity`, `require_lsp_carrier`, `parity_required`, `probe_payload`, `parity_ignore_keys`) and `docs/governance_rules.yaml` populated with initial per-command entries. 
- Added command ID `gabion.lspParityGate` and payload helpers (`normalized_command_id_list`) and wired a server-side implementation `_execute_lsp_parity_gate_total` that: normalizes probe payloads, invokes the LSP path and the direct executor, strips configured non-semantic keys, compares normalized structural results deterministically, and enforces `require_lsp_carrier`/parity policies. 
- Exposed the gate via a CLI thin-wrapper `gabion lsp-parity-gate` (no new standalone Python scripts), registered direct-dispatch support for diagnostics, and integrated the subcommand into `scripts/checks.sh` and the CI audit/check lane. 
- Added tests (`tests/test_lsp_parity_gate.py`) that assert blocking for beta/production commands lacking LSP validation, deterministic normalized parity comparison, and that the CLI is a thin dispatcher; adjusted existing governance-related tests to accept the new metadata shape. 

### Testing
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_lsp_parity_gate.py tests/test_command_dispatch_registry.py tests/test_runtime_kernel_contracts.py` which completed successfully with all tests passing (`16 passed`). 
- Exercised the new gate end-to-end via the CLI with `PYTHONPATH=src python -m gabion lsp-parity-gate --command gabion.check`, which produced a successful parity outcome (exit_code 0) against the configured probe payload after parity-ignore tuning. 
- Verified `scripts/checks.sh --list` shows the new lsp parity gate entry and updated CI step was added to the audit lane. 
- Note: an initial attempt to run the suite via `mise exec` in this environment hit trust/network/toolchain resolution constraints, so tests were validated with a PYTHONPATH-driven runner instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d01af66f083248967699cb65d424f)