### PR TITLE
Harden override lifecycle validation and centralize transport-policy + enforcement map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 103
+doc_revision: 104
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -29,7 +29,7 @@ doc_review_notes:
   CONTRIBUTING.md#contributing_contract: "Self-review via Grothendieck analysis (cofibration/dedup/contrast); docflow now fails on missing GH references for SPPF-relevant changes; baseline guardrail + ci_cycle helper affirmed."
   AGENTS.md#agent_obligations: "Agent review discipline aligns with contributor workflow."
   POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev1 (mechanized governance default; branch/tag CAS + check-before-use constraints); no conflicts with this document's scope."
-  docs/normative_clause_index.md#normative_clause_index: "Canonical clause IDs adopted for repeated obligations (LSP-first, policy pinning/allow-list, bundle tiers, baseline ratchet)."
+  docs/normative_clause_index.md#normative_clause_index: "Canonical clause IDs adopted for repeated obligations and cross-linked to the machine-readable enforcement ledger."
   glossary.md#contract: "Reviewed glossary.md#contract rev1 (glossary contract + semantic typing discipline)."
   docs/coverage_semantics.md#coverage_semantics: "Reviewed docs/coverage_semantics.md#coverage_semantics v1 (glossary-lifted projection + explicit core anchors); contributor guidance unchanged."
 doc_sections:
@@ -113,6 +113,9 @@ valid.
 - **Python execution discipline:** for repo-local tooling, prefer `mise exec -- python`
   so the pinned interpreter/toolchain is used; in CI, invoking `.venv/bin/python` is acceptable
   once the workflow has bootstrapped pinned dependencies (for reproducible hermetic runs).
+- **Override lifecycle source-of-truth:** override record schema/validation semantics are enforced by `src/gabion/tooling/override_record.py` and consumed by both runtime transport policy and CI override emit/gates.
+- **Command transport decision surface:** CLI and tooling paths must use `src/gabion/commands/transport_policy.py` so direct-vs-LSP enforcement remains maturity/parity aligned.
+- **Normative completeness ledger:** use `docs/normative_enforcement_map.yaml` as the canonical clause-to-enforcement map, and keep `scripts/policy_check.py --normative-map` green when governance mappings change.
 
 ## Optional governance framing
 See `docs/doer_judge_witness.md` for a lightweight Doer/Judge/Witness workflow

--- a/docs/normative_clause_index.md
+++ b/docs/normative_clause_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 3
+doc_revision: 4
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: normative_clause_index
 doc_role: normative_index
@@ -24,7 +24,7 @@ doc_reviewed_as_of:
 doc_review_notes:
   POLICY_SEED.md#policy_seed: "Clause index derived from policy invariants to reduce duplicated prose drift."
   README.md#repo_contract: "README obligation references consolidated to stable clause IDs."
-  CONTRIBUTING.md#contributing_contract: "Contributor-facing obligations consolidated behind stable clause IDs."
+  CONTRIBUTING.md#contributing_contract: "Contributor-facing obligations consolidated behind stable clause IDs and linked to the enforcement completeness ledger."
   AGENTS.md#agent_obligations: "Agent obligations mapped to canonical clause anchors."
   glossary.md#contract: "Dataflow tier references remain governed by glossary contract."
 doc_sections:
@@ -146,9 +146,15 @@ link to clause IDs instead of duplicating long-form normative prose.
 
 <a id="clause-command-maturity-parity"></a>
 ### `NCI-COMMAND-MATURITY-PARITY` — Command maturity, carrier, and parity governance
-- `beta`/`production` command maturity requires LSP-carrier validation (`require_lsp_carrier`) and cannot treat direct execution as normative without a valid override lifecycle record.
+- `beta`/`production` command maturity requires LSP-carrier validation (`require_lsp_carrier`) and cannot treat direct execution as normative without valid override evidence + lifecycle record.
 - Parity-governed commands (`parity_required`) must retain probe validation payload coverage and declared parity-ignore semantics.
