### PR TITLE
Establish canonical ASPF identity contract and witness-carried provenance

### DIFF
--- a/src/gabion/analysis/aspf_core.py
+++ b/src/gabion/analysis/aspf_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Mapping
 from typing import Protocol
 
 
@@ -52,6 +53,88 @@ class AspfTwoCellWitness:
             and self.left.target == self.right.target
             and tuple(self.left.basis_path) == tuple(self.right.basis_path)
         )
+
+    def links(self, *, baseline_representative: str, current_representative: str) -> bool:
+        left = self.left.representative
+        right = self.right.representative
+        return (left, right) in {
+            (baseline_representative, current_representative),
+            (current_representative, baseline_representative),
+        }
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "left": self.left.as_dict(),
+            "right": self.right.as_dict(),
+            "witness_id": self.witness_id,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class SuiteSiteEndpoint:
+    kind: str
+    key: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {"kind": self.kind, "key": list(self.key)}
+
+
+@dataclass(frozen=True)
+class AspfCanonicalIdentityContract:
+    identity_kind: str
+    source: BasisZeroCell
+    target: BasisZeroCell
+    representative: str
+    basis_path: tuple[str, ...]
+    suite_site_source: SuiteSiteEndpoint
+    suite_site_target: SuiteSiteEndpoint
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "identity_kind": self.identity_kind,
+            "source": self.source.label,
+            "target": self.target.label,
+            "representative": self.representative,
+            "basis_path": list(self.basis_path),
+            "suite_site_endpoints": {
+                "source": self.suite_site_source.as_dict(),
+                "target": self.suite_site_target.as_dict(),
+            },
+        }
+
+
+def parse_2cell_witness(payload: Mapping[str, object]) -> AspfTwoCellWitness | None:
+    left_payload = payload.get("left")
+    right_payload = payload.get("right")
+    witness_id = payload.get("witness_id")
+    reason = payload.get("reason")
+    if not isinstance(left_payload, Mapping) or not isinstance(right_payload, Mapping):
+        return None
+    if not isinstance(witness_id, str) or not isinstance(reason, str):
+        return None
+
+    def _decode_1cell(raw: Mapping[str, object]) -> AspfOneCell | None:
+        source = raw.get("source")
+        target = raw.get("target")
+        representative = raw.get("representative")
+        basis_path = raw.get("basis_path")
+        if not isinstance(source, str) or not isinstance(target, str) or not isinstance(representative, str):
+            return None
+        if not isinstance(basis_path, list) or not all(isinstance(item, str) for item in basis_path):
+            return None
+        return AspfOneCell(
+            source=BasisZeroCell(source),
+            target=BasisZeroCell(target),
+            representative=representative,
+            basis_path=tuple(basis_path),
+        )
+
+    left = _decode_1cell(left_payload)
+    right = _decode_1cell(right_payload)
+    if left is None or right is None:
+        return None
+    return AspfTwoCellWitness(left=left, right=right, witness_id=witness_id, reason=reason)
 
 
 def identity_1cell(cell: BasisZeroCell) -> AspfOneCell:

--- a/src/gabion/analysis/aspf_decision_surface.py
+++ b/src/gabion/analysis/aspf_decision_surface.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from .aspf_core import AspfTwoCellWitness
+
 
 class RepresentativeSelectionMode(StrEnum):
     LEXICOGRAPHIC_MIN = "lexicographic_min"
@@ -59,10 +61,17 @@ def classify_drift_by_homotopy(
     *,
     baseline_representative: str,
     current_representative: str,
-    has_equivalence_witness: bool,
+    equivalence_witness: AspfTwoCellWitness | None = None,
+    has_equivalence_witness: bool | None = None,
 ) -> str:
     if baseline_representative == current_representative:
         return "non_drift"
-    if has_equivalence_witness:
+    if equivalence_witness is not None:
+        if equivalence_witness.is_compatible() and equivalence_witness.links(
+            baseline_representative=baseline_representative,
+            current_representative=current_representative,
+        ):
+            return "non_drift"
+    if bool(has_equivalence_witness):
         return "non_drift"
     return "drift"

--- a/src/gabion/analysis/aspf_morphisms.py
+++ b/src/gabion/analysis/aspf_morphisms.py
@@ -64,3 +64,15 @@ class DomainToAspfCofibration:
                 for entry in self.entries
             ]
         }
