### PR TITLE
ASPF-typed reuse classes, rewrite witness gates, and shadow replay log

### DIFF
--- a/in/in-32.md
+++ b/in/in-32.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 6
+doc_revision: 7
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: in_32
 doc_role: in_step
@@ -523,3 +523,24 @@ No parallel phases; each phase depends on validation of the previous.
 **Sheaf gluing**: Hierarchical merge semantics for nested fork/join; local fixed-points are compatible globally.
 
 **Security-module-grade safety**: Safety properties that cannot be violated by any implementation detail or attack; enforced structurally, not configurably.
+
+
+## Milestone slices (module-aligned)
+
+To make this workstream enforceable against current modules, decompose implementation into the following slices.
+
+1. **MS1 — ASPF classed subtree reuse (`src/gabion/analysis/dataflow_audit.py`, `src/gabion/analysis/structure_reuse_classes.py`)**
+   - Invariant: subtree reuse grouping keys are derived from canonical ASPF structure classes, not ad-hoc payload hashes.
+   - Test gate: `tests/test_structure_reuse.py::test_compute_structure_reuse_detects_repeated_subtrees` asserts `aspf_structure_class` payloads exist on reuse groups.
+
+2. **MS2 — Fingerprint/rewrite witness coupling (`src/gabion/analysis/dataflow_decision_surfaces.py`, `src/gabion/analysis/dataflow_audit.py`)**
+   - Invariant: every generated rewrite plan carries explicit witness obligations plus at least one non-regression gate.
+   - Test gate: `tests/test_dataflow_decision_surfaces_module.py::test_decision_surface_summaries_and_plans_cover_edges` and `tests/test_rewrite_plan_verification.py::test_verify_rewrite_plan_enforces_witness_obligations_non_regression`.
+
+3. **MS3 — ASPF mutation log shadow replay (`src/gabion/analysis/aspf_mutation_log.py`)**
+   - Invariant: snapshot + tail replay in shadow mode must report equivalence only when replayed state matches live state under canonical comparison.
+   - Test gate: `tests/test_aspf_mutation_log.py`.
+
+4. **MS4 — Checklist synchronization (`in/in-32.md`, docs/checklist nodes)**
+   - Invariant: each slice has exactly one enforceable invariant and one test gate wired to active modules.
+   - Test gate: repository docflow + targeted pytest slice must pass before promoting the next milestone.

--- a/src/gabion/analysis/aspf_mutation_log.py
+++ b/src/gabion/analysis/aspf_mutation_log.py
@@ -1,0 +1,74 @@
+# gabion:boundary_normalization_module
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Mapping
+
+from gabion.analysis.json_types import JSONObject, JSONValue
+
+
+@dataclass(frozen=True)
+class AspfMutationRecord:
+    op_id: str
+    op_kind: str
+    payload: JSONObject
+
+
+@dataclass(frozen=True)
+class AspfMutationSnapshot:
+    seq: int
+    state: JSONObject
+
+
+@dataclass(frozen=True)
+class AspfShadowReplayResult:
+    equivalent: bool
+    expected: JSONObject
+    replayed: JSONObject
+    tail_length: int
+
+
+def apply_mutation(state: JSONObject, record: AspfMutationRecord) -> JSONObject:
+    next_state: JSONObject = dict(state)
+    if record.op_kind == "set":
+        key = str(record.payload.get("key", ""))
+        if key:
+            next_state[key] = record.payload.get("value")
+    elif record.op_kind == "delete":
+        key = str(record.payload.get("key", ""))
+        if key:
+            next_state.pop(key, None)
+    else:
+        ops = list(next_state.get("_unknown_ops") or []) if isinstance(next_state.get("_unknown_ops"), list) else []
+        ops.append(record.op_kind)
+        next_state["_unknown_ops"] = ops
+    return next_state
+
+
+def snapshot_state(state: Mapping[str, JSONValue], *, seq: int) -> AspfMutationSnapshot:
+    return AspfMutationSnapshot(seq=seq, state=dict(state))
+
+
+def replay_tail(snapshot: AspfMutationSnapshot, tail: list[AspfMutationRecord]) -> JSONObject:
+    state = dict(snapshot.state)
+    for record in tail:
+        state = apply_mutation(state, record)
+    return state
+
+
+def shadow_replay_equivalence(
+    *,
+    live_state: Mapping[str, JSONValue],
+    snapshot: AspfMutationSnapshot,
+    tail: list[AspfMutationRecord],
+) -> AspfShadowReplayResult:
+    replayed = replay_tail(snapshot, tail)
+    expected = dict(live_state)
+    equivalent = json.dumps(expected, sort_keys=True) == json.dumps(replayed, sort_keys=True)
+    return AspfShadowReplayResult(
+        equivalent=equivalent,
+        expected=expected,
+        replayed=replayed,
+        tail_length=len(tail),
+    )

--- a/src/gabion/analysis/dataflow_decision_surfaces.py
+++ b/src/gabion/analysis/dataflow_decision_surfaces.py
@@ -225,6 +225,10 @@ def compute_fingerprint_rewrite_plans(
                 "kind": "remainder_non_regression",
                 "expect": "no-new-remainder",
             },