-- Canonical sources: `docs/governance_rules.yaml`, `src/gabion/cli.py`, `POLICY_SEED.md#policy_seed`.
+- Canonical sources: `docs/governance_rules.yaml`, `src/gabion/commands/transport_policy.py`, `src/gabion/cli.py`, `POLICY_SEED.md#policy_seed`.
+
+
+## Enforcement completeness ledger
+
+Machine-readable clause-to-enforcement traceability is maintained in `docs/normative_enforcement_map.yaml`.
+Policy checks validate map integrity and CI/workflow anchors via `scripts/policy_check.py --normative-map`.
 
 ## Usage rule
 

--- a/docs/normative_enforcement_map.yaml
+++ b/docs/normative_enforcement_map.yaml
@@ -1,0 +1,107 @@
+version: 1
+clauses:
+  NCI-LSP-FIRST:
+    status: enforced
+    enforcing_modules:
+      - src/gabion/cli.py
+      - src/gabion/lsp_client.py
+      - src/gabion/commands/transport_policy.py
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: LSP parity gate
+    expected_artifacts:
+      - artifacts/out/lsp_parity_gate.json
+  NCI-ACTIONS-PINNED:
+    status: enforced
+    enforcing_modules:
+      - scripts/policy_check.py
+      - docs/allowed_actions.txt
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (workflows)
+    expected_artifacts: []
+  NCI-ACTIONS-ALLOWLIST:
+    status: enforced
+    enforcing_modules:
+      - scripts/policy_check.py
+      - docs/allowed_actions.txt
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (workflows)
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (posture)
+    expected_artifacts: []
+  NCI-DATAFLOW-BUNDLE-TIERS:
+    status: enforced
+    enforcing_modules:
+      - src/gabion/analysis/dataflow_bundle_iteration.py
+      - .github/workflows/pr-dataflow-grammar.yml
+    ci_anchors:
+      - workflow: .github/workflows/pr-dataflow-grammar.yml
+        job: dataflow-grammar
+        step: Render dataflow grammar report
+      - workflow: .github/workflows/ci.yml
+        job: dataflow-grammar
+        step: Dataflow audit invocation
+    expected_artifacts:
+      - artifacts/dataflow_grammar/report.md
+      - artifacts/audit_reports/dataflow_report.md
+  NCI-SHIFT-AMBIGUITY-LEFT:
+    status: enforced
+    enforcing_modules:
+      - scripts/branchless_policy_check.py
+      - scripts/defensive_fallback_policy_check.py
+      - src/gabion/tooling/ambiguity_contract_policy_check.py
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (branchless)
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (defensive fallback)
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Policy check (ambiguity contract)
+    expected_artifacts:
+      - artifacts/out/ambiguity_contract_policy_check.json
+  NCI-COMMAND-MATURITY-PARITY:
+    status: enforced
+    enforcing_modules:
+      - docs/governance_rules.yaml
+      - src/gabion/commands/transport_policy.py
+      - src/gabion/cli.py
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: LSP parity gate
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Override lifecycle record emit
+    expected_artifacts:
+      - artifacts/out/governance_override_record.json
+      - artifacts/out/lsp_parity_gate.json
+  NCI-CONTROLLER-DRIFT-LIFECYCLE:
+    status: enforced
+    enforcing_modules:
+      - scripts/governance_controller_audit.py
+      - scripts/ci_override_record_emit.py
+      - scripts/ci_controller_drift_gate.py
+      - src/gabion/tooling/override_record.py
+    ci_anchors:
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Controller drift audit
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Override lifecycle record emit
+      - workflow: .github/workflows/ci.yml
+        job: checks
+        step: Controller drift gate
+    expected_artifacts:
+      - artifacts/out/controller_drift.json
+      - artifacts/out/governance_override_record.json
+      - artifacts/out/controller_drift_gate.json