+
+
+@dataclass(frozen=True)
+class CofibrationWitnessCarrier:
+    canonical_identity_kind: str
+    cofibration: DomainToAspfCofibration
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "canonical_identity_kind": self.canonical_identity_kind,
+            "cofibration": self.cofibration.as_dict(),
+        }

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -147,6 +147,7 @@ from .projection_registry import (
     spec_metadata_payload,
 )
 from .wl_refinement import emit_wl_refinement_facets
+from .aspf_core import parse_2cell_witness
 from .aspf_decision_surface import classify_drift_by_homotopy
 from .dataflow_decision_surfaces import (
     compute_fingerprint_coherence as _ds_compute_fingerprint_coherence,
@@ -3756,10 +3757,18 @@ def _compute_fingerprint_provenance(
                         "basis_path", []
                     )
                 )
+                higher_path_payload = identity_payload.get("witness_carriers", {}).get(
+                    "higher_path_witness"
+                )
+                higher_path_witness = (
+                    parse_2cell_witness(higher_path_payload)
+                    if isinstance(higher_path_payload, dict)
+                    else None
+                )
                 drift_classification = classify_drift_by_homotopy(
                     baseline_representative=representative,
                     current_representative=basis_repr,
-                    has_equivalence_witness=True,
+                    equivalence_witness=higher_path_witness,
                 )
                 bundle_key = ",".join(bundle_params)
                 entries.append(
@@ -3800,10 +3809,15 @@ def _compute_fingerprint_provenance(
                         },
                         "soundness_issues": soundness_issues,
                         "glossary_matches": matches,
+                        "canonical_identity_contract": identity_payload[
+                            "canonical_identity_contract"
+                        ],
                         "identity_layers": identity_payload["identity_layers"],
                         "representative_selection": identity_payload[
                             "representative_selection"
                         ],
+                        "witness_carriers": identity_payload["witness_carriers"],
+                        "derived_aliases": identity_payload["derived_aliases"],
                         "cofibration_witness": identity_payload.get(
                             "cofibration_witness", {"entries": []}
                         ),

--- a/tests/test_aspf_cofibration_laws.py
+++ b/tests/test_aspf_cofibration_laws.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from gabion.analysis.aspf_core import (
+    AspfCanonicalIdentityContract,
     AspfOneCell,
     AspfTwoCellWitness,
     BasisZeroCell,
+    SuiteSiteEndpoint,
     compose_1cells,
     identity_1cell,
     validate_2cell_compatibility,
@@ -16,6 +18,7 @@ from gabion.analysis.aspf_decision_surface import (
 )
 from gabion.analysis.aspf_morphisms import (
     AspfPrimeBasis,
+    CofibrationWitnessCarrier,
     DomainPrimeBasis,
     DomainToAspfCofibration,
     DomainToAspfCofibrationEntry,
@@ -50,7 +53,7 @@ def test_higher_path_equivalence_and_drift_quotienting() -> None:
     assert classify_drift_by_homotopy(
         baseline_representative="left",
         current_representative="right",
-        has_equivalence_witness=True,
+        equivalence_witness=witness,
     ) == "non_drift"
     assert classify_drift_by_homotopy(
         baseline_representative="left",
@@ -73,7 +76,32 @@ def test_cofibration_injective_and_faithful() -> None:
         )
     )
     cofibration.validate()
+    carrier = CofibrationWitnessCarrier(
+        canonical_identity_kind="canonical_aspf_structural_identity",
+        cofibration=cofibration,
+    )
+    assert carrier.as_dict()["cofibration"]["entries"]
 
+
+
+
+def test_canonical_identity_contract_carries_suite_site_endpoints() -> None:
+    contract = AspfCanonicalIdentityContract(
+        identity_kind="canonical_aspf_structural_identity",
+        source=BasisZeroCell("fingerprint:start"),
+        target=BasisZeroCell("fingerprint:end"),
+        representative="rep",
+        basis_path=("a", "b"),
+        suite_site_source=SuiteSiteEndpoint("SuiteSite", ("fingerprint:start", "fingerprint", "source")),
+        suite_site_target=SuiteSiteEndpoint("SuiteSite", ("fingerprint:end", "fingerprint", "target")),
+    )
+    payload = contract.as_dict()
+    assert payload["suite_site_endpoints"]["source"]["kind"] == "SuiteSite"
+    assert payload["suite_site_endpoints"]["target"]["key"] == [
+        "fingerprint:end",
+        "fingerprint",
+        "target",
+    ]
 
 def test_deterministic_representative_selection_and_identity_layers() -> None:
     witness = select_representative(

--- a/tests/test_type_fingerprints_sidecar.py
+++ b/tests/test_type_fingerprints_sidecar.py
@@ -207,6 +207,35 @@ def test_dataflow_fingerprint_provenance_emits_identity_layer_and_selection_witn
     )
     assert provenance
     entry = provenance[0]
+    assert entry["canonical_identity_contract"]["identity_kind"] == "canonical_aspf_structural_identity"
+    assert entry["canonical_identity_contract"]["suite_site_endpoints"]["source"]["kind"] == "SuiteSite"
     assert entry["identity_layers"]["identity_layer"] == "canonical_aspf_path"
     assert entry["representative_selection"]["mode"] == "lexicographic_min"
+    assert entry["witness_carriers"]["higher_path_witness"]["witness_id"].startswith("higher:")
+    assert entry["derived_aliases"]["scalar_prime_product"]["canonical"] is False
     assert entry["drift_classification"] == "non_drift"
+
+
+def test_dataflow_fingerprint_provenance_preserves_legacy_adapter_fields() -> None:
+    registry = PrimeRegistry()
+    ctor_registry = TypeConstructorRegistry(registry)
+    path = Path("pkg/mod.py")
+    groups_by_path = {path: {"fn": [{"left"}]}}
+    annotations_by_path = {path: {"fn": {"left": "int"}}}
+
+    provenance = _compute_fingerprint_provenance(
+        groups_by_path,
+        annotations_by_path,
+        registry=registry,
+        project_root=None,
+        index={},
+        ctor_registry=ctor_registry,
+    )
+
+    entry = provenance[0]
+    assert "identity_layers" in entry
+    assert "representative_selection" in entry
+    assert "cofibration_witness" in entry
+    assert entry["identity_layers"]["canonical"]["representative"] == entry[
+        "canonical_identity_contract"
+    ]["representative"]


### PR DESCRIPTION
### Motivation

- Provide a single canonical identity contract for ASPF paths (including SuiteSite endpoints) that serves as the source-of-truth for analysis outputs. 
- Stop treating scalar/hash identifiers as primary identities and mark them as derived aliases so consumers migrate to structural identity. 
- Make drift classification depend on actual higher-path witness linkage instead of inferred booleans. 
- Preserve backward-compatible adapter fields so existing report consumers continue to work.

### Description

- Add structural identity types and helpers in `src/gabion/analysis/aspf_core.py`: `AspfCanonicalIdentityContract`, `SuiteSiteEndpoint`, `AspfTwoCellWitness.as_dict/links`, and `parse_2cell_witness` for serialized witness parsing. 
- Change drift decision surface in `src/gabion/analysis/aspf_decision_surface.py` so `classify_drift_by_homotopy` prefers an actual `AspfTwoCellWitness` linkage (compatibility + representative pairing) and still supports the legacy boolean fallback. 
- Update fingerprint payload generation in `src/gabion/analysis/type_fingerprints.py` to emit `canonical_identity_contract` as the source-of-truth, thread `witness_carriers` (selection/cofibration/higher-path), and expose `derived_aliases` (scalar/digest) that are explicitly non-canonical; legacy fields like `identity_layers`, `representative_selection`, and `cofibration_witness` are still emitted for compatibility. 
- Thread parsing and use of higher-path witness in `src/gabion/analysis/dataflow_audit.py` so provenance entries use parsed witness linkage when computing `drift_classification`. 
- Add `CofibrationWitnessCarrier` wrapper in `src/gabion/analysis/aspf_morphisms.py` to carry cofibration witness semantics explicitly. 
- Add/adjust tests to validate canonical identity contract, witness-linked drift behavior, provenance payload contents (canonical + witness carriers + derived aliases), and that legacy adapter fields remain present in `tests/test_aspf_cofibration_laws.py` and `tests/test_type_fingerprints_sidecar.py`.

### Testing

- Ran targeted unit tests with `PYTHONPATH=src python -m pytest -q -o addopts='' tests/test_aspf_cofibration_laws.py tests/test_type_fingerprints_sidecar.py` and the suite passed (12 passed). 
- Compiled modified modules to validate syntax with `PYTHONPATH=src python -m compileall -q <files>` (compile succeeded). 
- Note: initial automated attempts using the environment's default `pytest` invocation and `mise exec` surfaced environment/import issues (`ModuleNotFoundError` and untrusted `mise.toml`), so the final test run used `PYTHONPATH=src` with `-o addopts=''` to run the targeted tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efae07a388324b2e9b82963d427a4)