### PR TITLE
Formalize ASPF fingerprint identity paths and witness-based drift semantics

### DIFF
--- a/docs/aspf_fingerprint_contract.md
+++ b/docs/aspf_fingerprint_contract.md
@@ -1,0 +1,53 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: aspf_fingerprint_contract
+doc_role: design
+doc_scope:
+  - analysis
+  - fingerprints
+doc_authority: informative
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - docs/normative_clause_index.md#normative_clause_index
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 1
+  glossary.md#contract: 1
+  docs/normative_clause_index.md#normative_clause_index: 1
+doc_change_protocol: POLICY_SEED.md#change_protocol
+---
+
+# ASPF fingerprint contract
+
+This document defines the formalized fingerprint contract used by analysis modules.
+
+## Fibration vs cofibration
+
+- **Fibration layer**: refinement paths inside the ASPF fingerprint object space (0-cells and 1-cells).
+- **Cofibration layer**: explicit witness maps from domain-prime basis elements to ASPF-prime basis elements; these maps must validate injective/faithful constraints.
+- Higher-path (2-cell) witnesses encode equivalence between alternate 1-cell representatives.
+
+## Canonical identity strata
+
+1. **Canonical semantic identity**: structural ASPF path payload (source, target, representative, basis path).
+2. **Derived scalar projection**: prime-product projection, explicitly marked `canonical: false`.
+3. **Derived digest alias**: hash alias derived from canonical payload, explicitly marked `canonical: false`.
+
+Downstream consumers must treat only the canonical ASPF path as semantic source-of-truth.
+
+## Representative selection and drift rules
+
+- Representative choice is a Decision Protocol with explicit modes.
+- Contradictions are validated at ingress via one validator surface.
+- Drift is classified by homotopy class change:
+  - representative change + valid higher-path witness => non-drift;
+  - missing/non-equivalent witness class => drift.
+
+## Policy anchors
+
+Implementation is aligned with:
+
+- `POLICY_SEED.md#policy_seed` for execution/control constraints.
+- `glossary.md#contract` for semantic contract and commutation terms.
+- `docs/normative_clause_index.md#normative_clause_index` (notably `NCI-LSP-FIRST` and `NCI-SHIFT-AMBIGUITY-LEFT`).

--- a/in/universal-curve-lab-bundle/artifacts/aspf_regression.json
+++ b/in/universal-curve-lab-bundle/artifacts/aspf_regression.json
@@ -1,0 +1,64 @@
+{
+  "boundary_asymmetry_scenario": {
+    "drift_classification": "non_drift",
+    "left": {
+      "basis_path": [
+        "p2",
+        "p3",
+        "p5"
+      ],
+      "representative": "left_embedding",
+      "source": "lab:start",
+      "target": "lab:end"
+    },
+    "right": {
+      "basis_path": [
+        "p2",
+        "p3",
+        "p5"
+      ],
+      "representative": "right_embedding",
+      "source": "lab:start",
+      "target": "lab:end"
+    }
+  },
+  "cofibration": {
+    "entries": [
+      {
+        "aspf": {
+          "key": "aspf:p2",
+          "prime": 2
+        },
+        "domain": {
+          "key": "lab:p2",
+          "prime": 2
+        }
+      },
+      {
+        "aspf": {
+          "key": "aspf:p3",
+          "prime": 3
+        },
+        "domain": {
+          "key": "lab:p3",
+          "prime": 3
+        }
+      },
+      {
+        "aspf": {
+          "key": "aspf:p5",
+          "prime": 5
+        },
+        "domain": {
+          "key": "lab:p5",
+          "prime": 5
+        }
+      }
+    ]
+  },
+  "higher_path_witness": {
+    "compatible": true,
+    "reason": "boundary-asymmetry-but-equivalent",
+    "witness_id": "lab:higher-path"
+  }
+}