--- a/scripts/ci_override_record_emit.py
+++ b/scripts/ci_override_record_emit.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 
-REQUIRED = {"actor", "rationale", "scope", "start", "expiry", "rollback_condition", "evidence_links"}
-
-
-def _parse_time(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+from gabion.tooling.override_record import validate_override_record_json
 
 
 def main() -> int:
@@ -27,14 +22,12 @@ def main() -> int:
     raw_record = os.getenv("GABION_OVERRIDE_RECORD_JSON", "").strip()
     payload: dict[str, object] = {"active_channels": active, "override_record": None}
     if active:
-        if not raw_record:
-            raise SystemExit("override channels active but GABION_OVERRIDE_RECORD_JSON is missing")
-        record = json.loads(raw_record)
-        if not isinstance(record, dict) or not REQUIRED.issubset(set(record.keys())):
-            raise SystemExit("override record missing required schema fields")
-        if _parse_time(str(record["expiry"])) <= datetime.now(timezone.utc):
-            raise SystemExit("override record expired")
-        payload["override_record"] = record
+        validation = validate_override_record_json(raw_record)
+        if not validation.valid:
+            raise SystemExit(
+                f"override channels active but override record is invalid: {validation.reason}"
+            )
+        payload["override_record"] = validation.record
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/policy_check.py
+++ b/scripts/policy_check.py
@@ -47,6 +47,90 @@ _DEFAULT_POLICY_TIMEOUT_BUDGET = DeadlineBudget(
 )
 
 
+NORMATIVE_ENFORCEMENT_MAP = REPO_ROOT / "docs" / "normative_enforcement_map.yaml"
+_REQUIRED_NORMATIVE_CLAUSES = {
+    "NCI-LSP-FIRST",
+    "NCI-ACTIONS-PINNED",
+    "NCI-ACTIONS-ALLOWLIST",
+    "NCI-DATAFLOW-BUNDLE-TIERS",
+    "NCI-SHIFT-AMBIGUITY-LEFT",
+    "NCI-COMMAND-MATURITY-PARITY",
+    "NCI-CONTROLLER-DRIFT-LIFECYCLE",
+}
+
+
+def _workflow_doc(path: Path):
+    if not path.exists():
+        return {}
+    return _load_yaml(path)
+
+
+def check_normative_enforcement_map() -> None:
+    errors: list[str] = []
+    if not NORMATIVE_ENFORCEMENT_MAP.exists():
+        _fail([f"missing normative enforcement map: {NORMATIVE_ENFORCEMENT_MAP}"])
+    payload = _load_yaml(NORMATIVE_ENFORCEMENT_MAP)
+    clauses = payload.get("clauses")
+    if not isinstance(clauses, dict):
+        _fail(["docs/normative_enforcement_map.yaml: clauses must be a mapping"])
+    clause_ids = set(clauses.keys())
+    missing = _REQUIRED_NORMATIVE_CLAUSES - clause_ids
+    extra = clause_ids - _REQUIRED_NORMATIVE_CLAUSES
+    if missing:
+        errors.append(f"normative map missing required clauses: {_sorted(missing)}")
+    if extra:
+        errors.append(f"normative map has unknown clause keys: {_sorted(extra)}")
+
+    for clause_id, entry in clauses.items():
+        check_deadline()
+        if not isinstance(entry, dict):
+            errors.append(f"{clause_id}: entry must be mapping")
+            continue
+        status = entry.get("status")
+        if status not in {"enforced", "partial", "document-only"}:
+            errors.append(f"{clause_id}: invalid status {status!r}")
+        for module_path in entry.get("enforcing_modules") or []:
+            module_ref = REPO_ROOT / str(module_path)
+            if not module_ref.exists():
+                errors.append(f"{clause_id}: missing enforcing module path {module_path}")
+        ci_anchors = entry.get("ci_anchors") or []
+        if not isinstance(ci_anchors, list):
+            errors.append(f"{clause_id}: ci_anchors must be a list")
+            continue
+        for anchor in ci_anchors:
+            if not isinstance(anchor, dict):
+                errors.append(f"{clause_id}: ci anchor must be mapping")
+                continue
+            workflow = REPO_ROOT / str(anchor.get("workflow", ""))
+            job = str(anchor.get("job", ""))
+            step = str(anchor.get("step", ""))
+            if not workflow.exists():
+                errors.append(f"{clause_id}: workflow does not exist: {workflow}")
+                continue
+            workflow_doc = _workflow_doc(workflow)
+            jobs = workflow_doc.get("jobs")
+            if not isinstance(jobs, dict) or job not in jobs:
+                errors.append(f"{clause_id}: missing workflow job anchor {workflow}:{job}")
+                continue
+            steps = jobs[job].get("steps") if isinstance(jobs[job], dict) else []
+            step_names = {
+                str(item.get("name", ""))
+                for item in steps
+                if isinstance(item, dict)
+            }
+            if step and step not in step_names:
+                errors.append(f"{clause_id}: missing workflow step anchor {workflow}:{job}:{step}")
+        artifacts = entry.get("expected_artifacts") or []
+        if not isinstance(artifacts, list):
+            errors.append(f"{clause_id}: expected_artifacts must be a list")
+            continue
+        for artifact in artifacts:
+            if not isinstance(artifact, str) or not artifact.strip():
+                errors.append(f"{clause_id}: invalid expected artifact reference {artifact!r}")
+    if errors:
+        _fail(errors)
+
+
 def _policy_timeout_budget() -> DeadlineBudget:
     raw_ticks = os.getenv("GABION_POLICY_TIMEOUT_TICKS", "").strip()
     raw_tick_ns = os.getenv("GABION_POLICY_TIMEOUT_TICK_NS", "").strip()
@@ -1155,9 +1239,10 @@ def main():
     parser.add_argument("--workflows", action="store_true", help="lint workflows")
     parser.add_argument("--posture", action="store_true", help="check GitHub posture")
     parser.add_argument("--ambiguity-contract", action="store_true", help="run ambiguity contract policy checks")
+    parser.add_argument("--normative-map", action="store_true", help="validate docs/normative_enforcement_map.yaml")
     args = parser.parse_args()
 
-    if not args.workflows and not args.posture and not args.ambiguity_contract:
+    if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map:
         args.workflows = True
 
     with _policy_deadline_scope():
@@ -1167,6 +1252,8 @@ def main():
             check_posture()
         if args.ambiguity_contract:
             check_ambiguity_contract()
+        if args.normative_map:
+            check_normative_enforcement_map()
     return 0
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,9 +8,12 @@ mkdir -p "$run_dir"
 timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
 log_file="$run_dir/pytest_${timestamp}.log"
 
-if command -v mise >/dev/null 2>&1; then
-  mise exec -- pytest "$@" 2>&1 | tee "$log_file"
-else
-  echo "mise not found; falling back to system python" | tee "$log_file"
-  pytest "$@" 2>&1 | tee -a "$log_file"
+if ! command -v mise >/dev/null 2>&1; then
+  {
+    echo "mise is required for deterministic test execution."
+    echo "Install mise and run: mise install && mise exec -- pytest"
+  } | tee "$log_file"
+  exit 2
 fi
+
+mise exec -- pytest "$@" 2>&1 | tee "$log_file"

--- a/src/gabion/commands/__init__.py
+++ b/src/gabion/commands/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     "direct_dispatch",
     "payload_codec",
     "progress_contract",
+    "transport_policy",
 ]

