### PR TITLE
Controller drift gate: add persisted history, stabilization logic, CI restore/upload, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,29 @@ jobs:
         run: .venv/bin/python scripts/branchless_policy_check.py --root .
       - name: Policy check (defensive fallback)
         run: .venv/bin/python scripts/defensive_fallback_policy_check.py --root .
+      - name: Restore controller drift gate history
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          mkdir -p artifacts/out
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "GH_TOKEN unavailable; skipping controller drift history restore."
+            exit 0
+          fi
+          history_url=$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts" \
+            --paginate \
+            -f per_page=100 \
+            --jq '.artifacts[] | select(.name == "controller-drift-gate-history" and .expired == false and .workflow_run.head_branch == env.BRANCH_NAME) | .archive_download_url' \
+            | head -n 1)
+          if [ -z "${history_url:-}" ]; then
+            echo "No prior controller drift history artifact found for branch ${BRANCH_NAME}."
+            exit 0
+          fi
+          gh api "$history_url" > artifacts/out/controller_drift_gate_history.zip
+          python -c 'import zipfile; from pathlib import Path; z=Path("artifacts/out/controller_drift_gate_history.zip"); zipfile.ZipFile(z).extractall("artifacts/out"); z.unlink(missing_ok=True)'
       - name: Controller drift audit
         run: .venv/bin/python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json
       - name: Override lifecycle record emit
@@ -209,7 +232,8 @@ jobs:
         run: |
           .venv/bin/python scripts/ci_controller_drift_gate.py \
             --drift-artifact artifacts/out/controller_drift.json \
-            --override-record artifacts/out/governance_override_record.json
+            --override-record artifacts/out/governance_override_record.json \
+            --history artifacts/out/controller_drift_gate_history.json
       - name: LSP parity gate
         run: .venv/bin/python -m gabion lsp-parity-gate --command gabion.check
       - name: Tests
@@ -245,6 +269,12 @@ jobs:
             --history artifacts/out/governance_telemetry_history.json \
             --json-out artifacts/out/governance_telemetry.json \
             --md-out artifacts/audit_reports/governance_telemetry.md
+      - name: Upload controller drift gate history
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: controller-drift-gate-history
+          path: artifacts/out/controller_drift_gate_history.json
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -254,4 +284,5 @@ jobs:
             artifacts/test_runs
             artifacts/out/governance_telemetry.json
             artifacts/out/governance_telemetry_history.json
+            artifacts/out/controller_drift_gate_history.json
             artifacts/audit_reports/governance_telemetry.md

--- a/scripts/ci_controller_drift_gate.py
+++ b/scripts/ci_controller_drift_gate.py
@@ -15,7 +15,21 @@ def _load_json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
+def _read_history_streak(history: Path) -> int:
+    if not history.exists():
+        return 0
+    try:
+        history_payload = _load_json(history)
+    except (json.JSONDecodeError, OSError):
+        return 0
+    streak_raw = history_payload.get("clean_streak_length", 0)
+    try:
+        return max(0, int(streak_raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def run(*, drift_artifact: Path, override_record: Path, out: Path, history: Path) -> int:
     rules = load_governance_rules().controller_drift
     drift = _load_json(drift_artifact)
     findings = drift.get("findings", [])
@@ -26,9 +40,16 @@ def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
     enforce_rank = SEVERITY.get(rules.enforce_at_or_above.lower(), 99)
     override_validation = validate_override_record_file(override_record)
 
-    status = "pass"
+    prior_streak = _read_history_streak(history)
+
+    status = "clean"
     if max_rank >= enforce_rank:
         status = "override" if override_validation.valid else "fail"
+
+    clean_streak_length = prior_streak + 1 if status == "clean" else 0
+    stabilization_achieved = clean_streak_length >= rules.consecutive_passes_required
+    if status == "clean" and stabilization_achieved:
+        status = "stabilized"
 
     payload = {
         "status": status,
@@ -37,8 +58,15 @@ def run(*, drift_artifact: Path, override_record: Path, out: Path) -> int:
         "required_remediation": rules.remediation_by_severity,
         "override_record": override_validation.record,
         "override_diagnostics": override_validation.telemetry(source="controller_drift_gate"),
-        "consecutive_passes_required": rules.consecutive_passes_required,
+        "clean_streak_length": clean_streak_length,
+        "required_clean_streak_length": rules.consecutive_passes_required,
+        "stabilization_achieved": stabilization_achieved,
     }
+    history.parent.mkdir(parents=True, exist_ok=True)
+    history.write_text(
+        json.dumps({"clean_streak_length": clean_streak_length}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 2 if status == "fail" else 0
@@ -49,8 +77,9 @@ def main() -> int:
     parser.add_argument("--drift-artifact", type=Path, required=True)
     parser.add_argument("--override-record", type=Path, default=Path("artifacts/out/governance_override_record.json"))
     parser.add_argument("--out", type=Path, default=Path("artifacts/out/controller_drift_gate.json"))
+    parser.add_argument("--history", type=Path, default=Path("artifacts/out/controller_drift_gate_history.json"))
     args = parser.parse_args()
-    return run(drift_artifact=args.drift_artifact, override_record=args.override_record, out=args.out)
+    return run(drift_artifact=args.drift_artifact, override_record=args.override_record, out=args.out, history=args.history)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure the controller-drift gate only reports true stabilization after the configured number of consecutive clean runs (`controller_drift.consecutive_passes_required` in `docs/governance_rules.yaml`).
- Make the gate stateful across CI runs by restoring and persisting a small run-state so stabilization can be evaluated across attempts.
- Provide machine-readable telemetry about current streak and stabilization for downstream tooling and audits.

### Description
- Extended `scripts/ci_controller_drift_gate.py` to accept `--history` and read/write a small JSON history file containing `clean_streak_length`, with robust handling for missing or malformed history files via a new helper `_read_history_streak`.
- Implemented streak logic so a clean run increments the streak, failures reset it, and the gate emits `status` `clean` or `stabilized` only once `consecutive_passes_required` is met; added machine-readable fields `clean_streak_length`, `required_clean_streak_length`, and `stabilization_achieved` to the output payload.
- Persist the updated streak to `artifacts/out/controller_drift_gate_history.json` after each run so subsequent CI runs can resume the streak.
- Updated `.github/workflows/ci.yml` to attempt a best-effort restore of the prior history artifact (via the GitHub Actions artifacts API), pass the restored history into the gate step (`--history`), and upload the refreshed `controller_drift_gate_history.json` artifact for future runs.
- Added tests in `tests/test_ci_governance_scripts.py` to cover missing history, first clean run, intermediate streak progression, threshold reached yielding `stabilized`, and reset on failure; also updated existing override-expiry test path to supply the history file.

### Testing
- Ran the governance script unit tests with local pytest: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_ci_governance_scripts.py tests/test_override_record.py` and all tests passed (`8 passed`).
- Noted an initial local run failure when running pytest with repo `pytest.ini` defaults due to environment differences, resolved by clearing `addopts` as above for CI-like invocation; subsequent run succeeded.
- CI wiring updates are best-effort (restore continues-on-error) and were added to the workflow to restore and upload the artifact `controller-drift-gate-history` so history persistence is available between runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de707faf483249c625f5359599c84)