--- a/in/universal-curve-lab-bundle/python/aspf_adapter.py
+++ b/in/universal-curve-lab-bundle/python/aspf_adapter.py
@@ -1,0 +1,78 @@
+"""Adapter from prime structural lab artifacts to ASPF witness objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+from gabion.analysis.aspf_core import AspfOneCell, AspfTwoCellWitness, BasisZeroCell
+from gabion.analysis.aspf_decision_surface import classify_drift_by_homotopy
+from gabion.analysis.aspf_morphisms import (
+    AspfPrimeBasis,
+    DomainPrimeBasis,
+    DomainToAspfCofibration,
+    DomainToAspfCofibrationEntry,
+)
+
+
+@dataclass(frozen=True)
+class LabPrimeArtifact:
+    label: str
+    prime: int
+
+
+def convert_lab_artifacts(artifacts: list[LabPrimeArtifact]) -> dict[str, object]:
+    entries = tuple(
+        DomainToAspfCofibrationEntry(
+            domain=DomainPrimeBasis(domain_key=f"lab:{item.label}", prime=item.prime),
+            aspf=AspfPrimeBasis(aspf_key=f"aspf:{item.label}", prime=item.prime),
+        )
+        for item in artifacts
+    )
+    cofibration = DomainToAspfCofibration(entries=entries)
+    cofibration.validate()
+
+    start = BasisZeroCell("lab:start")
+    end = BasisZeroCell("lab:end")
+    left = AspfOneCell(start, end, "left_embedding", tuple(i.label for i in artifacts))
+    right = AspfOneCell(start, end, "right_embedding", tuple(i.label for i in artifacts))
+    witness = AspfTwoCellWitness(
+        left=left,
+        right=right,
+        witness_id="lab:higher-path",
+        reason="boundary-asymmetry-but-equivalent",
+    )
+    drift = classify_drift_by_homotopy(
+        baseline_representative=left.representative,
+        current_representative=right.representative,
+        has_equivalence_witness=witness.is_compatible(),
+    )
+    return {
+        "cofibration": cofibration.as_dict(),
+        "higher_path_witness": {
+            "witness_id": witness.witness_id,
+            "compatible": witness.is_compatible(),
+            "reason": witness.reason,
+        },
+        "boundary_asymmetry_scenario": {
+            "left": left.as_dict(),
+            "right": right.as_dict(),
+            "drift_classification": drift,
+        },
+    }
+
+
+def write_regression_artifact(output_path: Path) -> None:
+    payload = convert_lab_artifacts(
+        [LabPrimeArtifact("p2", 2), LabPrimeArtifact("p3", 3), LabPrimeArtifact("p5", 5)]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    artifact = root / "artifacts" / "aspf_regression.json"
+    write_regression_artifact(artifact)
+    print(str(artifact))

--- a/src/gabion/analysis/aspf_core.py
+++ b/src/gabion/analysis/aspf_core.py
@@ -1,0 +1,80 @@
+# gabion:boundary_normalization_module
+# gabion:decision_protocol_module
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class AspfZeroCell(Protocol):
+    """Typed 0-cell contract in the ASPF basis."""
+
+    label: str
+
+
+@dataclass(frozen=True)
+class BasisZeroCell:
+    """Concrete 0-cell for ASPF path materialization."""
+
+    label: str
+
+
+@dataclass(frozen=True)
+class AspfOneCell:
+    """Typed path representative between 0-cells."""
+
+    source: BasisZeroCell
+    target: BasisZeroCell
+    representative: str
+    basis_path: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "source": self.source.label,
+            "target": self.target.label,
+            "representative": self.representative,
+            "basis_path": list(self.basis_path),
+        }
+
+
+@dataclass(frozen=True)
+class AspfTwoCellWitness:
+    """Higher path witness showing equivalent 1-cell representatives."""
+
+    left: AspfOneCell
+    right: AspfOneCell
+    witness_id: str
+    reason: str
+
+    def is_compatible(self) -> bool:
+        return (
+            self.left.source == self.right.source
+            and self.left.target == self.right.target
+            and tuple(self.left.basis_path) == tuple(self.right.basis_path)
+        )
+
+
+def identity_1cell(cell: BasisZeroCell) -> AspfOneCell:
+    return AspfOneCell(
+        source=cell,
+        target=cell,
+        representative=f"id:{cell.label}",
+        basis_path=(cell.label,),
+    )
+
+
+def compose_1cells(left: AspfOneCell, right: AspfOneCell) -> AspfOneCell:
+    if left.target != right.source:
+        raise ValueError("1-cell composition requires left.target == right.source")
+    stitched_basis = left.basis_path + right.basis_path[1:]
+    return AspfOneCell(
+        source=left.source,
+        target=right.target,
+        representative=f"{left.representative};{right.representative}",
+        basis_path=stitched_basis,
+    )
+
+
+def validate_2cell_compatibility(witness: AspfTwoCellWitness) -> None:
+    if not witness.is_compatible():
+        raise ValueError("2-cell witness must connect equivalent source/target/basis path")

--- a/src/gabion/analysis/aspf_decision_surface.py
+++ b/src/gabion/analysis/aspf_decision_surface.py
@@ -1,0 +1,68 @@
+# gabion:boundary_normalization_module
+# gabion:decision_protocol_module
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class RepresentativeSelectionMode(StrEnum):
+    LEXICOGRAPHIC_MIN = "lexicographic_min"
+    SHORTEST_PATH_THEN_LEXICOGRAPHIC = "shortest_path_then_lexicographic"
+
+
+@dataclass(frozen=True)
+class RepresentativeSelectionOptions:
+    mode: RepresentativeSelectionMode
+    candidates: tuple[str, ...]
+
+    def validate(self) -> None:
+        if not self.candidates:
+            raise ValueError("Representative selection requires non-empty candidates")
+        if len(set(self.candidates)) != len(self.candidates):
+            raise ValueError("Representative candidates must be unique")
+
+
+@dataclass(frozen=True)
+class RepresentativeSelectionWitness:
+    mode: RepresentativeSelectionMode
+    selected: str
+    candidates: tuple[str, ...]
+    witness_id: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "mode": self.mode.value,
+            "selected": self.selected,
+            "candidates": list(self.candidates),
+            "witness_id": self.witness_id,
+        }
+
+
+def select_representative(options: RepresentativeSelectionOptions) -> RepresentativeSelectionWitness:
+    options.validate()
+    if options.mode is RepresentativeSelectionMode.LEXICOGRAPHIC_MIN:
+        selected = min(options.candidates)
+    elif options.mode is RepresentativeSelectionMode.SHORTEST_PATH_THEN_LEXICOGRAPHIC:
+        selected = min(options.candidates, key=lambda value: (len(value), value))
+    else:  # pragma: no cover - enum exhaustiveness
+        raise ValueError(f"Unsupported representative selection mode: {options.mode}")
+    return RepresentativeSelectionWitness(
+        mode=options.mode,
+        selected=selected,
+        candidates=options.candidates,
+        witness_id=f"rep:{options.mode.value}:{selected}",
+    )
+
+
+def classify_drift_by_homotopy(
+    *,
+    baseline_representative: str,
+    current_representative: str,
+    has_equivalence_witness: bool,
+) -> str:
+    if baseline_representative == current_representative:
+        return "non_drift"
+    if has_equivalence_witness:
+        return "non_drift"
+    return "drift"

--- a/src/gabion/analysis/aspf_morphisms.py
+++ b/src/gabion/analysis/aspf_morphisms.py
@@ -1,0 +1,66 @@
+# gabion:boundary_normalization_module
+# gabion:decision_protocol_module
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DomainPrimeBasis:
+    domain_key: str
+    prime: int
+
+
+@dataclass(frozen=True)
+class AspfPrimeBasis:
+    aspf_key: str
+    prime: int
+
+
+@dataclass(frozen=True)
+class DomainToAspfCofibrationEntry:
+    domain: DomainPrimeBasis
+    aspf: AspfPrimeBasis
+
+
+@dataclass(frozen=True)
+class DomainToAspfCofibration:
+    entries: tuple[DomainToAspfCofibrationEntry, ...]
+
+    def validate_injective(self) -> None:
+        seen_targets: set[str] = set()
+        for entry in self.entries:
+            target = entry.aspf.aspf_key
+            if target in seen_targets:
+                raise ValueError("Cofibration must be injective over ASPF basis targets")
+            seen_targets.add(target)
+
+    def validate_faithful(self) -> None:
+        for entry in self.entries:
+            if entry.domain.prime <= 1 or entry.aspf.prime <= 1:
+                raise ValueError("Cofibration primes must be valid (>1)")
+            if entry.domain.prime != entry.aspf.prime:
+                raise ValueError("Cofibration faithfulness requires prime-preserving embedding")
+
+    def validate(self) -> None:
+        if not self.entries:
+            raise ValueError("Cofibration requires at least one basis embedding")
+        self.validate_injective()
+        self.validate_faithful()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "entries": [
+                {
+                    "domain": {
+                        "key": entry.domain.domain_key,
+                        "prime": entry.domain.prime,
+                    },
+                    "aspf": {
+                        "key": entry.aspf.aspf_key,
+                        "prime": entry.aspf.prime,
+                    },
+                }
+                for entry in self.entries
+            ]
+        }

--- a/tests/test_aspf_cofibration_laws.py
+++ b/tests/test_aspf_cofibration_laws.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from gabion.analysis.aspf_core import (
+    AspfOneCell,
+    AspfTwoCellWitness,
+    BasisZeroCell,
+    compose_1cells,
+    identity_1cell,
+    validate_2cell_compatibility,
+)
+from gabion.analysis.aspf_decision_surface import (
+    RepresentativeSelectionMode,
+    RepresentativeSelectionOptions,
+    classify_drift_by_homotopy,
+    select_representative,
+)
+from gabion.analysis.aspf_morphisms import (
+    AspfPrimeBasis,
+    DomainPrimeBasis,
+    DomainToAspfCofibration,
+    DomainToAspfCofibrationEntry,
+)
+from gabion.analysis.evidence_keys import fingerprint_identity_layers
+
+
+def test_aspf_identity_and_associativity() -> None:
+    a = BasisZeroCell("A")
+    b = BasisZeroCell("B")
+    c = BasisZeroCell("C")
+    ab = AspfOneCell(a, b, "ab", ("A", "B"))
+    bc = AspfOneCell(b, c, "bc", ("B", "C"))
+
+    left = compose_1cells(identity_1cell(a), ab)
+    right = compose_1cells(ab, identity_1cell(b))
+    assert left.basis_path == ab.basis_path
+    assert right.basis_path == ab.basis_path
+
+    composed = compose_1cells(ab, bc)
+    assert composed.basis_path == ("A", "B", "C")
+
+
+def test_higher_path_equivalence_and_drift_quotienting() -> None:
+    a = BasisZeroCell("A")
+    b = BasisZeroCell("B")
+    left = AspfOneCell(a, b, "left", ("A", "B"))
+    right = AspfOneCell(a, b, "right", ("A", "B"))
+    witness = AspfTwoCellWitness(left=left, right=right, witness_id="w:1", reason="equiv")
+    validate_2cell_compatibility(witness)
+
+    assert classify_drift_by_homotopy(
+        baseline_representative="left",
+        current_representative="right",
+        has_equivalence_witness=True,
+    ) == "non_drift"
+    assert classify_drift_by_homotopy(
+        baseline_representative="left",
+        current_representative="right",
+        has_equivalence_witness=False,
+    ) == "drift"
+
+
+def test_cofibration_injective_and_faithful() -> None:
+    cofibration = DomainToAspfCofibration(
+        entries=(
+            DomainToAspfCofibrationEntry(
+                domain=DomainPrimeBasis("d:int", 2),
+                aspf=AspfPrimeBasis("a:int", 2),
+            ),
+            DomainToAspfCofibrationEntry(
+                domain=DomainPrimeBasis("d:str", 3),
+                aspf=AspfPrimeBasis("a:str", 3),
+            ),
+        )
+    )
+    cofibration.validate()
+
+
+def test_deterministic_representative_selection_and_identity_layers() -> None:
+    witness = select_representative(
+        RepresentativeSelectionOptions(
+            mode=RepresentativeSelectionMode.SHORTEST_PATH_THEN_LEXICOGRAPHIC,
+            candidates=("zz", "a", "bbb"),
+        )
+    )
+    assert witness.selected == "a"
+
+    identity = fingerprint_identity_layers(
+        canonical_aspf_path={"representative": witness.selected, "basis_path": ["a"]},
+        scalar_prime_product=2,
+    ).as_dict()
+    assert identity["identity_layer"] == "canonical_aspf_path"
+    assert identity["derived"]["scalar_prime_product"]["canonical"] is False
+    assert identity["derived"]["digest_alias"]["canonical"] is False

--- a/tests/test_fingerprint_soundness.py
+++ b/tests/test_fingerprint_soundness.py
@@ -26,3 +26,12 @@ def test_fingerprint_soundness_issues_skip_empty() -> None:
         base=tf.FingerprintDimension(product=2, mask=0),
     )
     assert da._fingerprint_soundness_issues(fingerprint) == []
+
+
+def test_fingerprint_identity_payload_marks_canonical_vs_derived() -> None:
+    _, tf = _load()
+    fingerprint = tf.Fingerprint(base=tf.FingerprintDimension(product=2, mask=0))
+    payload = tf.fingerprint_identity_payload(fingerprint)
+    assert payload["identity_layers"]["identity_layer"] == "canonical_aspf_path"
+    assert payload["identity_layers"]["derived"]["scalar_prime_product"]["canonical"] is False
+    assert payload["identity_layers"]["derived"]["digest_alias"]["canonical"] is False

--- a/tests/test_type_fingerprints_sidecar.py
+++ b/tests/test_type_fingerprints_sidecar.py
@@ -188,3 +188,25 @@ def test_dataflow_fingerprint_reporting_parity_with_legacy_decode() -> None:
         "base": legacy_base_remaining,
         "ctor": legacy_ctor_remaining,
     }
+
+
+def test_dataflow_fingerprint_provenance_emits_identity_layer_and_selection_witness() -> None:
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+    path = Path("pkg/mod.py")
+    groups_by_path = {path: {"fn": [{"left"}]}}
+    annotations_by_path = {path: {"fn": {"left": "int"}}}
+
+    provenance = _compute_fingerprint_provenance(
+        groups_by_path,
+        annotations_by_path,
+        registry=registry,
+        project_root=None,
+        index={},
+        ctor_registry=ctor_registry,
+    )
+    assert provenance
+    entry = provenance[0]
+    assert entry["identity_layers"]["identity_layer"] == "canonical_aspf_path"
+    assert entry["representative_selection"]["mode"] == "lexicographic_min"
+    assert entry["drift_classification"] == "non_drift"


### PR DESCRIPTION
### Motivation
- Provide a principled, structural identity layer for fingerprints so canonical identity is a structural ASPF path rather than a scalar/hash projection.
- Enable explicit higher-path (2-cell) witnesses and cofibration embeddings so alternate representatives can be proven equivalent and not treated as drift.
- Centralize deterministic representative selection as a Decision Protocol to avoid ad-hoc representative choices and contradictory branches.
- Surface identity/cofibration/selection witnesses in provenance so downstream consumers cannot mistake derived projections (prime product / digest) for canonical identity.

### Description
- Added an ASPF core model with typed 0-cells, 1-cells, and 2-cell witnesses, plus `identity_1cell`, `compose_1cells`, and a 2-cell compatibility validator (`src/gabion/analysis/aspf_core.py`).
- Added a cofibration/morphism layer with `DomainPrimeBasis`, `AspfPrimeBasis`, and `DomainToAspfCofibration` including injective and faithful validation (`src/gabion/analysis/aspf_morphisms.py`).
- Introduced deterministic representative-selection Decision Protocol and homotopy-based drift classifier (`src/gabion/analysis/aspf_decision_surface.py`).
- Promoted canonical identity to a structural ASPF path and added an identity-layers API that returns the canonical ASPF payload and explicitly marked derived scalar and digest projections (`src/gabion/analysis/evidence_keys.py`).
- Integrated ASPF identity/cofibration/representative-selection witnesses into fingerprint construction and provenance emission (`src/gabion/analysis/type_fingerprints.py` and `src/gabion/analysis/dataflow_audit.py`).
- Added a universal-curve lab adapter that converts lab prime artifacts into ASPF/cofibration objects and emits a deterministic regression artifact that demonstrates boundary-asymmetry with a higher-path witness (`in/universal-curve-lab-bundle/python/aspf_adapter.py` and artifact JSON).
- Added tests that encode the Decision Protocol and law-based checks covering identity/associativity, higher-path equivalence, cofibration laws, deterministic representative selection, and identity-layer semantics (`tests/test_aspf_cofibration_laws.py`, and extensions to `tests/test_fingerprint_soundness.py` and `tests/test_type_fingerprints_sidecar.py`).
- Added a design doc formalizing fibration vs cofibration, canonical identity strata, representative-selection rules, and drift classification policy (`docs/aspf_fingerprint_contract.md`).

### Testing
- Ran unit tests targeted at the new and modified behavior with `PYTHONPATH=src pytest -q -c /dev/null tests/test_aspf_cofibration_laws.py tests/test_fingerprint_soundness.py tests/test_type_fingerprints_sidecar.py`, and they passed: `13 passed in 0.29s`.
- Compiled modules to validate imports with `PYTHONPATH=src python -m compileall -q src/gabion/analysis in/universal-curve-lab-bundle/python`, which succeeded.
- Executed the lab adapter with `PYTHONPATH=src python in/universal-curve-lab-bundle/python/aspf_adapter.py` to produce the deterministic regression artifact, which ran successfully and produced `in/universal-curve-lab-bundle/artifacts/aspf_regression.json`.
- Note: an attempt to run `mise exec -- python ...` was not usable in this environment because the local `mise.toml` trust was not configured, so equivalent commands were run directly under `PYTHONPATH=src` instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e792fbc6c8324a369719c1bb38523)