--- a/src/gabion/commands/transport_policy.py
+++ b/src/gabion/commands/transport_policy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Callable, Mapping, TypeAlias
+
+from gabion.invariants import never
+from gabion.lsp_client import run_command, run_command_direct
+from gabion.tooling.governance_rules import CommandPolicy, load_governance_rules
+from gabion.tooling.override_record import validate_override_record_json
+
+Runner: TypeAlias = Callable[..., Mapping[str, object]]
+
+DIRECT_RUN_ENV = "GABION_DIRECT_RUN"
+DIRECT_RUN_OVERRIDE_EVIDENCE_ENV = "GABION_DIRECT_RUN_OVERRIDE_EVIDENCE"
+OVERRIDE_RECORD_JSON_ENV = "GABION_OVERRIDE_RECORD_JSON"
+
+
+@dataclass(frozen=True)
+class CommandTransportDecision:
+    runner: Runner
+    direct_requested: bool
+    direct_override_evidence: str | None
+    direct_override_telemetry: Mapping[str, object] | None
+    policy: CommandPolicy | None
+
+
+def resolve_command_transport(*, command: str, runner: Runner) -> CommandTransportDecision:
+    direct_flag = os.getenv(DIRECT_RUN_ENV, "").strip().lower()
+    direct_requested = direct_flag in {"1", "true", "yes", "on"}
+    override_evidence = os.getenv(DIRECT_RUN_OVERRIDE_EVIDENCE_ENV, "").strip() or None
+    if runner is not run_command:
+        return CommandTransportDecision(
+            runner=runner,
+            direct_requested=direct_requested,
+            direct_override_evidence=override_evidence,
+            direct_override_telemetry=None,
+            policy=None,
+        )
+
+    policy = load_governance_rules().command_policies.get(command)
+    require_lsp_carrier = False
+    if policy is not None:
+        require_lsp_carrier = policy.require_lsp_carrier or policy.maturity in {
+            "beta",
+            "production",
+        }
+
+    override_record = validate_override_record_json(os.getenv(OVERRIDE_RECORD_JSON_ENV))
+    override_telemetry = None
+    if direct_requested and require_lsp_carrier:
+        if override_evidence is None:
+            never(
+                "direct transport forbidden by command maturity policy",
+                command=command,
+                maturity=(policy.maturity if policy is not None else "unknown"),
+                override_evidence_env=DIRECT_RUN_OVERRIDE_EVIDENCE_ENV,
+            )
+        if not override_record.valid:
+            never(
+                "direct transport override record invalid",
+                command=command,
+                maturity=(policy.maturity if policy is not None else "unknown"),
+                override_record_env=OVERRIDE_RECORD_JSON_ENV,
+                **override_record.telemetry(source="command_transport"),
+            )
+        override_telemetry = override_record.telemetry(source="command_transport")
+    resolved_runner = run_command_direct if direct_requested else run_command
+    return CommandTransportDecision(
+        runner=resolved_runner,
+        direct_requested=direct_requested,
+        direct_override_evidence=override_evidence,
+        direct_override_telemetry=override_telemetry,
+        policy=policy,
+    )
+

