### PR TITLE
Enforce maturity-aware transport and codify auditable CI override controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,27 +45,7 @@ jobs:
           .venv/bin/uv pip sync requirements.lock
           .venv/bin/uv pip install -e .
       - name: Seed version-controlled dataflow resume checkpoint (best effort)
-        run: |
-          target_dir="artifacts/audit_reports"
-          seed_checkpoint="baselines/dataflow_resume_checkpoint_ci.json"
-          seed_chunks="baselines/dataflow_resume_checkpoint_ci.json.chunks"
-          mkdir -p "$target_dir"
-          restored=0
-          if [ -f "$seed_checkpoint" ]; then
-            cp "$seed_checkpoint" "$target_dir/dataflow_resume_checkpoint_ci.json"
-            restored=1
-          fi
-          if [ -d "$seed_chunks" ]; then
-            rm -rf "$target_dir/dataflow_resume_checkpoint_ci.json.chunks"
-            mkdir -p "$target_dir/dataflow_resume_checkpoint_ci.json.chunks"
-            cp -R "$seed_chunks"/. "$target_dir/dataflow_resume_checkpoint_ci.json.chunks/"
-            restored=1
-          fi
-          if [ "$restored" = "1" ]; then
-            echo "Seeded checkpoint from version-controlled baseline."
-          else
-            echo "No version-controlled checkpoint seed found; continuing."
-          fi
+        run: .venv/bin/python scripts/ci_seed_dataflow_checkpoint.py
       - name: Restore previous dataflow resume checkpoint (best effort)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -93,42 +73,12 @@ jobs:
           TERMINAL_STATUS: ${{ steps.dataflow_stage.outputs.terminal_status }}
           ATTEMPTS_RUN: ${{ steps.dataflow_stage.outputs.attempts_run }}
         run: |
-          terminal_stage="${TERMINAL_STAGE:-none}"
-          terminal_exit="${TERMINAL_EXIT:-}"
-          terminal_state="${TERMINAL_STATE:-none}"
-          terminal_status="${TERMINAL_STATUS:-unknown}"
-          attempts_run="${ATTEMPTS_RUN:-0}"
-          if [ -z "$terminal_exit" ]; then
-            echo "No dataflow audit stage produced an exit code."
-            exit 1
-          fi
-          if [ "$terminal_status" = "unknown" ]; then
-            if [ "$terminal_exit" = "0" ]; then
-              terminal_status="success"
-            elif [ "$terminal_state" = "timed_out_progress_resume" ]; then
-              terminal_status="timeout_resume"
-            else
-              terminal_status="hard_failure"
-            fi
-          fi
-          echo "terminal_stage=$terminal_stage attempts=$attempts_run exit_code=$terminal_exit analysis_state=$terminal_state status=$terminal_status"
-          if [ "$terminal_status" = "success" ]; then
-            exit 0
-          fi
-          if [ -f artifacts/audit_reports/dataflow_report.md ]; then
-            echo "===== dataflow report ====="
-            cat artifacts/audit_reports/dataflow_report.md
-          fi
-          if [ -f artifacts/audit_reports/timeout_progress.md ]; then
-            echo "===== timeout progress ====="
-            cat artifacts/audit_reports/timeout_progress.md
-          fi
-          if [ "$terminal_status" = "timeout_resume" ]; then
-            echo "Dataflow audit invocation timed out with resumable progress."
-            exit 1
-          fi
-          echo "Dataflow audit failed for a non-timeout reason."
-          exit 1
+          .venv/bin/python scripts/ci_finalize_dataflow_outcome.py \
+            --terminal-exit "${TERMINAL_EXIT:-}" \
+            --terminal-state "${TERMINAL_STATE:-none}" \
+            --terminal-stage "${TERMINAL_STAGE:-none}" \
+            --terminal-status "${TERMINAL_STATUS:-unknown}" \
+            --attempts-run "${ATTEMPTS_RUN:-0}"
       - name: Deadline profile summary
         if: always()
         run: |
@@ -251,15 +201,15 @@ jobs:
         run: .venv/bin/python scripts/branchless_policy_check.py --root .
       - name: Policy check (defensive fallback)
         run: .venv/bin/python scripts/defensive_fallback_policy_check.py --root .
