### PR TITLE
Add universal-curve lab fingerprint bridge harness and artifacts

### DIFF
--- a/in/universal-curve-lab-bundle/artifacts/gabion_fingerprint_bridge.json
+++ b/in/universal-curve-lab-bundle/artifacts/gabion_fingerprint_bridge.json
@@ -1,0 +1,354 @@
+{
+  "case_count": 3,
+  "cases": [
+    {
+      "carrier_soundness": {
+        "base_vs_ctor": true,
+        "base_vs_provenance": true,
+        "base_vs_synth": true,
+        "ctor_vs_provenance": true,
+        "ctor_vs_synth": true,
+        "provenance_vs_synth": true
+      },
+      "case_id": "interior-window-symmetric-a",
+      "description": "Balanced interior window with symmetric left/right prime forcing.",
+      "dimensions": {
+        "base": {
+          "keys_with_remainder": {
+            "keys": [
+              "GapDelta2",
+              "PrimeWindow"
+            ],
+            "remainder": 1
+          },
+          "mask": 12,
+          "product": 35
+        },
+        "ctor": {
+          "keys_with_remainder": {
+            "keys": [
+              "ctor:list",
+              "ctor:tuple"
+            ],
+            "remainder": 1
+          },
+          "mask": 3,
+          "product": 6
+        },
+        "provenance": {
+          "keys_with_remainder": {
+            "keys": [
+              "evidence:symmetry:balanced",
+              "evidence:window:interior"
+            ],
+            "remainder": 1
+          },
+          "mask": 48,
+          "product": 143
+        },
+        "synth": {
+          "keys_with_remainder": {
+            "keys": [
+              "synth:lab-bridge@synth@1:35:6:143:48"
+            ],
+            "remainder": 1
+          },
+          "mask": 2048,
+          "product": 37
+        }
+      }
+    },
+    {
+      "carrier_soundness": {
+        "base_vs_ctor": true,
+        "base_vs_provenance": true,
+        "base_vs_synth": true,
+        "ctor_vs_provenance": true,
+        "ctor_vs_synth": true,
+        "provenance_vs_synth": true
+      },
+      "case_id": "interior-window-symmetric-b",
+      "description": "Duplicate interior witness to trigger a repeated structural tail for synth assignment.",
+      "dimensions": {
+        "base": {
+          "keys_with_remainder": {
+            "keys": [
+              "GapDelta2",
+              "PrimeWindow"
+            ],
+            "remainder": 1
+          },
+          "mask": 12,
+          "product": 35
+        },
+        "ctor": {
+          "keys_with_remainder": {
+            "keys": [
+              "ctor:list",
+              "ctor:tuple"
+            ],
+            "remainder": 1
+          },
+          "mask": 3,
+          "product": 6
+        },
+        "provenance": {
+          "keys_with_remainder": {
+            "keys": [
+              "evidence:symmetry:balanced",
+              "evidence:window:interior"
+            ],
+            "remainder": 1
+          },
+          "mask": 48,
+          "product": 143
+        },
+        "synth": {
+          "keys_with_remainder": {
+            "keys": [
+              "synth:lab-bridge@synth@1:35:6:143:48"
+            ],
+            "remainder": 1
+          },
+          "mask": 2048,
+          "product": 37
+        }
+      }
+    },
+    {
+      "carrier_soundness": {
+        "base_vs_ctor": true,
+        "base_vs_provenance": true,
+        "base_vs_synth": true,
+        "ctor_vs_provenance": true,
+        "ctor_vs_synth": true,
+        "provenance_vs_synth": true
+      },
+      "case_id": "end-window-asymmetry",
+      "description": "Boundary-focused case where right-edge closure differs from left-edge forcing.",
+      "dimensions": {
+        "base": {
+          "keys_with_remainder": {
+            "keys": [
+              "GapDelta3",
+              "PrimeWindow"
+            ],
+            "remainder": 1
+          },
+          "mask": 68,
+          "product": 85
+        },
+        "ctor": {
+          "keys_with_remainder": {
+            "keys": [
+              "ctor:list",
+              "ctor:tuple"
+            ],
+            "remainder": 1
+          },
+          "mask": 3,
+          "product": 6
+        },
+        "provenance": {
+          "keys_with_remainder": {
+            "keys": [
+              "evidence:boundary:asymmetric",
+              "evidence:claim:boundary-is-structure",
+              "evidence:window:end"
+            ],
+            "remainder": 1
+          },
+          "mask": 896,
+          "product": 12673
+        },
+        "synth": {
+          "keys_with_remainder": {
+            "keys": [
+              "synth:lab:boundary-token"
+            ],
+            "remainder": 1
+          },
+          "mask": 1024,
+          "product": 31
+        }
+      }
+    }
+  ],
+  "fingerprint_bridge_version": "gabion-lab-harness@1",
+  "registry_seed": {
+    "namespaces": {
+      "evidence_kind": {
+        "bit_positions": {
+          "boundary:asymmetric": 8,
+          "claim:boundary-is-structure": 9,
+          "symmetry:balanced": 5,
+          "window:end": 7,
+          "window:interior": 4
+        },
+        "primes": {
+          "boundary:asymmetric": 23,
+          "claim:boundary-is-structure": 29,
+          "symmetry:balanced": 13,
+          "window:end": 19,
+          "window:interior": 11
+        }
+      },
+      "synth": {
+        "bit_positions": {
+          "lab-bridge@synth@1:35:6:143:48": 11,
+          "lab:boundary-token": 10
+        },
+        "primes": {
+          "lab-bridge@synth@1:35:6:143:48": 37,
+          "lab:boundary-token": 31
+        }
+      },
+      "type_base": {
+        "bit_positions": {
+          "GapDelta2": 3,
+          "GapDelta3": 6,
+          "PrimeWindow": 2
+        },
+        "primes": {
+          "GapDelta2": 7,
+          "GapDelta3": 17,
+          "PrimeWindow": 5
+        }
+      },
+      "type_ctor": {
+        "bit_positions": {
+          "list": 1,
+          "tuple": 0
+        },
+        "primes": {
+          "list": 3,
+          "tuple": 2
+        }
+      }
+    },
+    "version": "prime-registry-seed@1"
+  },
+  "schema_version": "gabion-lab-adapter@1",
+  "synth_registry_snapshot": {
+    "entries": [
+      {
+        "base_keys": [
+          "GapDelta2",
+          "PrimeWindow"
+        ],
+        "ctor_keys": [
+          "list",
+          "tuple"
+        ],
+        "prime": 37,
+        "remainder": {
+          "base": 1,
+          "ctor": 1
+        },
+        "tail": {
+          "base": {
+            "mask": 12,
+            "product": 35
+          },
+          "ctor": {
+            "mask": 3,
+            "product": 6
+          },
+          "provenance": {
+            "mask": 48,
+            "product": 143
+          },
+          "synth": {
+            "mask": 0,
+            "product": 1
+          }
+        }
+      }
+    ],
+    "min_occurrences": 2,
+    "registry": {
+      "bit_positions": {
+        "GapDelta2": 3,
+        "GapDelta3": 6,
+        "PrimeWindow": 2,
+        "ctor:list": 1,
+        "ctor:tuple": 0,
+        "evidence:boundary:asymmetric": 8,
+        "evidence:claim:boundary-is-structure": 9,
+        "evidence:symmetry:balanced": 5,
+        "evidence:window:end": 7,
+        "evidence:window:interior": 4,
+        "synth:lab-bridge@synth@1:35:6:143:48": 11,
+        "synth:lab:boundary-token": 10
+      },
+      "primes": {
+        "GapDelta2": 7,
+        "GapDelta3": 17,
+        "PrimeWindow": 5,
+        "ctor:list": 3,
+        "ctor:tuple": 2,
+        "evidence:boundary:asymmetric": 23,
+        "evidence:claim:boundary-is-structure": 29,
+        "evidence:symmetry:balanced": 13,
+        "evidence:window:end": 19,
+        "evidence:window:interior": 11,
+        "synth:lab-bridge@synth@1:35:6:143:48": 37,
+        "synth:lab:boundary-token": 31
+      },
+      "seed": {
+        "namespaces": {
+          "evidence_kind": {
+            "bit_positions": {
+              "boundary:asymmetric": 8,
+              "claim:boundary-is-structure": 9,
+              "symmetry:balanced": 5,
+              "window:end": 7,
+              "window:interior": 4
+            },
+            "primes": {
+              "boundary:asymmetric": 23,
+              "claim:boundary-is-structure": 29,
+              "symmetry:balanced": 13,
+              "window:end": 19,
+              "window:interior": 11
+            }
+          },
+          "synth": {
+            "bit_positions": {
+              "lab-bridge@synth@1:35:6:143:48": 11,
+              "lab:boundary-token": 10
+            },
+            "primes": {
+              "lab-bridge@synth@1:35:6:143:48": 37,
+              "lab:boundary-token": 31
+            }
+          },
+          "type_base": {
+            "bit_positions": {
+              "GapDelta2": 3,
+              "GapDelta3": 6,
+              "PrimeWindow": 2
+            },
+            "primes": {
+              "GapDelta2": 7,
+              "GapDelta3": 17,
+              "PrimeWindow": 5
+            }
+          },
+          "type_ctor": {
+            "bit_positions": {
+              "list": 1,
+              "tuple": 0
+            },
+            "primes": {
+              "list": 3,
+              "tuple": 2
+            }
+          }
+        },
+        "version": "prime-registry-seed@1"
+      }
+    },
+    "version": "lab-bridge@synth@1"
+  }
+}