--- a/src/gabion/tooling/delta_state_emit.py
+++ b/src/gabion/tooling/delta_state_emit.py
@@ -7,7 +7,7 @@ import time
 from typing import Callable, Literal, Mapping
 
 from gabion.commands import progress_contract as progress_timeline
-from gabion.lsp_client import run_command_direct
+from gabion.lsp_client import run_command, run_command_direct
 from gabion.tooling import delta_emit_runtime
 
 EmitterId = Literal[
@@ -197,6 +197,7 @@ def main_for_emitter(
     emitter_id: EmitterId,
     *,
     run_command_direct_fn: Callable[..., Mapping[str, object]] = run_command_direct,
+    run_command_fn: Callable[..., Mapping[str, object]] = run_command,
     root_path: Path = Path("."),
     output_path: Path | None = None,
     expected_outputs: tuple[Path, ...] | None = None,
@@ -218,6 +219,7 @@ def main_for_emitter(
         run_spec=run_spec,
         payload=payload,
         run_command_direct_fn=run_command_direct_fn,
+        run_command_fn=run_command_fn,
         root_path=root_path,
         print_fn=print_fn,
         monotonic_fn=monotonic_fn,
@@ -228,6 +230,7 @@ def main_for_emitter(
 def main(
     *,
     run_command_direct_fn: Callable[..., Mapping[str, object]] = run_command_direct,
+    run_command_fn: Callable[..., Mapping[str, object]] = run_command,
     print_fn: Callable[[str], None] = print,
     monotonic_fn: Callable[[], float] = time.monotonic,
     expected_state_paths: tuple[Path, ...] = _EXPECTED_STATE_PATHS,
@@ -236,6 +239,7 @@ def main(
     return main_for_emitter(
         "delta_state_emit",
         run_command_direct_fn=run_command_direct_fn,
+        run_command_fn=run_command_fn,
         root_path=root_path,
         expected_outputs=expected_state_paths,
         print_fn=print_fn,
@@ -246,6 +250,7 @@ def main(
 def obsolescence_main(
     *,
     run_command_direct_fn: Callable[..., Mapping[str, object]] = run_command_direct,
+    run_command_fn: Callable[..., Mapping[str, object]] = run_command,
     root_path: Path = Path("."),
     delta_path: Path = _OBSOLESCENCE_DELTA_PATH,
     resume_checkpoint: Path | bool | None = None,
@@ -255,6 +260,7 @@ def obsolescence_main(
     return main_for_emitter(
         "obsolescence_delta_emit",
         run_command_direct_fn=run_command_direct_fn,
+        run_command_fn=run_command_fn,
         root_path=root_path,
         output_path=delta_path,
         resume_checkpoint=resume_checkpoint,
@@ -266,6 +272,7 @@ def obsolescence_main(
 def annotation_drift_main(
     *,
     run_command_direct_fn: Callable[..., Mapping[str, object]] = run_command_direct,
+    run_command_fn: Callable[..., Mapping[str, object]] = run_command,
     root_path: Path = Path("."),
     delta_path: Path = _ANNOTATION_DRIFT_DELTA_PATH,
     resume_checkpoint: Path | bool | None = None,
@@ -275,6 +282,7 @@ def annotation_drift_main(
     return main_for_emitter(
         "annotation_drift_delta_emit",
         run_command_direct_fn=run_command_direct_fn,
+        run_command_fn=run_command_fn,
         root_path=root_path,
         output_path=delta_path,
         resume_checkpoint=resume_checkpoint,
@@ -286,6 +294,7 @@ def annotation_drift_main(
 def ambiguity_main(
     *,
     run_command_direct_fn: Callable[..., Mapping[str, object]] = run_command_direct,
+    run_command_fn: Callable[..., Mapping[str, object]] = run_command,
     root_path: Path = Path("."),
     delta_path: Path = _AMBIGUITY_DELTA_PATH,
     resume_checkpoint: Path | bool | None = None,
@@ -295,6 +304,7 @@ def ambiguity_main(
     return main_for_emitter(
         "ambiguity_delta_emit",
         run_command_direct_fn=run_command_direct_fn,
+        run_command_fn=run_command_fn,
         root_path=root_path,
         output_path=delta_path,
         resume_checkpoint=resume_checkpoint,

--- a/tests/test_ci_governance_scripts.py
+++ b/tests/test_ci_governance_scripts.py
@@ -77,3 +77,62 @@ def test_controller_drift_gate_override_expiry_behavior(tmp_path: Path) -> None:
 
 def test_controller_audit_requires_clause_anchors_for_enforcement_surfaces() -> None:
     assert governance_controller_audit._enforcement_clause_findings() == []
+
+
+def test_policy_check_normative_enforcement_map_validates_current_repo() -> None:
+    policy_check.check_normative_enforcement_map()
+
+
+def test_policy_check_normative_enforcement_map_fails_missing_module(tmp_path: Path) -> None:
+    broken = tmp_path / "normative_enforcement_map.yaml"
+    broken.write_text(
+        """version: 1
+clauses:
+  NCI-LSP-FIRST:
+    status: enforced
+    enforcing_modules: [missing/file.py]
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-ACTIONS-PINNED:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-ACTIONS-ALLOWLIST:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-DATAFLOW-BUNDLE-TIERS:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-SHIFT-AMBIGUITY-LEFT:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-COMMAND-MATURITY-PARITY:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+  NCI-CONTROLLER-DRIFT-LIFECYCLE:
+    status: document-only
+    enforcing_modules: []
+    ci_anchors: []
+    expected_artifacts: []
+""",
+        encoding="utf-8",
+    )
+    original = policy_check.NORMATIVE_ENFORCEMENT_MAP
+    try:
+        policy_check.NORMATIVE_ENFORCEMENT_MAP = broken
+        try:
+            policy_check.check_normative_enforcement_map()
+            assert False, "expected check_normative_enforcement_map to fail"
+        except SystemExit as exc:
+            assert exc.code == 2
+    finally:
+        policy_check.NORMATIVE_ENFORCEMENT_MAP = original

--- a/tests/test_override_record.py
+++ b/tests/test_override_record.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from gabion.tooling.override_record import validate_override_record
+
+
+def _valid_record() -> dict[str, object]:
+    return {
+        "actor": "ci",
+        "rationale": "temporary",
+        "scope": "direct_transport",
+        "start": "2024-01-01T00:00:00Z",
+        "expiry": "2999-01-01T00:00:00Z",
+        "rollback_condition": "fix merged",
+        "evidence_links": ["artifact://override/1"],
+    }
+
+
+def test_validate_override_record_reason_codes() -> None:
+    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert validate_override_record(None, now=now).reason == "missing"
+    assert validate_override_record([], now=now).reason == "non_mapping"
+    assert validate_override_record({"actor": "ci"}, now=now).reason == "missing_fields"
+
+    empty = _valid_record()
+    empty["rationale"] = "   "
+    assert validate_override_record(empty, now=now).reason == "empty_field"
+
+    bad_links = _valid_record()
+    bad_links["evidence_links"] = ["", "artifact://ok"]
+    assert validate_override_record(bad_links, now=now).reason == "invalid_evidence_links"
+
+    bad_ts = _valid_record()
+    bad_ts["start"] = "not-a-time"
+    assert validate_override_record(bad_ts, now=now).reason == "invalid_timestamp"
+
+    bad_interval = _valid_record()
+    bad_interval["start"] = "2025-02-01T00:00:00Z"
+    bad_interval["expiry"] = "2025-01-01T00:00:00Z"
+    assert validate_override_record(bad_interval, now=now).reason == "invalid_interval"
+
+    expired = _valid_record()
+    expired["expiry"] = "2024-12-31T00:00:00Z"
+    assert validate_override_record(expired, now=now).reason == "expired"
+
+
+def test_validate_override_record_valid_path() -> None:
+    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    result = validate_override_record(_valid_record(), now=now)
+    assert result.valid is True
+    assert result.reason is None
+    telemetry = result.telemetry(source="test")
+    assert telemetry["override_valid"] is True
+    assert telemetry["override_source"] == "test"

--- a/tests/test_transport_policy.py
+++ b/tests/test_transport_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from gabion.commands import command_ids
+from gabion.commands import transport_policy
+from gabion.exceptions import NeverThrown
+from gabion.lsp_client import run_command, run_command_direct
+
+
+@contextmanager
+def _env_scope(updates: dict[str, str | None]):
+    originals = {key: os.environ.get(key) for key in updates}
+    try:
+        for key, value in updates.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in originals.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_transport_policy_denies_direct_for_governed_without_override() -> None:
+    with _env_scope({transport_policy.DIRECT_RUN_ENV: "1", transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: None}):
+        with pytest.raises(NeverThrown):
+            transport_policy.resolve_command_transport(command=command_ids.CHECK_COMMAND, runner=run_command)
+
+
+def test_transport_policy_allows_direct_for_governed_with_valid_override() -> None:
+    with _env_scope(
+        {
+            transport_policy.DIRECT_RUN_ENV: "1",
+            transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: "artifact://override/1",
+            transport_policy.OVERRIDE_RECORD_JSON_ENV: json.dumps(
+                {
+                    "actor": "ci",
+                    "rationale": "temporary",
+                    "scope": "direct_transport",
+                    "start": "2024-01-01T00:00:00Z",
+                    "expiry": "2999-01-01T00:00:00Z",
+                    "rollback_condition": "fix merged",
+                    "evidence_links": ["artifact://override/1"],
+                }
+            ),
+        }
+    ):
+        decision = transport_policy.resolve_command_transport(command=command_ids.CHECK_COMMAND, runner=run_command)
+    assert decision.runner is run_command_direct
+    assert decision.direct_override_telemetry is not None
+
+
+def test_transport_policy_keeps_direct_for_non_governed_command() -> None:
+    with _env_scope({transport_policy.DIRECT_RUN_ENV: "1", transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: None}):
+        decision = transport_policy.resolve_command_transport(
+            command=command_ids.LSP_PARITY_GATE_COMMAND,
+            runner=run_command,
+        )
+    assert decision.runner is run_command_direct


### PR DESCRIPTION
### Motivation
- Strengthen override lifecycle semantics so overrides are machine-validated for safety and telemetry-driven diagnosis. 
- Unify the direct-vs-LSP transport decision surface so CLI and tooling make the same policy decisions. 
- Provide machine-readable clause→enforcement traceability so CI can assert governance completeness. 
- Tighten local test discipline to avoid silent fallbacks that mask tooling/configuration problems.

### Description
- Hardened `validate_override_record` in `src/gabion/tooling/override_record.py` to enforce non-empty trimmed text for `actor`, `rationale`, `scope`, `rollback_condition`, require `evidence_links` to be a non-empty list of non-empty strings, parse `start`/`expiry` and enforce `start < expiry`, and emit explicit failure reason codes such as `missing_fields`, `empty_field`, `invalid_evidence_links`, `invalid_timestamp`, `invalid_interval`, and `expired`; stable telemetry fields are preserved and augmented. 
- Replaced ad-hoc override checks in `scripts/ci_override_record_emit.py` with the shared validator so CI and runtime share one policy source. 
- Extracted transport decision logic into `src/gabion/commands/transport_policy.py` and updated `src/gabion/cli.py` to use it; updated tooling paths (`src/gabion/tooling/delta_emit_runtime.py` and `src/gabion/tooling/delta_state_emit.py`) to consult the same helper before choosing `run_command_direct` vs `run_command`. 
- Added `docs/normative_enforcement_map.yaml` as a machine-readable clause-to-enforcement ledger and extended `scripts/policy_check.py` with `--normative-map` validation that checks clause coverage, enforcing module paths, CI workflow job/step anchors, and expected artifact references. 
- Tightened `scripts/run_tests.sh` to fail closed when `mise` is unavailable and provide remediation text. 
- Added tests: `tests/test_override_record.py`, `tests/test_transport_policy.py`, and extended CI governance script tests in `tests/test_ci_governance_scripts.py` to cover the enforcement-map validator; updated existing tooling to route through the shared helpers.

### Testing
- Ran targeted pytest invocation with repository PYTHONPATH: `PYTHONPATH=src python -m pytest -c /dev/null tests/test_override_record.py tests/test_transport_policy.py tests/test_ci_governance_scripts.py tests/test_delta_emit_runtime.py tests/test_cli_helpers.py -q`, which completed successfully with `153 passed`. 
- Validated the enforcement ledger with `PYTHONPATH=src python scripts/policy_check.py --normative-map`, which returned success. 
- Note: an initial `mise exec` invocation could not be completed in this environment due to external toolchain/network resolution, so verification used the repo-local interpreter (`PYTHONPATH=src`) for deterministic automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd8649dbc8324add5d0d37daf249b)