+            {
+                "kind": "witness_obligation_non_regression",
+                "expect": "stable",
+            },
             *(
                 [
                     {
@@ -266,12 +270,31 @@ def compute_fingerprint_rewrite_plans(
                 "evidence": {
                     "provenance_id": entry.get("provenance_id"),
                     "coherence_id": coherence_id,
+                    "fingerprint_matches": candidates,
+                    "witness_obligations": [
+                        {
+                            "witness_ref": entry.get("provenance_id"),
+                            "required": True,
+                            "kind": "provenance",
+                        },
+                        {
+                            "witness_ref": coherence_id,
+                            "required": coherence_id is not None,
+                            "kind": "coherence",
+                        },
+                    ],
                 },
                 "post_expectation": post_expectation,
                 "verification": {
                     "mode": "re-audit",
                     "status": "UNVERIFIED",
                     "predicates": predicates,
+                    "non_regression_gates": [
+                        predicate.get("kind")
+                        for predicate in predicates
+                        if isinstance(predicate.get("kind"), str)
+                        and str(predicate.get("kind", "")).endswith("non_regression")
+                    ],
                 },
             }
 

--- a/src/gabion/analysis/structure_reuse_classes.py
+++ b/src/gabion/analysis/structure_reuse_classes.py
@@ -1,0 +1,57 @@
+# gabion:boundary_normalization_module
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Iterable
+
+from gabion.analysis.aspf import NodeId, structural_key_atom, structural_key_json
+from gabion.analysis.json_types import JSONObject
+
+
+@dataclass(frozen=True)
+class AspfStructureClass:
+    """Canonical ASPF-aligned structure class for subtree reuse grouping."""
+
+    kind: str
+    node_id: NodeId
+    child_fingerprints: tuple[str, ...]
+
+    def key_payload(self) -> JSONObject:
+        return {
+            "kind": self.kind,
+            "node_id": self.node_id.as_dict(),
+            "node_fingerprint": [self.node_id.fingerprint()[0], list(self.node_id.fingerprint()[1])],
+            "child_fingerprints": list(self.child_fingerprints),
+        }
+
+    def digest(self) -> str:
+        payload = self.key_payload()
+        return hashlib.sha1(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+
+def build_structure_class(
+    *,
+    kind: str,
+    value: object | None,
+    child_hashes: Iterable[str],
+) -> AspfStructureClass:
+    atom = structural_key_atom(value, source="structure_reuse_classes.value")
+    node_id = NodeId(kind=f"Reuse:{kind}", key=(atom,))
+    return AspfStructureClass(
+        kind=kind,
+        node_id=node_id,
+        child_fingerprints=tuple(child_hashes),
+    )
+
+
+def structure_class_payload(structure_class: AspfStructureClass) -> JSONObject:
+    payload = structure_class.key_payload()
+    payload["node_id"] = {
+        "kind": structure_class.node_id.kind,
+        "key": structural_key_json(structure_class.node_id.key),
+    }
+    return payload

--- a/tests/test_aspf_mutation_log.py
+++ b/tests/test_aspf_mutation_log.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from gabion.analysis.aspf_mutation_log import (
+    AspfMutationRecord,
+    shadow_replay_equivalence,
+    snapshot_state,
+)
+
+
+def test_shadow_replay_equivalence_passes_for_matching_live_state() -> None:
+    snapshot = snapshot_state({"a": 1}, seq=1)
+    tail = [AspfMutationRecord(op_id="2", op_kind="set", payload={"key": "b", "value": 2})]
+    result = shadow_replay_equivalence(live_state={"a": 1, "b": 2}, snapshot=snapshot, tail=tail)
+    assert result.equivalent is True
+    assert result.tail_length == 1
+
+
+def test_shadow_replay_equivalence_detects_divergence() -> None:
+    snapshot = snapshot_state({"a": 1}, seq=1)
+    tail = [AspfMutationRecord(op_id="2", op_kind="delete", payload={"key": "a"})]
+    result = shadow_replay_equivalence(live_state={"a": 1}, snapshot=snapshot, tail=tail)
+    assert result.equivalent is False

--- a/tests/test_dataflow_decision_surfaces_module.py
+++ b/tests/test_dataflow_decision_surfaces_module.py
@@ -95,6 +95,11 @@ def test_decision_surface_summaries_and_plans_cover_edges() -> None:
     )
     assert plans
     assert plans[0]["pre"]["exception_obligations_summary"]["UNKNOWN"] == 1
+    assert any(
+        pred.get("kind") == "witness_obligation_non_regression"
+        for pred in plans[0].get("verification", {}).get("predicates", [])
+        if isinstance(pred, dict)
+    )
 
     assert summarize_rewrite_plans([], check_deadline=_check_deadline) == []
     rewrite_summary = summarize_rewrite_plans(

--- a/tests/test_rewrite_plan_verification.py
+++ b/tests/test_rewrite_plan_verification.py
@@ -368,3 +368,43 @@ def test_verify_rewrite_plan_rejects_missing_kind_payload_fields() -> None:
     result = da.verify_rewrite_plan(plan, post_provenance=[_post_entry()])
     assert result["accepted"] is False
     assert any("missing parameters" in issue for issue in result["issues"])
+
+
+def test_verify_rewrite_plan_enforces_witness_obligations_non_regression() -> None:
+    da = _load()
+    plan = _plan(
+        pre={
+            "base_keys": ["int"],
+            "ctor_keys": [],
+            "remainder": {"base": 1, "ctor": 1},
+            "canonical_identity_contract": {"representative": "rep:a"},
+        },
+        evidence={
+            "provenance_id": "prov:a.py:f:a",
+            "witness_obligations": [{"kind": "provenance", "required": True, "witness_ref": "prov:a.py:f:a"}],
+        },
+        verification={"predicates": [{"kind": "witness_obligation_non_regression", "expect": "stable"}]},
+    )
+    accepted = da.verify_rewrite_plan(
+        plan,
+        post_provenance=[_post_entry(canonical_identity_contract={"representative": "rep:a"})],
+    )
+    assert accepted["accepted"] is True
+
+    rejected = da.verify_rewrite_plan(
+        _plan(
+            pre={
+                "base_keys": ["int"],
+                "ctor_keys": [],
+                "remainder": {"base": 1, "ctor": 1},
+                "canonical_identity_contract": {"representative": "rep:a"},
+            },
+            evidence={
+                "provenance_id": "prov:a.py:f:a",
+                "witness_obligations": [{"kind": "provenance", "required": True, "witness_ref": ""}],
+            },
+            verification={"predicates": [{"kind": "witness_obligation_non_regression", "expect": "stable"}]},
+        ),
+        post_provenance=[_post_entry(canonical_identity_contract={"representative": "rep:b"})],
+    )
+    assert rejected["accepted"] is False

--- a/tests/test_structure_reuse.py
+++ b/tests/test_structure_reuse.py
@@ -38,6 +38,7 @@ def test_compute_structure_reuse_detects_repeated_subtrees() -> None:
     bundle_entries = [
         entry for entry in reuse["reused"] if entry.get("kind") == "bundle"
     ]
+    assert all("aspf_structure_class" in entry for entry in bundle_entries)
     assert any(entry.get("value") == ["a", "b"] for entry in bundle_entries)
     suggestions = reuse.get("suggested_lemmas", [])
     assert any(


### PR DESCRIPTION
### Motivation
- Rebase subtree reuse grouping onto canonical ASPF structure classes so reuse keys are structural (not ad-hoc payload hashes) and therefore stable under canonicalization. 
- Connect fingerprint matches to rewrite plans with explicit witness obligations and non‑regression gates to make rewrite proposals verifiable and safe to apply. 
- Introduce an ASPF mutation log + snapshot/tail replay to allow shadow-mode equivalence checks against live state. 
- Decompose `in/in-32.md` into module-aligned milestone slices so each slice has one enforceable invariant and one test gate.

### Description
- Add `src/gabion/analysis/structure_reuse_classes.py` implementing `AspfStructureClass`, `build_structure_class`, and `structure_class_payload`, and wire these into `compute_structure_reuse` so reuse entries now include an `aspf_structure_class` payload. 
- Change `src/gabion/analysis/dataflow_decision_surfaces.py` to include `witness_obligations`, `fingerprint_matches`, and `non_regression_gates` in generated rewrite plans. 
- Extend `src/gabion/analysis/dataflow_audit.py` to thread plan evidence into the rewrite verification context and add a `_evaluate_witness_obligation_non_regression_predicate` evaluator that enforces required witness refs and canonical identity stability. 
- Add `src/gabion/analysis/aspf_mutation_log.py` providing `AspfMutationRecord`, snapshot/tail replay helpers, and `shadow_replay_equivalence` for canonical equivalence checks. 
- Update architecture doc `in/in-32.md` with module-aligned milestone slices (MS1–MS4) tying each slice to a single invariant and test gate. 
- Add and update unit tests to cover the new behaviors: `tests/test_structure_reuse.py`, `tests/test_structure_reuse_edges.py`, `tests/test_dataflow_decision_surfaces_module.py`, `tests/test_rewrite_plan_verification.py`, and new `tests/test_aspf_mutation_log.py`.

### Testing
- Attempted `mise exec -- python -m pytest ...` was blocked by tooling resolution / trust issues in this environment (reported by `mise`), so a local test runner step was used instead. 
- Ran the targeted pytest subset with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_structure_reuse.py tests/test_structure_reuse_edges.py tests/test_dataflow_decision_surfaces_module.py tests/test_rewrite_plan_verification.py tests/test_aspf_mutation_log.py`, and all collected tests passed (`32 passed`). 
- The committed changes include new/modified tests that exercised `compute_structure_reuse` payload emission, rewrite plan witness gating and verification, and shadow replay equivalence; the pytest run above validated these behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699effd9422083248d27a24248a0d1fe)