--- a/in/universal-curve-lab-bundle/docs/experiments.md
+++ b/in/universal-curve-lab-bundle/docs/experiments.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 3
+doc_revision: 4
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: universal_curve_lab_experiments
 doc_role: research_protocol
@@ -24,3 +24,43 @@ See `python/`.
 - Prime-by-prime forcing atlases.
 - Interning curves: collision-rate vs scale for GF(p)/mod p/cap.
 - SPPF memoization and JSON exports (audit artifacts).
+
+## Gabion fingerprint bridge harness
+
+The integration harness at `python/gabion_fingerprint_bridge.py` maps minimal lab
+adapter payloads (`python/adapter_schema.json`) into Gabion-compatible
+fingerprint dimensions.
+
+Adapter schema (`gabion-lab-adapter@1`) case fields:
+
+- `base_atoms`: maps to base type atoms (`type_base` namespace).
+- `ctor_atoms`: maps to constructor atoms (`type_ctor` namespace).
+- `provenance_atoms` (optional): maps to provenance/evidence atoms
+  (`evidence_kind` namespace).
+- `synth_atoms` (optional): maps to direct synth atoms (`synth` namespace)
+  before repeated-tail synth assignment.
+
+Harness outputs are written to
+`artifacts/gabion_fingerprint_bridge.json`, including:
+
+- dimensional fingerprints (`base` / `ctor` / `provenance` / `synth`),
+- `keys_with_remainder` diagnostics per dimension,
+- pairwise carrier-soundness checks via `fingerprint_carrier_soundness`,
+- synth-registry payload snapshots (`synth_registry_payload`) and registry seed.
+
+### Boundary-focused case: end-window asymmetry
+
+The `end-window-asymmetry` case encodes the lab claim that boundary behavior is
+structural rather than noise (`boundary:asymmetric`,
+`claim:boundary-is-structure`, `window:end`).
+
+Gabion interpretation in this bridge:
+
+- **Provenance/coherence:** boundary asymmetry appears in the provenance
+  dimension as explicit evidence atoms, separating structural location semantics
+  from base and constructor carriers.
+- **Coherence check:** `keys_with_remainder.remainder == 1` across dimensions
+  indicates the prime basis fully explains the encoded boundary state.
+- **Carrier interpretation:** pairwise carrier soundness remains true, so the
+  boundary-structure evidence commutes with base/ctor carriers without hidden
+  overlap in mask-gcd diagnostics.

