### PR TITLE
Stabilize dataflow fingerprint registry mutation with boundary normalization

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -72,6 +72,8 @@ from gabion.analysis.type_fingerprints import (
     FingerprintDimension,
     PrimeRegistry,
     TypeConstructorRegistry,
+    _collect_base_atoms,
+    _collect_constructors,
     SynthRegistry,
     build_synth_registry,
     build_fingerprint_registry,
@@ -3689,6 +3691,36 @@ def _compute_fingerprint_warnings(
     return sort_once(
         set(warnings),
         source="_compute_fingerprint_warnings.warnings",
+    )
+
+
+def _collect_fingerprint_atom_keys(
+    groups_by_path: dict[Path, dict[str, list[set[str]]]],
+    annotations_by_path: dict[Path, dict[str, dict[str, str | None]]],
+) -> tuple[list[str], list[str]]:
+    check_deadline()
+    base_keys: set[str] = set()
+    ctor_keys: set[str] = set()
+    for path, groups in groups_by_path.items():
+        check_deadline()
+        annots_by_fn = annotations_by_path.get(path, {})
+        for fn_name, bundles in groups.items():
+            check_deadline()
+            fn_annots = annots_by_fn.get(fn_name, {})
+            for bundle in bundles:
+                check_deadline()
+                for param_name in bundle:
+                    check_deadline()
+                    hint = fn_annots.get(param_name)
+                    if hint is None:
+                        continue
+                    atoms: list[str] = []
+                    _collect_base_atoms(hint, atoms)
+                    base_keys.update(atom for atom in atoms if atom)
+                    _collect_constructors(hint, ctor_keys)
+    return (
+        sort_once(base_keys, source="_collect_fingerprint_atom_keys.base_keys"),
+        sort_once(ctor_keys, source="_collect_fingerprint_atom_keys.ctor_keys"),
     )
 
 

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -3696,7 +3696,7 @@ def _compute_fingerprint_warnings(
 
 def _collect_fingerprint_atom_keys(
     groups_by_path: dict[Path, dict[str, list[set[str]]]],
-    annotations_by_path: dict[Path, dict[str, dict[str, str | None]]],
+    annotations_by_path: dict[Path, dict[str, ParamAnnotationMap]],
 ) -> tuple[list[str], list[str]]:
     check_deadline()
     base_keys: set[str] = set()
@@ -3712,12 +3712,11 @@ def _collect_fingerprint_atom_keys(
                 for param_name in bundle:
                     check_deadline()
                     hint = fn_annots.get(param_name)
-                    if hint is None:
-                        continue
-                    atoms: list[str] = []
-                    _collect_base_atoms(hint, atoms)
-                    base_keys.update(atom for atom in atoms if atom)
-                    _collect_constructors(hint, ctor_keys)
+                    if hint is not None:
+                        atoms: list[str] = []
+                        _collect_base_atoms(hint, atoms)
+                        base_keys.update(atom for atom in atoms if atom)
+                        _collect_constructors(hint, ctor_keys)
     return (
         sort_once(base_keys, source="_collect_fingerprint_atom_keys.base_keys"),
         sort_once(ctor_keys, source="_collect_fingerprint_atom_keys.ctor_keys"),

--- a/src/gabion/analysis/dataflow_pipeline.py
+++ b/src/gabion/analysis/dataflow_pipeline.py
@@ -702,6 +702,18 @@ def _run_post_phase(
                 )
         else:
             _emit_post_phase_progress(marker="fingerprint:annotations:0/0")
+        base_keys, ctor_keys = _collect_fingerprint_atom_keys(
+            groups_by_path,
+            annotations_by_path,
+        )
+        for key in base_keys:
+            check_deadline()
+            config.fingerprint_registry.get_or_assign(key)
+        if config.constructor_registry is not None:
+            for key in ctor_keys:
+                check_deadline()
+                config.constructor_registry.get_or_assign(key)
+        _emit_post_phase_progress(marker="fingerprint:normalize")
         fingerprint_warnings = _compute_fingerprint_warnings(
             groups_by_path,
             annotations_by_path,

--- a/tests/test_dataflow_pipeline_edges.py
+++ b/tests/test_dataflow_pipeline_edges.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from gabion.analysis import dataflow_pipeline
@@ -96,3 +98,32 @@ def test_analyze_paths_rejects_invalid_phase_progress_callback() -> None:
             include_unused_arg_smells=False,
             on_phase_progress="not-callable",  # type: ignore[arg-type]
         )
+
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_pipeline_edges.py::test_dataflow_pipeline_collect_fingerprint_atoms_order_invariant::dataflow_pipeline.py::gabion.analysis.dataflow_pipeline._bind_audit_symbols
+def test_dataflow_pipeline_collect_fingerprint_atoms_order_invariant() -> None:
+    _bind()
+    first = Path("pkg/a.py")
+    second = Path("pkg/b.py")
+    groups_a = {
+        first: {"f": [{"alpha", "beta"}]},
+        second: {"g": [{"payload"}]},
+    }
+    annotations_a = {
+        first: {"f": {"alpha": "dict[str, int]", "beta": "list[int]"}},
+        second: {"g": {"payload": "tuple[int, str]"}},
+    }
+    groups_b = {
+        second: {"g": [{"payload"}]},
+        first: {"f": [{"beta", "alpha"}]},
+    }
+    annotations_b = {
+        second: {"g": {"payload": "tuple[int, str]"}},
+        first: {"f": {"beta": "list[int]", "alpha": "dict[str, int]"}},
+    }
+
+    assert dataflow_pipeline._collect_fingerprint_atom_keys(
+        groups_a,
+        annotations_a,
+    ) == dataflow_pipeline._collect_fingerprint_atom_keys(groups_b, annotations_b)

--- a/tests/test_dataflow_pipeline_edges.py
+++ b/tests/test_dataflow_pipeline_edges.py
@@ -127,3 +127,40 @@ def test_dataflow_pipeline_collect_fingerprint_atoms_order_invariant() -> None:
         groups_a,
         annotations_a,
     ) == dataflow_pipeline._collect_fingerprint_atom_keys(groups_b, annotations_b)
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_pipeline_edges.py::test_analyze_paths_primes_constructor_registry_from_collected_ctor_keys::dataflow_pipeline.py::gabion.analysis.dataflow_pipeline._collect_fingerprint_atom_keys::dataflow_pipeline.py::gabion.analysis.dataflow_pipeline.analyze_paths
+def test_analyze_paths_primes_constructor_registry_from_collected_ctor_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind()
+    registry, index = dataflow_pipeline.build_fingerprint_registry(
+        {"shape": ["list[int]"]},
+    )
+    ctor_registry = dataflow_pipeline.TypeConstructorRegistry(registry)
+    monkeypatch.setattr(
+        dataflow_pipeline,
+        "_collect_fingerprint_atom_keys",
+        lambda _groups, _annots: ([], ["list"]),
+    )
+
+    dataflow_pipeline.analyze_paths(
+        paths=[],
+        forest=dataflow_pipeline.Forest(),
+        recursive=False,
+        type_audit=False,
+        type_audit_report=False,
+        type_audit_max=0,
+        include_constant_smells=False,
+        include_unused_arg_smells=False,
+        config=dataflow_pipeline.AuditConfig(
+            project_root=tmp_path,
+            fingerprint_registry=registry,
+            fingerprint_index=index,
+            constructor_registry=ctor_registry,
+        ),
+        file_paths_override=[],
+    )
+
+    assert registry.prime_for("ctor:list") is not None

--- a/tests/test_fingerprint_soundness.py
+++ b/tests/test_fingerprint_soundness.py
@@ -48,3 +48,80 @@ def test_fingerprint_identity_payload_handles_empty_cofibration_basis() -> None:
     payload = tf.fingerprint_identity_payload(fingerprint)
     assert payload["witness_carriers"]["cofibration_witness"] == {"entries": []}
     assert "cofibration_witness" not in payload
+
+
+def _normalize_provenance(entries: list[dict[str, object]]) -> list[dict[str, object]]:
+    return sorted(entries, key=lambda entry: str(entry.get("provenance_id", "")))
+
+
+# gabion:evidence E:call_footprint::tests/test_fingerprint_soundness.py::test_fingerprint_phase_outputs_are_stable_under_permuted_input_order::dataflow_audit.py::gabion.analysis.dataflow_audit._collect_fingerprint_atom_keys::dataflow_audit.py::gabion.analysis.dataflow_audit._compute_fingerprint_warnings::dataflow_audit.py::gabion.analysis.dataflow_audit._compute_fingerprint_matches::dataflow_audit.py::gabion.analysis.dataflow_audit._compute_fingerprint_provenance::dataflow_audit.py::gabion.analysis.dataflow_audit._compute_fingerprint_synth
+def test_fingerprint_phase_outputs_are_stable_under_permuted_input_order() -> None:
+    da, tf = _load()
+
+    first = Path("pkg/a.py")
+    second = Path("pkg/b.py")
+    groups_a = {
+        first: {"f": [{"left", "right"}]},
+        second: {"g": [{"payload", "meta"}]},
+    }
+    annotations_a = {
+        first: {"f": {"left": "list[int]", "right": "dict[str, int]"}},
+        second: {"g": {"payload": "tuple[str, int]", "meta": "list[str]"}},
+    }
+    groups_b = {
+        second: {"g": [{"meta", "payload"}]},
+        first: {"f": [{"right", "left"}]},
+    }
+    annotations_b = {
+        second: {"g": {"meta": "list[str]", "payload": "tuple[str, int]"}},
+        first: {"f": {"right": "dict[str, int]", "left": "list[int]"}},
+    }
+
+    base_registry, base_index = tf.build_fingerprint_registry(
+        {"shape.a": ["list[int]", "dict[str, int]"], "shape.b": ["tuple[str, int]", "list[str]"]}
+    )
+    seed = base_registry.seed_payload()
+
+    def _run(groups, annotations):
+        registry = tf.PrimeRegistry()
+        registry.load_seed_payload(seed)
+        ctor_registry = tf.TypeConstructorRegistry(registry)
+        base_keys, ctor_keys = da._collect_fingerprint_atom_keys(groups, annotations)
+        for key in base_keys:
+            registry.get_or_assign(key)
+        for key in ctor_keys:
+            ctor_registry.get_or_assign(key)
+        warnings = da._compute_fingerprint_warnings(
+            groups,
+            annotations,
+            registry=registry,
+            index=base_index,
+            ctor_registry=ctor_registry,
+        )
+        matches = da._compute_fingerprint_matches(
+            groups,
+            annotations,
+            registry=registry,
+            index=base_index,
+            ctor_registry=ctor_registry,
+        )
+        provenance = da._compute_fingerprint_provenance(
+            groups,
+            annotations,
+            registry=registry,
+            project_root=None,
+            index=base_index,
+            ctor_registry=ctor_registry,
+        )
+        synth_lines, synth_payload = da._compute_fingerprint_synth(
+            groups,
+            annotations,
+            registry=registry,
+            ctor_registry=ctor_registry,
+            min_occurrences=2,
+            version="synth-registry@v1",
+            existing=None,
+        )
+        return warnings, matches, _normalize_provenance(provenance), synth_lines, synth_payload
+
+    assert _run(groups_a, annotations_a) == _run(groups_b, annotations_b)

--- a/tests/test_type_fingerprints_sidecar.py
+++ b/tests/test_type_fingerprints_sidecar.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from gabion.analysis.dataflow_audit import (
+    _collect_fingerprint_atom_keys,
     _compute_fingerprint_matches,
     _compute_fingerprint_provenance,
 )
@@ -241,3 +242,30 @@ def test_dataflow_fingerprint_provenance_preserves_legacy_adapter_fields() -> No
     assert entry["identity_layers"]["canonical"]["representative"] == entry[
         "canonical_identity_contract"
     ]["representative"]
+
+
+# gabion:evidence E:call_footprint::tests/test_type_fingerprints_sidecar.py::test_collect_fingerprint_atom_keys_is_order_invariant::dataflow_audit.py::gabion.analysis.dataflow_audit._collect_fingerprint_atom_keys
+def test_collect_fingerprint_atom_keys_is_order_invariant() -> None:
+    first = Path("pkg/a.py")
+    second = Path("pkg/b.py")
+    groups_a = {
+        first: {"f": [{"left", "right"}]},
+        second: {"g": [{"arg"}]},
+    }
+    annotations_a = {
+        first: {"f": {"left": "dict[str, list[int]]", "right": "set[str]"}},
+        second: {"g": {"arg": "tuple[int, str]"}},
+    }
+    groups_b = {
+        second: {"g": [{"arg"}]},
+        first: {"f": [{"right", "left"}]},
+    }
+    annotations_b = {
+        second: {"g": {"arg": "tuple[int, str]"}},
+        first: {"f": {"right": "set[str]", "left": "dict[str, list[int]]"}},
+    }
+
+    assert _collect_fingerprint_atom_keys(groups_a, annotations_a) == _collect_fingerprint_atom_keys(
+        groups_b,
+        annotations_b,
+    )


### PR DESCRIPTION
### Motivation
- Prevent nondeterministic registry growth during per-bundle fingerprint computation by priming the `PrimeRegistry`/constructor registry once per run before emitting fingerprint warnings/matches/provenance/synth. 
- Collect the full set of base-type atoms and constructor atoms needed by fingerprint phases from `groups_by_path` + `annotations_by_path` so registry mutation timing is deterministic. 
- Keep the existing per-bundle fingerprint logic unchanged and only stabilize when registry entries are created. 

### Description
- Added `_collect_fingerprint_atom_keys(...)` in `src/gabion/analysis/dataflow_audit.py` which scans `groups_by_path` and `annotations_by_path` to extract canonical base-type atoms and constructor atoms and returns sorted key lists. 
- Imported `_collect_base_atoms` and `_collect_constructors` from `type_fingerprints` to reuse existing atom extraction logic. 
- In `src/gabion/analysis/dataflow_pipeline.py` (post-phase fingerprint path) call `_collect_fingerprint_atom_keys(...)` and pre-register returned base keys into `config.fingerprint_registry` and constructor keys into `config.constructor_registry` (when present) before invoking `_compute_fingerprint_warnings`, `_compute_fingerprint_matches`, `_compute_fingerprint_provenance`, and `_compute_fingerprint_synth`. 
- Added deterministic tests to validate order-invariance and phase stability: `tests/test_type_fingerprints_sidecar.py` (atom-key order invariance), `tests/test_fingerprint_soundness.py` (fingerprint phase outputs stable under permuted input), and `tests/test_dataflow_pipeline_edges.py` (pipeline-bound helper order-invariance). 

### Testing
- Ran the targeted test subset with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_type_fingerprints_sidecar.py tests/test_fingerprint_soundness.py tests/test_dataflow_pipeline_edges.py`, and all tests passed (`15 passed`).
- Attempted to run via the repo toolchain (`mise exec ...`) per repo guidance but `mise` resolution/trust/network prevented a successful run in this environment, so the direct-Python invocation above was used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e733099148324808b4c98c83b9176)