-      - name: Controller drift audit (advisory, ratchet-ready)
-        env:
-          CONTROLLER_DRIFT_FAIL_ON: ${{ vars.CONTROLLER_DRIFT_FAIL_ON || '' }}
+      - name: Controller drift audit
+        run: .venv/bin/python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json
+      - name: Override lifecycle record emit
+        run: .venv/bin/python scripts/ci_override_record_emit.py --out artifacts/out/governance_override_record.json
+      - name: Controller drift gate
         run: |
-          args=(--out artifacts/out/controller_drift.json)
-          if [ -n "${CONTROLLER_DRIFT_FAIL_ON:-}" ]; then
-            args+=(--fail-on-severity "$CONTROLLER_DRIFT_FAIL_ON")
-          fi
-          .venv/bin/python scripts/governance_controller_audit.py "${args[@]}"
+          .venv/bin/python scripts/ci_controller_drift_gate.py \
+            --drift-artifact artifacts/out/controller_drift.json \
+            --override-record artifacts/out/governance_override_record.json
       - name: LSP parity gate
         run: .venv/bin/python -m gabion lsp-parity-gate --command gabion.check
       - name: Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 101
+doc_revision: 102
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -549,7 +549,7 @@ It uses `mise` (via `gabion.toml`) to install the toolchain.
 For push-driven `dataflow-grammar`, prefer warm caches:
 - CI restores the previous same-branch `dataflow-report` artifact's resume
   checkpoint (`dataflow_resume_checkpoint_ci.json`) on a best-effort basis.