--- a/in/universal-curve-lab-bundle/python/adapter_schema.json
+++ b/in/universal-curve-lab-bundle/python/adapter_schema.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "gabion-lab-adapter@1",
+  "cases": [
+    {
+      "case_id": "interior-window-symmetric-a",
+      "description": "Balanced interior window with symmetric left/right prime forcing.",
+      "base_atoms": [
+        "PrimeWindow",
+        "GapDelta2"
+      ],
+      "ctor_atoms": [
+        "tuple",
+        "list"
+      ],
+      "provenance_atoms": [
+        "window:interior",
+        "symmetry:balanced"
+      ]
+    },
+    {
+      "case_id": "interior-window-symmetric-b",
+      "description": "Duplicate interior witness to trigger a repeated structural tail for synth assignment.",
+      "base_atoms": [
+        "PrimeWindow",
+        "GapDelta2"
+      ],
+      "ctor_atoms": [
+        "tuple",
+        "list"
+      ],
+      "provenance_atoms": [
+        "window:interior",
+        "symmetry:balanced"
+      ]
+    },
+    {
+      "case_id": "end-window-asymmetry",
+      "description": "Boundary-focused case where right-edge closure differs from left-edge forcing.",
+      "base_atoms": [
+        "PrimeWindow",
+        "GapDelta3"
+      ],
+      "ctor_atoms": [
+        "tuple",
+        "list"
+      ],
+      "provenance_atoms": [
+        "window:end",
+        "boundary:asymmetric",
+        "claim:boundary-is-structure"
+      ],
+      "synth_atoms": [
+        "lab:boundary-token"
+      ]
+    }
+  ]
+}

