### PR TITLE
Rename local variable in bundle_fingerprint_with_constructors and add canonicalization test

### DIFF
--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -977,10 +977,10 @@ def bundle_fingerprint_with_constructors(
     product = 1
     for hint in types:
         check_deadline()
-        key = canonical_type_key_with_constructor(hint, ctor_registry)
-        if not key:
+        canonical_key = canonical_type_key_with_constructor(hint, ctor_registry)
+        if not canonical_key:
             continue
-        product *= registry.get_or_assign(key)
+        product *= registry.get_or_assign(canonical_key)
     return product
 
 


### PR DESCRIPTION
### Motivation

- Make the intent of the local value returned by `canonical_type_key_with_constructor` explicit and avoid potential confusion from reusing the name `key` inside `bundle_fingerprint_with_constructors`.
- Add a regression test to ensure constructors are canonicalized exactly once per hint to guard against extra work or double-counting.

### Description

- Renamed the loop-local variable from `key` to `canonical_key` in `bundle_fingerprint_with_constructors` and used it when calling `registry.get_or_assign` to clarify the value being used.
- Added `test_bundle_fingerprint_with_constructors_canonicalizes_once_per_hint` to `tests/test_type_fingerprints.py` which verifies that canonicalization/constructor registration is performed the expected number of times for nested hints.

### Testing

- Ran the tests in `tests/test_type_fingerprints.py` including the new `test_bundle_fingerprint_with_constructors_canonicalizes_once_per_hint` and they passed.
- Ran the repository unit test suite with `pytest` and observed no failures related to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e731a703083248b47a6c1dc2e44f7)