-- `gabion run-dataflow-stage` emits resume metrics in logs/step-summary
+- `scripts/ci_seed_dataflow_checkpoint.py` and `scripts/ci_finalize_dataflow_outcome.py` are the CI orchestration entrypoints around `gabion run-dataflow-stage`; the gabion command still emits resume metrics in logs/step-summary
   (`completed_paths`, `hydrated_paths`, `paths_parsed_after_resume`) so cache
   impact can be verified explicitly.
 - Keep resume identity stable (forest spec / fingerprint seed / strictness
@@ -574,6 +574,9 @@ Run:
 ```
 mise exec -- python -m pip install pyyaml
 mise exec -- python scripts/policy_check.py --workflows
+mise exec -- python scripts/ci_seed_dataflow_checkpoint.py
+mise exec -- python scripts/ci_finalize_dataflow_outcome.py --terminal-exit 0
+mise exec -- python scripts/ci_controller_drift_gate.py --drift-artifact artifacts/out/controller_drift.json
 ```
 Posture checks require `POLICY_GITHUB_TOKEN` with admin read access:
 ```

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 45
+doc_revision: 46
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -819,3 +819,13 @@ If you want next steps, I can:
 * Tie this explicitly to your Prism “advance → quotient → recognition” framework as a security analogue.
 
 Just tell me how far you want to push the self-referential loop.
+
+## 4.9 Second-order controller adaptation protocol
+
+- Canonical clauses: [`NCI-DEADLINE-TIMEOUT-PROPAGATION`](docs/normative_clause_index.md#clause-deadline-timeout-propagation), [`NCI-CONTROLLER-ADAPTATION-LAW`](docs/normative_clause_index.md#clause-controller-adaptation-law), [`NCI-OVERRIDE-LIFECYCLE`](docs/normative_clause_index.md#clause-override-lifecycle).
+- Adaptation triggers (telemetry-derived): parity instability, chronic timeout resumes, and recurring gate-noise false positives.
+- Allowed bounded control moves: timeout budget tuning, retry-profile shaping, and drift-threshold class adjustments declared in `docs/governance_rules.yaml`.
+- Forbidden compensations: baseline refresh as bypass, silent strictness downgrades, and undeclared transport downgrades.
+- Overrides must emit machine-readable records with: `actor`, `rationale`, `scope`, `start`, `expiry`, `rollback_condition`, `evidence_links`.
+- CI must fail when override metadata is missing/incomplete or expiry has elapsed.
+- Post-override convergence requirement: affected gates/paths must pass for at least `consecutive_passes_required` runs before stabilization is declared.

--- a/docs/governance_rules.yaml
+++ b/docs/governance_rules.yaml
@@ -112,6 +112,14 @@ gates:
     blocking_prefix: Docflow contradictions increased
     ok_prefix: Docflow delta OK
 
+controller_drift:
+  severity_classes: [low, medium, high, critical]
+  enforce_at_or_above: high
+  remediation_by_severity:
+    high: corrective_controller_or_policy_update_or_temporary_override
+    critical: immediate_corrective_update_required
+  consecutive_passes_required: 3
+
 command_policies:
   gabion.check:
     maturity: beta

--- a/docs/normative_clause_index.md
+++ b/docs/normative_clause_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 2
+doc_revision: 3
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: normative_clause_index
 doc_role: normative_index
@@ -116,6 +116,27 @@ link to clause IDs instead of duplicating long-form normative prose.
 - Baselines are ratchet checkpoints, not bypass levers.
 - Do not refresh baselines to bypass positive deltas while gates are enabled.
 - Canonical source: `CONTRIBUTING.md#contributing_contract`.
+
+
+<a id="clause-deadline-timeout-propagation"></a>
+### `NCI-DEADLINE-TIMEOUT-PROPAGATION` — Deadline carrier propagation
+- Timeout/deadline tokens must propagate across CLI dispatch, LSP transport, and CI wrappers.
+- Timeout recovery state must be emitted as deterministic machine-readable artifacts.
+- Canonical sources: `POLICY_SEED.md#policy_seed`, `CONTRIBUTING.md#contributing_contract`.
+
+<a id="clause-controller-adaptation-law"></a>
+### `NCI-CONTROLLER-ADAPTATION-LAW` — Second-order controller adaptation law
+- Adaptation is trigger-driven (parity instability, timeout resume churn, gate noise).
+- Allowed moves are bounded to declared knobs and require telemetry/evidence links.
+- Forbidden compensations include baseline-refresh bypasses and silent strictness downgrades.
+- Canonical source: `POLICY_SEED.md#policy_seed`.
+
+<a id="clause-override-lifecycle"></a>
+### `NCI-OVERRIDE-LIFECYCLE` — Override lifecycle governance
+- Override channels require machine-readable records with actor, rationale, scope, start, expiry, rollback condition, and evidence links.
+- Expired or metadata-incomplete overrides fail governance gates.
+- Post-override convergence requires consecutive clean runs before stabilization is declared.
+- Canonical sources: `POLICY_SEED.md#policy_seed`, `docs/governance_rules.yaml`.
 
 ## Usage rule
 

--- a/scripts/ci_controller_drift_gate.py
+++ b/scripts/ci_controller_drift_gate.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from gabion.tooling.governance_rules import load_governance_rules
+
+SEVERITY = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
+    rules = load_governance_rules().controller_drift
+    drift = _load_json(drift_artifact)
+    findings = drift.get("findings", [])
+    max_rank = 0
+    for finding in findings if isinstance(findings, list) else []:
+        sev = str((finding or {}).get("severity", "")).lower()
+        max_rank = max(max_rank, SEVERITY.get(sev, 0))
+    enforce_rank = SEVERITY.get(rules.enforce_at_or_above.lower(), 99)
+    override_used = override_record.exists()
+    override_valid = False
+    override_payload: dict[str, object] | None = None
+    if override_used:
+        override_payload = _load_json(override_record)
+        required = {"actor", "rationale", "scope", "start", "expiry", "rollback_condition", "evidence_links"}
+        override_valid = required.issubset(set(override_payload.keys()))
+        if override_valid:
+            override_valid = _parse_time(str(override_payload["expiry"])) > datetime.now(timezone.utc)
+
+    status = "pass"
+    if max_rank >= enforce_rank:
+        status = "override" if override_valid else "fail"
+
+    payload = {
+        "status": status,
+        "max_severity_rank": max_rank,
+        "enforce_at_or_above": rules.enforce_at_or_above,
+        "required_remediation": rules.remediation_by_severity,
+        "override_record": override_payload,
+        "consecutive_passes_required": rules.consecutive_passes_required,
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 2 if status == "fail" else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--drift-artifact", type=Path, required=True)
+    parser.add_argument("--override-record", type=Path, default=Path("artifacts/out/governance_override_record.json"))
+    parser.add_argument("--out", type=Path, default=Path("artifacts/out/controller_drift_gate.json"))
+    args = parser.parse_args()
+    return run(drift_artifact=args.drift_artifact, override_record=args.override_record, out=args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_finalize_dataflow_outcome.py
+++ b/scripts/ci_finalize_dataflow_outcome.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _emit(path: Path, label: str) -> None:
+    if not path.exists():
+        return
+    print(f"===== {label} =====")
+    print(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--terminal-exit", required=True)
+    parser.add_argument("--terminal-state", default="none")
+    parser.add_argument("--terminal-stage", default="none")
+    parser.add_argument("--terminal-status", default="unknown")
+    parser.add_argument("--attempts-run", default="0")
+    args = parser.parse_args()
+
+    terminal_status = args.terminal_status
+    if terminal_status == "unknown":
+        if args.terminal_exit == "0":
+            terminal_status = "success"
+        elif args.terminal_state == "timed_out_progress_resume":
+            terminal_status = "timeout_resume"
+        else:
+            terminal_status = "hard_failure"
+    print(
+        "terminal_stage="
+        f"{args.terminal_stage} attempts={args.attempts_run} "
+        f"exit_code={args.terminal_exit} analysis_state={args.terminal_state} status={terminal_status}"
+    )
+    if terminal_status == "success":
+        return 0
+    _emit(Path("artifacts/audit_reports/dataflow_report.md"), "dataflow report")
+    _emit(Path("artifacts/audit_reports/timeout_progress.md"), "timeout progress")
+    if terminal_status == "timeout_resume":
+        print("Dataflow audit invocation timed out with resumable progress.")
+        return 1
+    print("Dataflow audit failed for a non-timeout reason.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_override_record_emit.py
+++ b/scripts/ci_override_record_emit.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED = {"actor", "rationale", "scope", "start", "expiry", "rollback_condition", "evidence_links"}
+
+
+def _parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=Path("artifacts/out/governance_override_record.json"))
+    args = parser.parse_args()
+
+    override_channels = {
+        "direct_transport": os.getenv("GABION_DIRECT_RUN_OVERRIDE_EVIDENCE", "").strip(),
+        "controller_drift": os.getenv("CONTROLLER_DRIFT_OVERRIDE", "").strip(),
+    }
+    active = {k: v for k, v in override_channels.items() if v}
+    raw_record = os.getenv("GABION_OVERRIDE_RECORD_JSON", "").strip()
+    payload: dict[str, object] = {"active_channels": active, "override_record": None}
+    if active:
+        if not raw_record:
+            raise SystemExit("override channels active but GABION_OVERRIDE_RECORD_JSON is missing")
+        record = json.loads(raw_record)
+        if not isinstance(record, dict) or not REQUIRED.issubset(set(record.keys())):
+            raise SystemExit("override record missing required schema fields")
+        if _parse_time(str(record["expiry"])) <= datetime.now(timezone.utc):
+            raise SystemExit("override record expired")
+        payload["override_record"] = record
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_seed_dataflow_checkpoint.py
+++ b/scripts/ci_seed_dataflow_checkpoint.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-dir", type=Path, default=Path("artifacts/audit_reports"))
+    parser.add_argument("--seed-checkpoint", type=Path, default=Path("baselines/dataflow_resume_checkpoint_ci.json"))
+    parser.add_argument("--seed-chunks", type=Path, default=Path("baselines/dataflow_resume_checkpoint_ci.json.chunks"))
+    args = parser.parse_args()
+
+    args.target_dir.mkdir(parents=True, exist_ok=True)
+    restored = False
+    target_checkpoint = args.target_dir / "dataflow_resume_checkpoint_ci.json"
+    target_chunks = args.target_dir / "dataflow_resume_checkpoint_ci.json.chunks"
+    if args.seed_checkpoint.is_file():
+        shutil.copy2(args.seed_checkpoint, target_checkpoint)
+        restored = True
+    if args.seed_chunks.is_dir():
+        if target_chunks.exists():
+            shutil.rmtree(target_chunks)
+        shutil.copytree(args.seed_chunks, target_chunks)
+        restored = True
+    print(
+        "Seeded checkpoint from version-controlled baseline."
+        if restored
+        else "No version-controlled checkpoint seed found; continuing."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/governance_controller_audit.py
+++ b/scripts/governance_controller_audit.py
@@ -178,10 +178,22 @@ def run(policy_path: Path, out_path: Path, fail_on_severity: str | None) -> int:
                 }
             )
 
+    severity_counts = {"low": 0, "medium": 0, "high": 0, "critical": 0}
+    for item in findings:
+        sev = str(item.get("severity", "")).lower()
+        if sev in severity_counts:
+            severity_counts[sev] += 1
+    highest = "none"
+    for candidate in ("critical", "high", "medium", "low"):
+        if severity_counts[candidate] > 0:
+            highest = candidate
+            break
     summary = {
         "total_findings": len(findings),
         "high_severity_findings": sum(1 for item in findings if str(item.get("severity")) == "high"),
         "sensors": sorted({str(item.get("sensor")) for item in findings}),
+        "severity_counts": severity_counts,
+        "highest_severity": highest,
     }
 
     payload = {

--- a/tests/test_ci_governance_scripts.py
+++ b/tests/test_ci_governance_scripts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import ci_controller_drift_gate as drift_gate
+from scripts import policy_check
+
+
+def test_policy_check_requires_ci_script_entrypoints() -> None:
+    errors: list[str] = []
+    policy_check._check_ci_script_entrypoints(
+        {
+            "jobs": {
+                "checks": {
+                    "steps": [
+                        {"run": "python scripts/ci_seed_dataflow_checkpoint.py"},
+                        {"run": "python scripts/ci_finalize_dataflow_outcome.py --terminal-exit 0"},
+                    ]
+                }
+            }
+        },
+        Path(".github/workflows/ci.yml"),
+        errors,
+    )
+    assert any("scripts/ci_controller_drift_gate.py" in error for error in errors)
+
+
+def test_controller_drift_gate_override_expiry_behavior(tmp_path: Path) -> None:
+    drift = tmp_path / "drift.json"
+    out = tmp_path / "gate.json"
+    drift.write_text(json.dumps({"findings": [{"severity": "high"}]}), encoding="utf-8")
+
+    expired = tmp_path / "expired.json"
+    expired.write_text(
+        json.dumps(
+            {
+                "actor": "ci",
+                "rationale": "temporary",
+                "scope": "controller_drift",
+                "start": "2024-01-01T00:00:00Z",
+                "expiry": "2024-01-02T00:00:00Z",
+                "rollback_condition": "fix merged",
+                "evidence_links": ["artifact://x"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert drift_gate.run(drift_artifact=drift, override_record=expired, out=out) == 2
+
+    valid = tmp_path / "valid.json"
+    valid.write_text(
+        json.dumps(
+            {
+                "actor": "ci",
+                "rationale": "temporary",
+                "scope": "controller_drift",
+                "start": "2024-01-01T00:00:00Z",
+                "expiry": "2999-01-02T00:00:00Z",
+                "rollback_condition": "fix merged",
+                "evidence_links": ["artifact://x"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert drift_gate.run(drift_artifact=drift, override_record=valid, out=out) == 0

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -2256,6 +2256,42 @@ def test_dispatch_command_passes_timeout_ticks(tmp_path: Path) -> None:
 
 
 # gabion:evidence E:call_footprint::tests/test_cli_helpers.py::test_dispatch_command_preserves_existing_timeout_ms::cli.py::gabion.cli.dispatch_command
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_helpers.py::test_dispatch_command_blocks_direct_transport_for_beta_without_override::cli.py::gabion.cli._resolve_command_transport
+def test_dispatch_command_blocks_direct_transport_for_beta_without_override(tmp_path: Path) -> None:
+    with _env_scope({"GABION_DIRECT_RUN": "1", "GABION_DIRECT_RUN_OVERRIDE_EVIDENCE": None}):
+        with pytest.raises(NeverThrown):
+            cli.dispatch_command(
+                command=cli.CHECK_COMMAND,
+                payload={"paths": [str(tmp_path / "x.py")]},
+                root=tmp_path,
+                runner=cli.run_command,
+            )
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_helpers.py::test_dispatch_command_allows_direct_transport_for_debug_maturity::cli.py::gabion.cli._resolve_command_transport
+def test_dispatch_command_allows_direct_transport_for_debug_maturity(tmp_path: Path) -> None:
+    with _env_scope({"GABION_DIRECT_RUN": "1", "GABION_DIRECT_RUN_OVERRIDE_EVIDENCE": None}):
+        result = cli.dispatch_command(
+            command=cli.LSP_PARITY_GATE_COMMAND,
+            payload={},
+            root=tmp_path,
+            runner=cli.run_command,
+        )
+    assert isinstance(result, dict)
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_helpers.py::test_dispatch_command_allows_beta_direct_with_override_evidence::cli.py::gabion.cli._resolve_command_transport
+def test_dispatch_command_allows_beta_direct_with_override_evidence(tmp_path: Path) -> None:
+    with _env_scope({"GABION_DIRECT_RUN": "1", "GABION_DIRECT_RUN_OVERRIDE_EVIDENCE": "audit://ci/transport-override/123"}):
+        result = cli.dispatch_command(
+            command=cli.CHECK_COMMAND,
+            payload={"paths": [str(tmp_path / "x.py")]},
+            root=tmp_path,
+            runner=cli.run_command,
+        )
+    assert isinstance(result, dict)
 def test_dispatch_command_preserves_existing_timeout_ms(tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
### Motivation
- Centralize transport decision-making so command maturity policies are enforced at CLI dispatch and direct-only runs cannot bypass LSP-first constraints for higher-maturity commands.
- Move large inline CI orchestration shells into explicit script entrypoints for clearer policy conformance and deterministic artifact emission.
- Provide a second-order controller adaptation protocol and auditable override lifecycle so high-severity governance failures require explicit, machine-readable justification and expiry.
- Make controller-drift remediation and enforcement deterministic and testable (consecutive-pass stabilization, remediation classes, and CI gating).

### Description
- Added a transport decision helper `_resolve_command_transport(...)` in `src/gabion/cli.py` that loads command policy via `load_governance_rules` and blocks direct transport for commands whose policy requires an LSP carrier or which are `beta`/`production` unless explicit override evidence is present; invariant failures use `never(...)` and the decision returns a `CommandTransportDecision` structure.
- Extended the governance schema in `src/gabion/tooling/governance_rules.py` and `docs/governance_rules.yaml` with a `controller_drift` policy (`ControllerDriftPolicy`) including `severity_classes`, `enforce_at_or_above`, `remediation_by_severity`, and `consecutive_passes_required` and hardened bool parsing for command flags.
- Extracted CI inline shells into scripts: `scripts/ci_seed_dataflow_checkpoint.py`, `scripts/ci_finalize_dataflow_outcome.py`, `scripts/ci_override_record_emit.py`, and `scripts/ci_controller_drift_gate.py`, and updated `.github/workflows/ci.yml` to call these orchestration entrypoints instead of long `run:` blocks.
- Added CI policy checks in `scripts/policy_check.py` to require the new orchestration script entrypoints and updated `scripts/governance_controller_audit.py` to emit deterministic `severity_counts`/`highest_severity` telemetry used by CI gates.
- Implemented `ci_controller_drift_gate.py` to enforce controller-drift gating that fails CI for findings at-or-above the configured severity unless a valid, unexpired machine-readable override record is present; added `ci_override_record_emit.py` to produce that artifact from env/override channels.
- Updated docs and normative index: `POLICY_SEED.md`, `docs/normative_clause_index.md`, and `CONTRIBUTING.md` to codify the second-order controller adaptation protocol, deadline/timeout propagation clause, and override lifecycle obligations.
- Added tests: CLI transport parity/blocks tests integrated into `tests/test_cli_helpers.py`, governance-rule loader tests updated in `tests/test_governance_rules_policy.py`, and CI script and override expiry behavior tests in `tests/test_ci_governance_scripts.py`.

### Testing
- Ran focused CLI transport tests: `mise exec -- env PYTHONPATH=src python -m pytest -o addopts='' tests/test_cli_helpers.py -k "dispatch_command_blocks_direct_transport_for_beta_without_override or dispatch_command_allows_direct_transport_for_debug_maturity or dispatch_command_allows_beta_direct_with_override_evidence"` and received `3 passed`.
- Ran governance-rule and CI-script tests: `mise exec -- env PYTHONPATH=src python -m pytest -o addopts='' tests/test_governance_rules_policy.py tests/test_ci_governance_scripts.py` and received `6 passed`.
- Executed policy/workflow check: `mise exec -- env PYTHONPATH=src python scripts/policy_check.py --workflows` which completed successfully and flagged missing CI script invocations until the scripts were added and the check passed after updates.
- Exercised CI orchestration scripts end-to-end: `scripts/ci_seed_dataflow_checkpoint.py`, `scripts/ci_finalize_dataflow_outcome.py`, and `scripts/ci_override_record_emit.py` under `PYTHONPATH=src` to validate runtime behavior; these invocations returned expected outputs (seed/no-seed messages, terminal summaries, and override-record emission).
- All automated tests and script smoke-runs listed above succeeded after iterative fixes; initial test runs encountered local `mise`/trust bootstrap issues which were resolved during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc8eb9eb883249609d7b18460ff04)