--- a/in/universal-curve-lab-bundle/python/gabion_fingerprint_bridge.py
+++ b/in/universal-curve-lab-bundle/python/gabion_fingerprint_bridge.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gabion.analysis.timeout_context import Deadline, deadline_clock_scope, deadline_scope
+from gabion.deadline_clock import GasMeter
+from gabion.analysis.type_fingerprints import (
+    EVIDENCE_KIND_NAMESPACE,
+    SYNTH_NAMESPACE,
+    TYPE_CTOR_NAMESPACE,
+    Fingerprint,
+    FingerprintDimension,
+    PrimeRegistry,
+    TypeConstructorRegistry,
+    apply_synth_dimension,
+    build_synth_registry,
+    fingerprint_carrier_soundness,
+    synth_registry_payload,
+)
+
+
+@dataclass(frozen=True)
+class LabAdapterCase:
+    case_id: str
+    description: str
+    base_atoms: tuple[str, ...]
+    ctor_atoms: tuple[str, ...]
+    provenance_atoms: tuple[str, ...] = ()
+    synth_atoms: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LabAdapterSpec:
+    schema_version: str
+    cases: tuple[LabAdapterCase, ...]
+
+
+def _load_adapter_spec(path: Path) -> LabAdapterSpec:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases: list[LabAdapterCase] = []
+    for raw_case in payload.get("cases", []):
+        cases.append(
+            LabAdapterCase(
+                case_id=str(raw_case["case_id"]),
+                description=str(raw_case.get("description", "")),
+                base_atoms=tuple(str(atom) for atom in raw_case.get("base_atoms", [])),
+                ctor_atoms=tuple(str(atom) for atom in raw_case.get("ctor_atoms", [])),
+                provenance_atoms=tuple(
+                    str(atom) for atom in raw_case.get("provenance_atoms", [])
+                ),
+                synth_atoms=tuple(str(atom) for atom in raw_case.get("synth_atoms", [])),
+            )
+        )
+    return LabAdapterSpec(
+        schema_version=str(payload.get("schema_version", "gabion-lab-adapter@1")),
+        cases=tuple(cases),
+    )
+
+
+def _namespace_atom(namespace: str, atom: str) -> str:
+    if namespace == TYPE_CTOR_NAMESPACE:
+        return f"ctor:{atom}"
+    if namespace == EVIDENCE_KIND_NAMESPACE:
+        return f"evidence:{atom}"
+    if namespace == SYNTH_NAMESPACE:
+        return f"synth:{atom}"
+    return atom
+
+
+def _dimension_from_atoms(
+    atoms: tuple[str, ...],
+    registry: PrimeRegistry,
+    *,
+    namespace: str,
+) -> FingerprintDimension:
+    product = 1
+    mask = 0
+    exponents: dict[str, int] = {}
+    for atom in atoms:
+        key = _namespace_atom(namespace, atom)
+        prime = registry.get_or_assign(key)
+        product *= prime
+        bit = registry.bit_for(key)
+        if bit is not None:
+            mask |= 1 << bit
+        exponents[key] = exponents.get(key, 0) + 1
+    return FingerprintDimension(
+        product=product,
+        mask=mask,
+        exponents=tuple(sorted(exponents.items())),
+    )
+
+
+def _decode_dimension(dim: FingerprintDimension, registry: PrimeRegistry) -> dict[str, Any]:
+    keys, remainder = dim.keys_with_remainder(registry)
+    return {
+        "product": dim.product,
+        "mask": dim.mask,
+        "keys_with_remainder": {
+            "keys": keys,
+            "remainder": remainder,
+        },
+    }
+
+
+def _run_bridge() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    adapter_path = repo_root / "in/universal-curve-lab-bundle/python/adapter_schema.json"
+    artifacts_dir = repo_root / "in/universal-curve-lab-bundle/artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    spec = _load_adapter_spec(adapter_path)
+
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+
+    unsynthesized_cases: list[tuple[LabAdapterCase, Fingerprint]] = []
+    for case in spec.cases:
+        for ctor in case.ctor_atoms:
+            ctor_registry.get_or_assign(ctor)
+        base_dim = _dimension_from_atoms(case.base_atoms, registry, namespace="type_base")
+        ctor_dim = _dimension_from_atoms(
+            case.ctor_atoms,
+            registry,
+            namespace=TYPE_CTOR_NAMESPACE,
+        )
+        provenance_dim = _dimension_from_atoms(
+            case.provenance_atoms,
+            registry,
+            namespace=EVIDENCE_KIND_NAMESPACE,
+        )
+        provided_synth_dim = _dimension_from_atoms(
+            case.synth_atoms,
+            registry,
+            namespace=SYNTH_NAMESPACE,
+        )
+        unsynthesized_cases.append(
+            (
+                case,
+                Fingerprint(
+                    base=base_dim,
+                    ctor=ctor_dim,
+                    provenance=provenance_dim,
+                    synth=provided_synth_dim,
+                ),
+            )
+        )
+
+    synth_registry = build_synth_registry(
+        (fingerprint for _, fingerprint in unsynthesized_cases),
+        registry,
+        min_occurrences=2,
+        version="lab-bridge@synth@1",
+    )
+
+    case_outputs: list[dict[str, Any]] = []
+    with_synth: list[Fingerprint] = []
+    for case, raw_fingerprint in unsynthesized_cases:
+        synthesized = apply_synth_dimension(raw_fingerprint, synth_registry)
+        if (
+            not raw_fingerprint.synth.is_empty()
+            and not synthesized.synth.is_empty()
+            and synthesized.synth != raw_fingerprint.synth
+        ):
+            merged_exponents: dict[str, int] = {}
+            for key, exponent in raw_fingerprint.synth.exponents:
+                merged_exponents[key] = merged_exponents.get(key, 0) + exponent
+            for key, exponent in synthesized.synth.exponents:
+                merged_exponents[key] = merged_exponents.get(key, 0) + exponent
+            merged_synth = FingerprintDimension(
+                product=raw_fingerprint.synth.product * synthesized.synth.product,
+                mask=raw_fingerprint.synth.mask | synthesized.synth.mask,
+                exponents=tuple(sorted(merged_exponents.items())),
+            )
+            synthesized = Fingerprint(
+                base=synthesized.base,
+                ctor=synthesized.ctor,
+                provenance=synthesized.provenance,
+                synth=merged_synth,
+            )
+        with_synth.append(synthesized)
+        case_outputs.append(
+            {
+                "case_id": case.case_id,
+                "description": case.description,
+                "dimensions": {
+                    "base": _decode_dimension(synthesized.base, registry),
+                    "ctor": _decode_dimension(synthesized.ctor, registry),
+                    "provenance": _decode_dimension(synthesized.provenance, registry),
+                    "synth": _decode_dimension(synthesized.synth, registry),
+                },
+                "carrier_soundness": {
+                    "base_vs_ctor": fingerprint_carrier_soundness(
+                        synthesized.base,
+                        synthesized.ctor,
+                    ),
+                    "base_vs_provenance": fingerprint_carrier_soundness(
+                        synthesized.base,
+                        synthesized.provenance,
+                    ),
+                    "base_vs_synth": fingerprint_carrier_soundness(
+                        synthesized.base,
+                        synthesized.synth,
+                    ),
+                    "ctor_vs_provenance": fingerprint_carrier_soundness(
+                        synthesized.ctor,
+                        synthesized.provenance,
+                    ),
+                    "ctor_vs_synth": fingerprint_carrier_soundness(
+                        synthesized.ctor,
+                        synthesized.synth,
+                    ),
+                    "provenance_vs_synth": fingerprint_carrier_soundness(
+                        synthesized.provenance,
+                        synthesized.synth,
+                    ),
+                },
+            }
+        )
+
+    bridge_payload = {
+        "schema_version": spec.schema_version,
+        "fingerprint_bridge_version": "gabion-lab-harness@1",
+        "case_count": len(case_outputs),
+        "cases": case_outputs,
+        "synth_registry_snapshot": synth_registry_payload(
+            synth_registry,
+            registry,
+            min_occurrences=2,
+        ),
+        "registry_seed": registry.seed_payload(),
+    }
+
+    output_path = artifacts_dir / "gabion_fingerprint_bridge.json"
+    output_path.write_text(json.dumps(bridge_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    with deadline_scope(Deadline.from_timeout_ms(120_000)):
+        with deadline_clock_scope(GasMeter(limit=500_000)):
+            _run_bridge()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a small integration harness to map Universal Curve Lab outputs into Gabion fingerprint dimensions so lab experiments can be compared against Gabion provenance/coherence interpretations.
- Supply a minimal adapter schema for lab cases (base/ctor/provenance/synth atoms) and a concrete boundary-focused case (`end-window-asymmetry`) to exercise the claim that "boundary is structure." 
- Emit deterministic, inspectable artifacts (dimensional fingerprints, synth registry snapshots, and registry seeds) to make lab outputs reproducible and reloadable by Gabion tooling.

### Description
- Add `in/universal-curve-lab-bundle/python/gabion_fingerprint_bridge.py`, a Python harness that instantiates `PrimeRegistry` and `TypeConstructorRegistry`, builds base/ctor/provenance/synth `FingerprintDimension`s, applies `build_synth_registry`/`apply_synth_dimension`, computes `keys_with_remainder` diagnostics and pairwise `fingerprint_carrier_soundness` checks, and emits a JSON payload via `synth_registry_payload`/`PrimeRegistry.seed_payload`.
- Add adapter schema `in/universal-curve-lab-bundle/python/adapter_schema.json` containing three starter cases (two symmetric interior cases to trigger synth assignment and one `end-window-asymmetry` boundary case).
- Persist produced output to `in/universal-curve-lab-bundle/artifacts/gabion_fingerprint_bridge.json` and document the bridge and the boundary/coherence interpretation in `in/universal-curve-lab-bundle/docs/experiments.md` (bumped `doc_revision` to `4`).
- Small harness fixes: merge synth exponent sidecars deterministically when both provided and synthesized, and wrap the run in `deadline_scope`/`deadline_clock_scope` (`Deadline.from_timeout_ms` and `GasMeter`) to satisfy the repo's timeout context contracts.

### Testing
- Compiled the harness with `python -m py_compile in/universal-curve-lab-bundle/python/gabion_fingerprint_bridge.py` and the compile succeeded.
- Ran the harness with `PYTHONPATH=src mise exec -- python in/universal-curve-lab-bundle/python/gabion_fingerprint_bridge.py` to regenerate `in/universal-curve-lab-bundle/artifacts/gabion_fingerprint_bridge.json` and the run completed (environment warning about `mise` tool-version lookup was observed but did not prevent execution).
- Validated the produced JSON with `jq` (`jq '.cases[] | {case_id, synth:.dimensions.synth}' in/universal-curve-lab-bundle/artifacts/gabion_fingerprint_bridge.json`) to confirm expected case outputs and synth snapshots.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e733d3f3883249e893f1fcc1412ad)