### PR TITLE
Stabilize fingerprint registry assignments and cache identity compatibility

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 158
+doc_revision: 159
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -39,7 +39,7 @@ doc_review_notes:
   glossary.md#deadness_witness: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
   glossary.md#exception_obligation: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_sections:
-  sppf_checklist: 7
+  sppf_checklist: 8
 doc_section_requires:
   sppf_checklist:
     - README.md#repo_contract
@@ -55,47 +55,47 @@ doc_section_reviews:
   sppf_checklist:
     README.md#repo_contract:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed README.md rev1 (docflow audit now scans in/ by default); no conflicts with this document's scope."
     CONTRIBUTING.md#contributing_contract:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed CONTRIBUTING.md rev1 (docflow now fails on missing GH references for SPPF-relevant changes); no conflicts with this document's scope."
     glossary.md#decision_table:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#decision_table rev1 (decision table tier definition)."
     glossary.md#decision_bundle:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#decision_bundle rev1 (decision bundle tier definition)."
     glossary.md#decision_protocol:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#decision_protocol rev1 (decision protocol tier definition)."
     glossary.md#decision_surface:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#decision_surface rev1 (decision surface tier boundary semantics)."
     glossary.md#value_encoded_decision:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#value_encoded_decision rev1 (value-encoded decision surface semantics)."
     glossary.md#deadness_witness:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
     glossary.md#exception_obligation:
       dep_version: 1
-      self_version_at_review: 7
+      self_version_at_review: 8
       outcome: no_change
       note: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
@@ -205,7 +205,7 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - [x] Fingerprint arithmetic ops (gcd/lcm/subtyping checks). (GH-68)
 - [x] Glossary fingerprint matching + CI warnings. (GH-68)
 - [x] Hybrid fingerprint representation (prime products + bitmask existence checks). (GH-68)
-- [~] Deterministic fingerprint registry seeding (sorted key interning for primes/bits; basis is deterministic but migration/ratchet policy remains partial). Evidence anchors: `src/gabion/analysis/type_fingerprints.py::build_fingerprint_registry`, `tests/test_type_fingerprints.py::test_build_fingerprint_registry_deterministic_assignment`. (in-22, GH-68) sppf{doc=partial; impl=partial; doc_ref=in-22@2}
+- [x] Deterministic fingerprint registry policy (seeded-vs-learned assignment policy is serialized in the seed payload, deterministic rehydrate path accepts legacy cache identities, and registry/key stability is covered by suite-order perturbation regressions). Evidence anchors: `src/gabion/analysis/type_fingerprints.py::PrimeRegistry.seed_payload`, `src/gabion/analysis/type_fingerprints.py::build_synth_registry_from_payload`, `src/gabion/analysis/dataflow_audit.py::_canonical_cache_identity`, `tests/test_type_fingerprints.py::test_registry_assignment_policy_roundtrips_and_stays_deterministic`, `tests/test_dataflow_audit_helpers.py::test_cache_identity_supports_legacy_alias_matching`, `tests/test_aspf.py::test_suite_site_signature_stable_under_suite_order_perturbation`. (in-22, GH-68) sppf{doc=done; impl=done; doc_ref=in-22@2}
 - [x] Nested type constructor registry (dimensional prime mapping). (GH-68)
 - [x] Fingerprint reverse mapping for synthesis (factorization → type keys). (GH-68)
 - [~] ASPF dimensional fingerprints (base/ctor carriers + soundness invariants; entropy-controlled synthesis obligations still open). Evidence anchors: `src/gabion/analysis/type_fingerprints.py::bundle_fingerprint_dimensional`, `tests/test_type_fingerprints.py::test_dimensional_fingerprint_includes_constructors`. (in-22, GH-70) sppf{doc=partial; impl=partial; doc_ref=in-22@2}


### PR DESCRIPTION
### Motivation
- Ensure deterministic, auditable assignment of primes/bits by recording whether registry entries were `seeded` or `learned` so cache artifacts round-trip deterministically.
- Canonicalize stage/index/projection cache keys and accept legacy 40-hex identities so existing resume artifacts remain usable after the key format change.
- Add regression coverage for suite-order perturbations and cross-run determinism for fingerprint/registry artifacts.

### Description
- Record assignment origin in `PrimeRegistry` via a new `assignment_origin` map and include an `assignment_policy` section in `PrimeRegistry.seed_payload` that emits `seeded` and `learned` lists.
- Apply registry payloads deterministically in `_apply_registry_payload`, accept an `assignment_kind` argument (used as `"seeded"` when rehydrating synth/registry payloads), and honor `assignment_policy` when present.
- Treat synth-registry payload rehydration as importing a seeded registry basis by calling `_apply_registry_payload(..., assignment_kind="seeded")` from `build_synth_registry_from_payload` and `load_seed_payload` paths.
- Canonicalize cache identities to the `aspf:sha1:<digest>` form in `_canonical_cache_identity` and add `_cache_identity_aliases`, `_cache_identity_matches`, and `_resume_variant_for_identity` helpers to accept legacy 40-hex IDs and match variants by alias.
- Add tests exercising: registry `seeded` vs `learned` policy serialization and round-trip (`tests/test_type_fingerprints.py`), suite-site signature stability under order perturbation (`tests/test_aspf.py`), and legacy-vs-canonical cache identity compatibility plus canonical-prefix expectations (`tests/test_dataflow_audit_helpers.py`).
- Update `docs/sppf_checklist.md` to mark deterministic fingerprint registry policy as done and bump `doc_revision`/section review metadata.

### Testing
- Ran the targeted test set with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_type_fingerprints.py tests/test_aspf.py tests/test_dataflow_audit_helpers.py -q` and all tests passed: `224 passed`.
- Attempted `mise exec -- python -m pytest ...` but `mise` tool bootstrap failed in this environment; tests were executed successfully using the `PYTHONPATH=src` pytest invocation instead.
- Files changed and exercised by tests include `src/gabion/analysis/type_fingerprints.py`, `src/gabion/analysis/dataflow_audit.py`, plus the added/modified tests and `docs/sppf_checklist.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efc868bec8324b06c38cece72ea28)