### PR TITLE
Unify override lifecycle enforcement and clause-index controller governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 23
+doc_revision: 24
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: agents
 doc_role: agent
@@ -99,7 +99,8 @@ Semantic correctness is governed by `[glossary.md#contract](glossary.md#contract
   surface any violations explicitly.
 - Preserve [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first).
 - Enforce [`NCI-SHIFT-AMBIGUITY-LEFT`](docs/normative_clause_index.md#clause-shift-ambiguity-left) in semantic core refactors.
-- Enforce maturity transport policy: `experimental`/`debug` may use direct diagnostics, but `beta`/`production` must be validated over the LSP carrier and cannot rely on direct-only validation.
+- Enforce command maturity/carrier/parity policy: [`NCI-COMMAND-MATURITY-PARITY`](docs/normative_clause_index.md#clause-command-maturity-parity).
+- Enforce controller-drift override lifecycle policy: [`NCI-CONTROLLER-DRIFT-LIFECYCLE`](docs/normative_clause_index.md#clause-controller-drift-lifecycle).
 - Keep semantic behavior in server command handlers exposed via `gabion` subcommands; treat `scripts/` as orchestration wrappers only.
 - Use `mise exec -- python` for repo-local tooling to ensure the pinned
   interpreter and dependencies are used. In CI, `.venv/bin/python` is acceptable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 102
+doc_revision: 103
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -105,7 +105,8 @@ valid.
 
 ## Architectural invariants (normative)
 - **LSP-first invariant:** [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first).
-- **Maturity/transport policy:** `experimental` and `debug` may use direct-path diagnostics; `beta` and `production` require LSP-carrier validation and cannot treat direct path as the only normative route.
+- **Controller drift + override lifecycle:** [`NCI-CONTROLLER-DRIFT-LIFECYCLE`](docs/normative_clause_index.md#clause-controller-drift-lifecycle).
+- **Maturity/transport policy:** [`NCI-COMMAND-MATURITY-PARITY`](docs/normative_clause_index.md#clause-command-maturity-parity).
 - **Semantic ownership boundary:** user-facing semantics must live in server command handlers and be exposed as `gabion` subcommands. `scripts/` are orchestration wrappers (CI/bootstrap/audit), never canonical semantic engines.
 - **Single source of truth:** diagnostics and code actions must be derived from
   the server, not duplicated in client code.

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 46
+doc_revision: 47
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -822,7 +822,7 @@ Just tell me how far you want to push the self-referential loop.
 
 ## 4.9 Second-order controller adaptation protocol
 
-- Canonical clauses: [`NCI-DEADLINE-TIMEOUT-PROPAGATION`](docs/normative_clause_index.md#clause-deadline-timeout-propagation), [`NCI-CONTROLLER-ADAPTATION-LAW`](docs/normative_clause_index.md#clause-controller-adaptation-law), [`NCI-OVERRIDE-LIFECYCLE`](docs/normative_clause_index.md#clause-override-lifecycle).
+- Canonical clauses: [`NCI-DEADLINE-TIMEOUT-PROPAGATION`](docs/normative_clause_index.md#clause-deadline-timeout-propagation), [`NCI-CONTROLLER-ADAPTATION-LAW`](docs/normative_clause_index.md#clause-controller-adaptation-law), [`NCI-OVERRIDE-LIFECYCLE`](docs/normative_clause_index.md#clause-override-lifecycle), [`NCI-CONTROLLER-DRIFT-LIFECYCLE`](docs/normative_clause_index.md#clause-controller-drift-lifecycle), [`NCI-COMMAND-MATURITY-PARITY`](docs/normative_clause_index.md#clause-command-maturity-parity).
 - Adaptation triggers (telemetry-derived): parity instability, chronic timeout resumes, and recurring gate-noise false positives.
 - Allowed bounded control moves: timeout budget tuning, retry-profile shaping, and drift-threshold class adjustments declared in `docs/governance_rules.yaml`.
 - Forbidden compensations: baseline refresh as bypass, silent strictness downgrades, and undeclared transport downgrades.

--- a/docs/governance_control_loops.md
+++ b/docs/governance_control_loops.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 2
+doc_revision: 3
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: governance_control_loops
 doc_role: policy
@@ -151,6 +151,8 @@ Each loop entry must define:
 
 ### 3) LSP architecture
 
+Clause links: [`NCI-LSP-FIRST`](docs/normative_clause_index.md#clause-lsp-first), [`NCI-COMMAND-MATURITY-PARITY`](docs/normative_clause_index.md#clause-command-maturity-parity).
+
 - **sensor:** server/CLI split checks and governance contract conformance checks.
 - **state artifact:** `src/gabion/server.py`, `src/gabion/cli.py`, and audit outputs under `artifacts/audit_reports/`.
 - **target predicate:** LSP-first invariant holds; semantic logic remains server-owned and CLI stays thin.
@@ -183,6 +185,8 @@ Each loop entry must define:
 - **escalation threshold:** guard rejects refresh twice for the same unresolved source.
 
 ## Second-order controller loop (cybernetic meta-loop)
+
+Clause links: [`NCI-CONTROLLER-ADAPTATION-LAW`](docs/normative_clause_index.md#clause-controller-adaptation-law), [`NCI-OVERRIDE-LIFECYCLE`](docs/normative_clause_index.md#clause-override-lifecycle), [`NCI-CONTROLLER-DRIFT-LIFECYCLE`](docs/normative_clause_index.md#clause-controller-drift-lifecycle).
 
 Second-order governance closes drift between normative anchors and enforcement scripts.
 This loop governs first-order loop integrity and prevents controller drift.

--- a/docs/governance_rules.yaml
+++ b/docs/governance_rules.yaml
@@ -112,7 +112,7 @@ gates:
     blocking_prefix: Docflow contradictions increased
     ok_prefix: Docflow delta OK
 
-controller_drift:
+controller_drift:  # NCI-CONTROLLER-DRIFT-LIFECYCLE
   severity_classes: [low, medium, high, critical]
   enforce_at_or_above: high
   remediation_by_severity:
@@ -120,7 +120,7 @@ controller_drift:
     critical: immediate_corrective_update_required
   consecutive_passes_required: 3
 
-command_policies:
+command_policies:  # NCI-COMMAND-MATURITY-PARITY
   gabion.check:
     maturity: beta
     require_lsp_carrier: true

--- a/docs/normative_clause_index.md
+++ b/docs/normative_clause_index.md
@@ -138,6 +138,18 @@ link to clause IDs instead of duplicating long-form normative prose.
 - Post-override convergence requires consecutive clean runs before stabilization is declared.
 - Canonical sources: `POLICY_SEED.md#policy_seed`, `docs/governance_rules.yaml`.
 
+<a id="clause-controller-drift-lifecycle"></a>
+### `NCI-CONTROLLER-DRIFT-LIFECYCLE` — Controller drift enforcement and override lifecycle
+- Controller drift gates must enforce severity thresholds from governance rules and fail closed when blocking findings exceed policy and no valid override record exists.
+- Active controller-drift overrides must use non-expired machine-readable lifecycle records and emit normalized diagnostics/telemetry fields.
+- Canonical sources: `docs/governance_rules.yaml`, `scripts/ci_controller_drift_gate.py`, `POLICY_SEED.md#policy_seed`.
+
+<a id="clause-command-maturity-parity"></a>
+### `NCI-COMMAND-MATURITY-PARITY` — Command maturity, carrier, and parity governance
+- `beta`/`production` command maturity requires LSP-carrier validation (`require_lsp_carrier`) and cannot treat direct execution as normative without a valid override lifecycle record.
+- Parity-governed commands (`parity_required`) must retain probe validation payload coverage and declared parity-ignore semantics.
+- Canonical sources: `docs/governance_rules.yaml`, `src/gabion/cli.py`, `POLICY_SEED.md#policy_seed`.
+
 ## Usage rule
 
 When referencing one of these obligations in `README.md`, `CONTRIBUTING.md`,

--- a/scripts/ci_controller_drift_gate.py
+++ b/scripts/ci_controller_drift_gate.py
@@ -3,20 +3,16 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 from gabion.tooling.governance_rules import load_governance_rules
+from gabion.tooling.override_record import validate_override_record_file
 
 SEVERITY = {"low": 1, "medium": 2, "high": 3, "critical": 4}
 
 
 def _load_json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _parse_time(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
 def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
@@ -28,26 +24,19 @@ def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
         sev = str((finding or {}).get("severity", "")).lower()
         max_rank = max(max_rank, SEVERITY.get(sev, 0))
     enforce_rank = SEVERITY.get(rules.enforce_at_or_above.lower(), 99)
-    override_used = override_record.exists()
-    override_valid = False
-    override_payload: dict[str, object] | None = None
-    if override_used:
-        override_payload = _load_json(override_record)
-        required = {"actor", "rationale", "scope", "start", "expiry", "rollback_condition", "evidence_links"}
-        override_valid = required.issubset(set(override_payload.keys()))
-        if override_valid:
-            override_valid = _parse_time(str(override_payload["expiry"])) > datetime.now(timezone.utc)
+    override_validation = validate_override_record_file(override_record)
 
     status = "pass"
     if max_rank >= enforce_rank:
-        status = "override" if override_valid else "fail"
+        status = "override" if override_validation.valid else "fail"
 
     payload = {
         "status": status,
         "max_severity_rank": max_rank,
         "enforce_at_or_above": rules.enforce_at_or_above,
         "required_remediation": rules.remediation_by_severity,
-        "override_record": override_payload,
+        "override_record": override_validation.record,
+        "override_diagnostics": override_validation.telemetry(source="controller_drift_gate"),
         "consecutive_passes_required": rules.consecutive_passes_required,
     }
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/src/gabion/tooling/override_record.py
+++ b/src/gabion/tooling/override_record.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Mapping
+
+REQUIRED_OVERRIDE_FIELDS: tuple[str, ...] = (
+    "actor",
+    "rationale",
+    "scope",
+    "start",
+    "expiry",
+    "rollback_condition",
+    "evidence_links",
+)
+
+
+@dataclass(frozen=True)
+class OverrideValidationResult:
+    active: bool
+    valid: bool
+    reason: str | None
+    record: Mapping[str, object] | None
+
+    def telemetry(self, *, source: str) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "override_active": self.active,
+            "override_valid": self.valid,
+            "override_source": source,
+            "override_reason": self.reason,
+        }
+        if self.record is None:
+            return payload
+        payload["override_actor"] = self.record.get("actor")
+        payload["override_scope"] = self.record.get("scope")
+        payload["override_expiry"] = self.record.get("expiry")
+        return payload
+
+
+def _parse_time(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("timestamp must be a string")
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def validate_override_record(
+    raw_record: object,
+    *,
+    now: datetime | None = None,
+) -> OverrideValidationResult:
+    if raw_record is None:
+        return OverrideValidationResult(active=False, valid=False, reason="missing", record=None)
+    if not isinstance(raw_record, Mapping):
+        return OverrideValidationResult(active=True, valid=False, reason="non_mapping", record=None)
+    record = dict(raw_record)
+    missing = [field for field in REQUIRED_OVERRIDE_FIELDS if field not in record]
+    if missing:
+        return OverrideValidationResult(active=True, valid=False, reason="missing_fields", record=record)
+    try:
+        expiry = _parse_time(record["expiry"])
+        _parse_time(record["start"])
+    except ValueError:
+        return OverrideValidationResult(active=True, valid=False, reason="invalid_timestamp", record=record)
+    now_utc = now or datetime.now(timezone.utc)
+    if expiry <= now_utc:
+        return OverrideValidationResult(active=True, valid=False, reason="expired", record=record)
+    return OverrideValidationResult(active=True, valid=True, reason=None, record=record)
+
+
+def validate_override_record_json(raw_json: str | None) -> OverrideValidationResult:
+    stripped = (raw_json or "").strip()
+    if not stripped:
+        return OverrideValidationResult(active=False, valid=False, reason="missing", record=None)
+    try:
+        decoded = json.loads(stripped)
+    except json.JSONDecodeError:
+        return OverrideValidationResult(active=True, valid=False, reason="invalid_json", record=None)
+    return validate_override_record(decoded)
+
+
+def validate_override_record_file(path: Path) -> OverrideValidationResult:
+    if not path.exists():
+        return OverrideValidationResult(active=False, valid=False, reason="missing", record=None)
+    try:
+        decoded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return OverrideValidationResult(active=True, valid=False, reason="invalid_json", record=None)
+    return validate_override_record(decoded)
+

--- a/tests/test_ci_governance_scripts.py
+++ b/tests/test_ci_governance_scripts.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from scripts import ci_controller_drift_gate as drift_gate
+from scripts import governance_controller_audit
 from scripts import policy_check
 
 
@@ -30,6 +31,11 @@ def test_controller_drift_gate_override_expiry_behavior(tmp_path: Path) -> None:
     drift = tmp_path / "drift.json"
     out = tmp_path / "gate.json"
     drift.write_text(json.dumps({"findings": [{"severity": "high"}]}), encoding="utf-8")
+
+    missing = tmp_path / "missing.json"
+    assert drift_gate.run(drift_artifact=drift, override_record=missing, out=out) == 2
+    payload_missing = json.loads(out.read_text(encoding="utf-8"))
+    assert payload_missing["override_diagnostics"]["override_reason"] == "missing"
 
     expired = tmp_path / "expired.json"
     expired.write_text(
@@ -64,3 +70,10 @@ def test_controller_drift_gate_override_expiry_behavior(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert drift_gate.run(drift_artifact=drift, override_record=valid, out=out) == 0
+    payload_valid = json.loads(out.read_text(encoding="utf-8"))
+    assert payload_valid["override_diagnostics"]["override_valid"] is True
+    assert payload_valid["override_diagnostics"]["override_source"] == "controller_drift_gate"
+
+
+def test_controller_audit_requires_clause_anchors_for_enforcement_surfaces() -> None:
+    assert governance_controller_audit._enforcement_clause_findings() == []


### PR DESCRIPTION
### Motivation
- Centralize override-record validation so CLI and CI share the same lifecycle checks and telemetry shape.
- Ensure controller-drift gates and maturity-gated direct CLI runs fail closed for missing/invalid/expired overrides.
- Promote controller/parity governance into canonical clause IDs and bind enforcement surfaces to clause anchors to prevent drift.

### Description
- Add a shared validator `src/gabion/tooling/override_record.py` that validates machine-readable override records (required fields: `actor`, `rationale`, `scope`, `start`, `expiry`, `rollback_condition`, `evidence_links`) and emits a normalized `OverrideValidationResult.telemetry()` payload.
- Enforce override validation in CLI transport resolution (`src/gabion/cli.py`): maturity-gated direct runs (`beta`/`production` / `require_lsp_carrier`) now require `GABION_DIRECT_RUN` + `GABION_DIRECT_RUN_OVERRIDE_EVIDENCE` and a valid non-expired `GABION_OVERRIDE_RECORD_JSON`, otherwise fail closed with structured diagnostics.
- Reuse the validator in `scripts/ci_controller_drift_gate.py` so controller-drift gate output includes `override_diagnostics` and `override_record` fields and blocks when overrides are missing/invalid/expired for blocking severities.
- Add enforcement-surface checks to `scripts/governance_controller_audit.py` that surface unindexed enforcement keys when `docs/governance_rules.yaml` lacks clause annotations or the clause index lacks the corresponding anchors.
- Update governance docs and topology: add `NCI-CONTROLLER-DRIFT-LIFECYCLE` and `NCI-COMMAND-MATURITY-PARITY` to `docs/normative_clause_index.md`, annotate `docs/governance_rules.yaml`, and update `AGENTS.md`, `CONTRIBUTING.md`, `POLICY_SEED.md`, `docs/architecture_zones.md`, and `docs/governance_control_loops.md` to reference the new clauses and clarify `server_core` / `src/gabion_governance/` boundaries.
- Add and adjust tests for CLI direct-run override behavior and controller-drift override diagnostics (`tests/test_cli_helpers.py`, `tests/test_ci_governance_scripts.py`) and a governance-audit test that checks enforcement-surface clause anchors.

### Testing
- Ran targeted pytest suites with `PYTHONPATH=src` and `-o addopts=''` to avoid test-run isolation flags; the selected tests passed: `tests/test_cli_helpers.py` (selected direct-transport/override cases) and `tests/test_ci_governance_scripts.py` (controller drift override cases) succeeded (8 tests selected passed).
- Ran `tests/test_governance_rules_policy.py` and it passed (4 tests).
- Verified Python syntax with `python -m py_compile` for `src/gabion/tooling/override_record.py`, `scripts/ci_controller_drift_gate.py`, `scripts/governance_controller_audit.py`, and `src/gabion/cli.py` with no errors.
- Note: `mise exec` could not be used in this environment due to local `mise.toml` trust configuration, so local `python`/`pytest` runs with `PYTHONPATH=src` were used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd19e45ac8324949fa2284a3fa36f)