### PR TITLE
Add quotient-based test optimization docs (in-54 through in-58)

### DIFF
--- a/in/in-54.md
+++ b/in/in-54.md
@@ -1,0 +1,203 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: in_54
+doc_role: in_step
+doc_scope:
+  - repo
+  - tests
+  - semantics
+  - analysis
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-28.md#in_in_28
+  - in/in-53.md#in_in_53
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 48
+  glossary.md#contract: 43
+  CONTRIBUTING.md#contributing_contract: 107
+  README.md#repo_contract: 76
+  AGENTS.md#agent_obligations: 25
+  in/in-28.md#in_in_28: 8
+  in/in-53.md#in_in_53: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Reviewed POLICY_SEED.md rev48; quotient protocol remains subordinate to mechanized governance and change control."
+  glossary.md#contract: "Reviewed glossary.md rev43; scenario axes and quotient classes are treated as typed semantic carriers."
+  CONTRIBUTING.md#contributing_contract: "Reviewed CONTRIBUTING.md rev107; documentation review discipline and ratchet expectations are preserved."
+  README.md#repo_contract: "Reviewed README.md rev76; scope remains repo-local test optimization and tooling ergonomics."
+  AGENTS.md#agent_obligations: "Reviewed AGENTS.md rev25; protocol aligns with boundary normalization and decision-surface discipline."
+  in/in-28.md#in_in_28: "Reviewed in/in-28.md rev8; this step conforms to the canonical in_step template sections."
+  in/in-53.md#in_in_53: "Reviewed in/in-53.md rev1; staged promotion framing is reused for test-protocol adoption."
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_sections:
+  in_in_54: 1
+doc_section_requires:
+  in_in_54:
+    - POLICY_SEED.md#policy_seed
+    - glossary.md#contract
+    - CONTRIBUTING.md#contributing_contract
+    - README.md#repo_contract
+    - AGENTS.md#agent_obligations
+    - in/in-28.md#in_in_28
+    - in/in-53.md#in_in_53
+doc_section_reviews:
+  in_in_54:
+    POLICY_SEED.md#policy_seed:
+      dep_version: 48
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Governance constraints preserved; this step introduces no bypass of policy gates."
+    glossary.md#contract:
+      dep_version: 43
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Quotient entities are explicit semantic carriers with typed boundaries."
+    CONTRIBUTING.md#contributing_contract:
+      dep_version: 107
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Review and ratchet discipline retained for new artifacts."
+    README.md#repo_contract:
+      dep_version: 76
+      self_version_at_review: 1
+      outcome: no_change
+      note: "No change to product scope; this is execution-governance for tests."
+    AGENTS.md#agent_obligations:
+      dep_version: 25
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Boundary-first semantics and protocol reification remain intact."
+    in/in-28.md#in_in_28:
+      dep_version: 8
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Template sections and witness hooks are preserved."
+    in/in-53.md#in_in_53:
+      dep_version: 1
+      self_version_at_review: 1
+      outcome: no_change
+      note: "Promotion lifecycle framing is reused for protocol rollout."
+---
+
+<a id="in_in_54"></a>
+# in/in-54.md
+## Quotiented Scenario Algebra for Test Optimization
+
+### Purpose
+Define a canonical scenario algebra and quotient policy so test optimization is model-driven rather than name-driven.
+
+### Non-goals
+- This step does not change production semantics.
+- This step does not require immediate test renaming.
+- This step does not prescribe a single optimization goal; it defines goal-indexed profiles.
+
+---
+
+## Status
+- **This step installs:** a canonical model `S` (scenario space), `~g` (goal-indexed equivalence), and `Q_g = S/~g` (quotient classes).
+- **This step depends on:** `in-28` template protocol and staged promotion framing from `in-53`.
+- **This step unblocks:** deterministic extraction (`in-55`) and graded execution (`in-56`).
+- **Failure mode if absent:** migration and execution remain ad hoc, sparse, and non-composable.
+
+---
+
+## Definitions
+- **Scenario space (`S`):** product of declared axes (`A × C × E × T × P × ...`).
+- **Profile (`g`):** optimization goal selector (`min_suite`, `max_specificity`, etc.).
+- **Equivalence (`~g`):** profile-indexed relation over scenarios.
+- **Quotient class (`q ∈ Q_g`):** equivalence class under `~g`.
+- **Representative witness:** at least one test case attached to each required class.
+- **Axis registry:** typed declaration of each axis, value set, and normalization law.
+
+---
+
+## Face / Kit / Solver
+
+### Face (Obligations)
+- **F54-1:** Every optimization plan shall declare an explicit axis registry.
+  - **Witness hook:** `out/quotient_axis_registry.json`.
+- **F54-2:** Every profile shall declare an explicit equivalence relation.
+  - **Witness hook:** `out/quotient_profile_catalog.json`.
+- **F54-3:** Every required quotient class shall have at least one representative witness.
+  - **Witness hook:** class inventory with representative counts.
+- **F54-4:** Class identity shall be deterministic under canonical serialization.
+  - **Witness hook:** stable `class_id` checksum across repeated runs.
+
+### Kit (Existing machinery)
+- Existing in-step structure and obligations from `in/in-28.md#in_in_28`.
+- Existing staged promotion vocabulary from `in/in-53.md#in_in_53`.
+- Existing policy and contract roots in `POLICY_SEED.md#policy_seed` and `glossary.md#contract`.
+
+### Solver (Implementation plan)
+1. Define canonical axis schema and allowed value normalization.
+2. Define profile catalog (`g`) and relation declarations (`~g`).
+3. Define deterministic class identity derivation and serialization contract.
+4. Emit and validate quotient artifacts before migration work begins.
+
+---
+
+## Artifact Contract
+
+### Required artifacts
+#### `out/quotient_axis_registry.json`
+- **Producer:** extraction tooling
+- **Consumer:** migration and governance checks
+- **Schema:** axis id, value domain, normalization law, owner
+- **Determinism:** axis order and value ordering canonicalized
+
+#### `out/quotient_profile_catalog.json`
+- **Producer:** quotient policy tooling
+- **Consumer:** extraction, execution, CI policy checks
+- **Schema:** profile id, equivalence declaration, admissible erasures
+- **Determinism:** profile IDs and relation specs stable
+
+#### `out/quotient_class_schema.json`
+- **Producer:** quotient compiler
+- **Consumer:** graded execution planner
+- **Schema:** class_id, canonical tuple, required witness count
+- **Determinism:** class_id stable under replay
+
+### Provenance
+- All artifacts are policy-scoped and revisioned.
+- Dependency drift requires explicit review notes and revision updates.
+
+---
+
+## Admissibility
+- **Admissible:** adding axes/profiles with explicit normalization and class impacts.
+- **Inadmissible:** implicit axis creation via uncontrolled suffix growth.
+- **Ambiguity policy:** unresolved axis values must be surfaced as explicit unresolved states, never silently coerced.
+- **Non-explosion policy:** class growth must be justified by profile semantics, not incidental naming variance.
+
+---
+
+## Checks as Lemmas
+- **Lemma L54-1 (discharges F54-1):** axis registry is complete and schema-valid.
+- **Lemma L54-2 (discharges F54-2):** each profile has a parseable equivalence declaration.
+- **Lemma L54-3 (discharges F54-3):** each required class has at least one representative slot.
+- **Lemma L54-4 (discharges F54-4):** repeated runs produce identical class IDs.
+
+---
+
+## Success Criteria
+- [ ] Axis registry is accepted as canonical input to migration.
+- [ ] At least one profile is ready for deterministic extraction.
+- [ ] Class identity remains stable across repeated local runs.
+- [ ] Upstream/downstream document interfaces are explicit and machine-checkable.
+
+---
+
+## Failure Modes and Diagnostics
+- **FM54-1:** Axis omission → extraction cannot classify scenarios.
+- **FM54-2:** Relation ambiguity → profile disagreement across tools.
+- **FM54-3:** Unstable IDs → graded routing cannot be reproducible.
+- **FM54-4:** Silent class growth → governance ratchets lose meaning.

--- a/in/in-55.md
+++ b/in/in-55.md
@@ -1,0 +1,150 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: in_55
+doc_role: in_step
+doc_scope:
+  - repo
+  - tests
+  - tooling
+  - analysis
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-28.md#in_in_28
+  - in/in-54.md#in_in_54
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 48
+  glossary.md#contract: 43
+  CONTRIBUTING.md#contributing_contract: 107
+  README.md#repo_contract: 76
+  AGENTS.md#agent_obligations: 25
+  in/in-28.md#in_in_28: 8
+  in/in-54.md#in_in_54: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Reviewed rev48; extraction workflow remains deterministic and policy-compatible."
+  glossary.md#contract: "Reviewed rev43; corpus projection preserves typed scenario semantics."
+  CONTRIBUTING.md#contributing_contract: "Reviewed rev107; migration workflow includes explicit ratchet outputs for review."
+  README.md#repo_contract: "Reviewed rev76; extraction remains repo-internal tooling, not product surface."
+  AGENTS.md#agent_obligations: "Reviewed rev25; ambiguity is shifted left into explicit unresolved artifacts."
+  in/in-28.md#in_in_28: "Template obligations and artifact contracts are reused."
+  in/in-54.md#in_in_54: "Consumes axis/profile/class contracts as authoritative inputs."
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_sections:
+  in_in_55: 1
+---
+
+<a id="in_in_55"></a>
+# in/in-55.md
+## Corpus Projection and Quotient Migration Protocol
+
+### Purpose
+Project the existing test corpus into quotient classes and produce deterministic migration artifacts.
+
+### Non-goals
+- This step does not decide final graded execution budgets.
+- This step does not authorize ontology expansion without governance approval.
+- This step does not change runtime command semantics.
+
+---
+
+## Status
+- **This step installs:** the extraction pipeline from legacy test structures to `Q_g` classes.
+- **This step depends on:** canonical axis/profile contracts from `in-54`.
+- **This step unblocks:** graded execution routing (`in-56`) and governance ratchets (`in-57`).
+- **Failure mode if absent:** no reliable bridge exists between current suite reality and quotient plans.
+
+---
+
+## Definitions
+- **Legacy token:** pre-quotient naming/context fragment from current tests.
+- **Normalization map:** deterministic mapping from legacy token to axis value.
+- **Assignment:** `(test_id, profile_id) -> class_id | unresolved`.
+- **Basis representative:** minimal-cover class witness.
+- **Diagnostic representative:** high-discrimination witness for fault localization.
+
+---
+
+## Face / Kit / Solver
+
+### Face (Obligations)
+- **F55-1:** Every in-scope test shall receive class assignment or explicit unresolved reason.
+- **F55-2:** Normalization maps shall be deterministic and revisioned.
+- **F55-3:** Basis and diagnostic representative sets shall be emitted separately.
+- **F55-4:** Unresolved set deltas shall be tracked for ratchet gating.
+
+### Kit (Existing machinery)
+- Quotient schema and profile definitions from `in/in-54.md#in_in_54`.
+- Current suite metadata and naming surfaces.
+- Existing CI/reporting infrastructure for artifact persistence.
+
+### Solver (Implementation plan)
+1. Parse current tests and extract scenario signals.
+2. Normalize legacy signals into canonical axis values.
+3. Assign tests to classes per profile.
+4. Emit basis and diagnostic candidate sets with unresolved ledger.
+
+---
+
+## Artifact Contract
+
+### Required artifacts
+#### `out/quotient_assignment.json`
+- **Schema:** test_id, profile_id, class_id or unresolved code
+- **Determinism:** stable assignment ordering and IDs
+
+#### `out/quotient_unresolved_ambiguities.json`
+- **Schema:** unresolved test_id, ambiguity kind, required action
+- **Determinism:** reason codes and ordering stable
+
+#### `out/quotient_basis_candidates.json`
+- **Schema:** class_id -> representative tests (minimal cover)
+- **Determinism:** tie-break strategy explicit
+
+#### `out/quotient_diagnostic_candidates.json`
+- **Schema:** class_id -> discriminating tests for localization
+- **Determinism:** ranked by information gain heuristic
+
+### Provenance
+- Assignment artifacts are profile-indexed and reproducible.
+- Unresolved deltas must be reviewable across revisions.
+
+---
+
+## Admissibility
+- **Admissible:** unresolved emission with explicit reason codes.
+- **Inadmissible:** silent fallback assignment under ambiguity.
+- **Ambiguity policy:** unresolved states are first-class outputs, not hidden defaults.
+- **Non-explosion policy:** migration must reduce ad hoc suffix dimensions over time.
+
+---
+
+## Checks as Lemmas
+- **Lemma L55-1:** all in-scope tests are assigned or unresolved with reason.
+- **Lemma L55-2:** normalization map replay yields identical assignments.
+- **Lemma L55-3:** basis set covers all required classes.
+- **Lemma L55-4:** unresolved delta is non-increasing under ratchet policy (unless approved).
+
+---
+
+## Success Criteria
+- [ ] Assignment coverage reaches 100% assign-or-unresolved.
+- [ ] Basis and diagnostic sets are both generated and stable.
+- [ ] Unresolved ambiguity report is explicit and actionable.
+- [ ] Artifacts are ready inputs for graded execution.
+
+---
+
+## Failure Modes and Diagnostics
+- **FM55-1:** Parsing blind spot → tests missing from assignment domain.
+- **FM55-2:** Non-deterministic normalization → unstable class mapping.
+- **FM55-3:** Overfitted basis set → poor fault localization.
+- **FM55-4:** Unresolved debt growth → governance ratchets block promotion.

--- a/in/in-56.md
+++ b/in/in-56.md
@@ -1,0 +1,149 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: in_56
+doc_role: in_step
+doc_scope:
+  - repo
+  - tests
+  - execution
+  - tooling
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-28.md#in_in_28
+  - in/in-54.md#in_in_54
+  - in/in-55.md#in_in_55
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 48
+  glossary.md#contract: 43
+  CONTRIBUTING.md#contributing_contract: 107
+  README.md#repo_contract: 76
+  AGENTS.md#agent_obligations: 25
+  in/in-28.md#in_in_28: 8
+  in/in-54.md#in_in_54: 1
+  in/in-55.md#in_in_55: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Reviewed rev48; graded execution is deterministic and policy-gated."
+  glossary.md#contract: "Reviewed rev43; execution grades are modeled as explicit semantic decision surfaces."
+  CONTRIBUTING.md#contributing_contract: "Reviewed rev107; execution routing outputs are reviewable and ratchet-friendly."
+  README.md#repo_contract: "Reviewed rev76; graded execution is tooling behavior, not user-facing semantics expansion."
+  AGENTS.md#agent_obligations: "Reviewed rev25; dual-sensor discipline aligns with coarse-to-fine escalation."
+  in/in-28.md#in_in_28: "Template obligations and section ordering are preserved."
+  in/in-54.md#in_in_54: "Consumes quotient classes and profile declarations."
+  in/in-55.md#in_in_55: "Consumes assignment and representative artifacts."
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_sections:
+  in_in_56: 1
+---
+
+<a id="in_in_56"></a>
+# in/in-56.md
+## Graded Execution Strategy for Quotient Classes
+
+### Purpose
+Define deterministic coarse-to-fine test execution over quotient classes for fast detection and precise triangulation.
+
+### Non-goals
+- This step does not redefine quotient equivalence.
+- This step does not replace local debugging workflows.
+- This step does not waive governance or ratchet constraints.
+
+---
+
+## Status
+- **This step installs:** grade semantics (`G0`, `G1`, `G2`) and trigger routing contracts.
+- **This step depends on:** class assignments and representative sets from `in-55`.
+- **This step unblocks:** governance metrics and promotion decisions (`in-57`, `in-58`).
+- **Failure mode if absent:** either too many tests run always or failures lack localization resolution.
+
+---
+
+## Definitions
+- **G0 (sentinel):** minimal broad tests for early failure detection.
+- **G1 (partition):** class-localizing tests run after G0 failure.
+- **G2 (triangulation):** high-specificity tests for invariant-level diagnosis.
+- **Failure signature:** normalized summary of failing G0/G1 outcomes.
+- **Route plan:** deterministic mapping from signature to follow-up test subset.
+
+---
+
+## Face / Kit / Solver
+
+### Face (Obligations)
+- **F56-1:** Grade boundaries and trigger criteria shall be explicit and deterministic.
+- **F56-2:** Routing from signature to follow-up set shall be reproducible.
+- **F56-3:** Fan-out shall be bounded by explicit budget policy.
+- **F56-4:** Routing telemetry shall be captured for refinement feedback.
+
+### Kit (Existing machinery)
+- Quotient class contracts from `in-54`.
+- Assignment and representative outputs from `in-55`.
+- Existing CI execution surfaces and reporting channels.
+
+### Solver (Implementation plan)
+1. Construct sentinel `G0` basis from basis candidates.
+2. Define signature normalization and routing map to `G1`/`G2`.
+3. Apply budget constraints with deterministic ordering.
+4. Persist telemetry for precision/recall refinement.
+
+---
+
+## Artifact Contract
+
+### Required artifacts
+#### `out/graded_trigger_map.json`
+- **Schema:** signature pattern, candidate classes, follow-up test IDs
+- **Determinism:** route ordering and tie-break rules fixed
+
+#### `out/graded_execution_budget_profile.json`
+- **Schema:** per-profile fan-out limits, timeout budgets, escalation rules
+- **Determinism:** profile versioned and hash-addressable
+
+#### `out/graded_route_telemetry.json`
+- **Schema:** observed signatures, selected routes, localization outcomes
+- **Determinism:** event format stable, timestamps out-of-band for comparisons
+
+### Provenance
+- Route artifacts must be replayable from the same assignment inputs.
+- Telemetry is used to refine mappings, not to mutate policy silently.
+
+---
+
+## Admissibility
+- **Admissible:** deterministic escalation under budget constraints.
+- **Inadmissible:** non-deterministic routing based on ambient ordering side effects.
+- **Ambiguity policy:** ambiguous signatures route to explicit ambiguity bundles.
+- **Non-explosion policy:** escalation must prioritize information gain and bounded cost.
+
+---
+
+## Checks as Lemmas
+- **Lemma L56-1:** identical signatures under same profile produce identical routes.
+- **Lemma L56-2:** route fan-out never exceeds configured profile budget.
+- **Lemma L56-3:** every routed follow-up test belongs to mapped candidate classes.
+- **Lemma L56-4:** telemetry records are schema-valid and replay-comparable.
+
+---
+
+## Success Criteria
+- [ ] G0 detects broad regressions with reduced baseline runtime.
+- [ ] G1/G2 materially improve localization precision.
+- [ ] Route decisions are deterministic under replay.
+- [ ] Telemetry is ready input for governance ratchets.
+
+---
+
+## Failure Modes and Diagnostics
+- **FM56-1:** Over-broad G0 → noisy escalation.
+- **FM56-2:** Under-powered G0 → delayed detection.
+- **FM56-3:** Unbounded fan-out → runtime regression.
+- **FM56-4:** Poor signature design → weak triangulation quality.

--- a/in/in-57.md
+++ b/in/in-57.md
@@ -1,0 +1,151 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: in_57
+doc_role: in_step
+doc_scope:
+  - repo
+  - governance
+  - tests
+  - ci
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-28.md#in_in_28
+  - in/in-54.md#in_in_54
+  - in/in-55.md#in_in_55
+  - in/in-56.md#in_in_56
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 48
+  glossary.md#contract: 43
+  CONTRIBUTING.md#contributing_contract: 107
+  README.md#repo_contract: 76
+  AGENTS.md#agent_obligations: 25
+  in/in-28.md#in_in_28: 8
+  in/in-54.md#in_in_54: 1
+  in/in-55.md#in_in_55: 1
+  in/in-56.md#in_in_56: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Reviewed rev48; governance checks remain mechanized and non-bypassable."
+  glossary.md#contract: "Reviewed rev43; ontology and ratchets preserve typed semantic distinctions."
+  CONTRIBUTING.md#contributing_contract: "Reviewed rev107; ratchet and review workflows align with contributor contract."
+  README.md#repo_contract: "Reviewed rev76; governance scope remains repository-internal."
+  AGENTS.md#agent_obligations: "Reviewed rev25; explicit policy checks and surfaced violations are mandatory."
+  in/in-28.md#in_in_28: "Template constraints and witness hooks retained."
+  in/in-54.md#in_in_54: "Consumes axis/profile/class policy surfaces."
+  in/in-55.md#in_in_55: "Consumes assignment/unresolved deltas for ratchets."
+  in/in-56.md#in_in_56: "Consumes route telemetry for quality governance."
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_sections:
+  in_in_57: 1
+---
+
+<a id="in_in_57"></a>
+# in/in-57.md
+## Governance Ratchets for Quotient and Graded Execution
+
+### Purpose
+Install CI-governed ratchets that preserve quotient integrity, routing quality, and drift resistance.
+
+### Non-goals
+- This step does not prescribe one permanent ontology version.
+- This step does not block exploratory local workflows outside policy gates.
+- This step does not redefine promotion lifecycle semantics.
+
+---
+
+## Status
+- **This step installs:** ontology, assignment, and routing ratchets with explicit violation reporting.
+- **This step depends on:** artifacts from `in-54`, `in-55`, and `in-56`.
+- **This step unblocks:** promotion decisions that are evidence-backed (`in-58`).
+- **Failure mode if absent:** protocol quality drifts silently and optimization gains decay.
+
+---
+
+## Definitions
+- **Ontology drift:** net-new uncontrolled axis/token/class vocabulary growth.
+- **Assignment debt:** unresolved mappings not covered by approved exemptions.
+- **Routing quality floor:** minimum precision/latency envelope for graded routes.
+- **Ratchet delta:** structured report of net-new debt vs baseline.
+
+---
+
+## Face / Kit / Solver
+
+### Face (Obligations)
+- **F57-1:** Ontology expansion shall require explicit declaration and review note.
+- **F57-2:** Assignment debt shall not increase without approved exception.
+- **F57-3:** Routing quality shall not regress below profile floors.
+- **F57-4:** All violations shall be emitted with deterministic reason codes.
+
+### Kit (Existing machinery)
+- Policy and clause-index governance model.
+- Assignment and routing telemetry artifacts.
+- Existing CI reporting and ratchet mechanisms.
+
+### Solver (Implementation plan)
+1. Define baseline snapshots for ontology, assignment debt, and routing quality.
+2. Compute ratchet deltas on each run.
+3. Enforce fail/warn policy by profile and branch context.
+4. Persist violation payloads and remediation hints.
+
+---
+
+## Artifact Contract
+
+### Required artifacts
+#### `out/quotient_governance_report.json`
+- **Schema:** profile summary, debt metrics, quality metrics, decision
+- **Determinism:** metric naming and ordering stable
+
+#### `out/quotient_ratchet_delta.json`
+- **Schema:** baseline vs current deltas with reason codes
+- **Determinism:** baseline identifier pinned
+
+#### `out/quotient_policy_violations.json`
+- **Schema:** violation id, clause, severity, remediation path
+- **Determinism:** clause IDs and reason codes stable
+
+### Provenance
+- Baselines are explicit and revision-addressed.
+- Violations are surfaced; no silent suppression in strict profiles.
+
+---
+
+## Admissibility
+- **Admissible:** approved exceptions with owner, reason, expiry.
+- **Inadmissible:** net-new debt without declared exception path.
+- **Ambiguity policy:** policy uncertainty is emitted as explicit governance ambiguity.
+- **Non-explosion policy:** ratchets prioritize debt reduction and class stability.
+
+---
+
+## Checks as Lemmas
+- **Lemma L57-1:** ontology diff is empty or explicitly approved.
+- **Lemma L57-2:** unresolved assignment debt is non-increasing.
+- **Lemma L57-3:** routing metrics satisfy profile floors.
+- **Lemma L57-4:** all violations map to canonical clause/reason identifiers.
+
+---
+
+## Success Criteria
+- [ ] Drift is visible and bounded by ratchets.
+- [ ] New classes/tokens are intentional and reviewable.
+- [ ] Graded execution quality remains above profile floors.
+- [ ] Violation payloads are actionable in CI and local repro loops.
+
+---
+
+## Failure Modes and Diagnostics
+- **FM57-1:** Ontology sprawl → class identity becomes unstable.
+- **FM57-2:** Debt creep → unresolved mapping backlog blocks promotion.
+- **FM57-3:** Quality erosion → escalations become expensive and uninformative.
+- **FM57-4:** Opaque violations → contributors cannot remediate quickly.

--- a/in/in-58.md
+++ b/in/in-58.md
@@ -1,0 +1,157 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: in_58
+doc_role: in_step
+doc_scope:
+  - repo
+  - governance
+  - tests
+  - release
+doc_authority: normative
+doc_owner: maintainer
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+  - CONTRIBUTING.md#contributing_contract
+  - README.md#repo_contract
+  - AGENTS.md#agent_obligations
+  - in/in-28.md#in_in_28
+  - in/in-53.md#in_in_53
+  - in/in-54.md#in_in_54
+  - in/in-55.md#in_in_55
+  - in/in-56.md#in_in_56
+  - in/in-57.md#in_in_57
+doc_reviewed_as_of:
+  POLICY_SEED.md#policy_seed: 48
+  glossary.md#contract: 43
+  CONTRIBUTING.md#contributing_contract: 107
+  README.md#repo_contract: 76
+  AGENTS.md#agent_obligations: 25
+  in/in-28.md#in_in_28: 8
+  in/in-53.md#in_in_53: 1
+  in/in-54.md#in_in_54: 1
+  in/in-55.md#in_in_55: 1
+  in/in-56.md#in_in_56: 1
+  in/in-57.md#in_in_57: 1
+doc_review_notes:
+  POLICY_SEED.md#policy_seed: "Reviewed rev48; promotion gating remains explicit, deterministic, and policy-controlled."
+  glossary.md#contract: "Reviewed rev43; convergence criteria preserve semantic typing and commutation obligations."
+  CONTRIBUTING.md#contributing_contract: "Reviewed rev107; adoption checklist and rollback protocol are reviewer-visible."
+  README.md#repo_contract: "Reviewed rev76; lifecycle applies to test tooling protocol, not external product contract."
+  AGENTS.md#agent_obligations: "Reviewed rev25; violation surfacing and conservative refusal posture preserved."
+  in/in-28.md#in_in_28: "Template structure and witness hooks retained for final convergence step."
+  in/in-53.md#in_in_53: "Promotion/demotion lifecycle reused and specialized for quotient+graded protocol."
+  in/in-54.md#in_in_54: "Convergence depends on stable class model and profile definitions."
+  in/in-55.md#in_in_55: "Convergence depends on assignment completeness and debt control."
+  in/in-56.md#in_in_56: "Convergence depends on deterministic graded routing quality."
+  in/in-57.md#in_in_57: "Convergence depends on green governance ratchets."
+doc_change_protocol: POLICY_SEED.md#change_protocol
+doc_erasure:
+  - formatting
+  - typos
+doc_sections:
+  in_in_58: 1
+---
+
+<a id="in_in_58"></a>
+# in/in-58.md
+## Convergence and Promotion Lifecycle for Quotient + Graded Test Optimization
+
+### Purpose
+Define adoption, promotion, demotion, and recovery semantics for the full quotient and graded execution protocol chain.
+
+### Non-goals
+- This step does not replace underlying policy seed governance.
+- This step does not force immediate strict-profile adoption.
+- This step does not remove the need for local diagnostic autonomy.
+
+---
+
+## Status
+- **This step installs:** lifecycle gates for activating and maintaining the protocol.
+- **This step depends on:** `in-54` through `in-57` artifact and ratchet readiness.
+- **This step unblocks:** stable long-term operation with explicit rollback semantics.
+- **Failure mode if absent:** protocol adoption is ad hoc and regressions lack controlled remediation.
+
+---
+
+## Definitions
+- **Adoption profile:** operational mode (`observe`, `contain`, `enforce`).
+- **Promotion gate:** required readiness predicate bundle for profile advancement.
+- **Demotion trigger:** deterministic condition requiring profile rollback.
+- **Recovery bundle:** minimal artifact/actions required to clear demotion trigger.
+
+---
+
+## Face / Kit / Solver
+
+### Face (Obligations)
+- **F58-1:** Promotion requires green checks from model, migration, execution, and governance layers.
+- **F58-2:** Demotion triggers shall be explicit, deterministic, and auditable.
+- **F58-3:** Recovery procedures shall preserve artifact continuity and provenance.
+- **F58-4:** Lifecycle decisions shall be encoded in machine-readable reports.
+
+### Kit (Existing machinery)
+- Staged lifecycle framing from `in/in-53.md#in_in_53`.
+- Quotient model and migration outputs (`in-54`, `in-55`).
+- Graded execution and governance outputs (`in-56`, `in-57`).
+
+### Solver (Implementation plan)
+1. Define readiness predicates per adoption profile.
+2. Evaluate promotion gates from ratchet and telemetry artifacts.
+3. Emit promotion/demotion decisions with reason codes.
+4. On demotion, execute recovery bundle and re-evaluate deterministically.
+
+---
+
+## Artifact Contract
+
+### Required artifacts
+#### `out/quotient_protocol_readiness.json`
+- **Schema:** profile, gate predicates, pass/fail details
+- **Determinism:** predicate ordering and IDs stable
+
+#### `out/quotient_promotion_decision.json`
+- **Schema:** decision, target profile, rationale codes, timestamp metadata
+- **Determinism:** rationale code set canonical
+
+#### `out/quotient_demotion_incidents.json`
+- **Schema:** trigger id, impacted profile, recovery requirements, closure status
+- **Determinism:** trigger taxonomy fixed
+
+### Provenance
+- Decisions are reproducible from captured artifacts.
+- Recovery actions are linked to the exact trigger and closure evidence.
+
+---
+
+## Admissibility
+- **Admissible:** staged promotion when all required gates are satisfied.
+- **Inadmissible:** forced promotion with unresolved governance or quality failures.
+- **Ambiguity policy:** lifecycle uncertainty is emitted as explicit undecided state, not implicit success.
+- **Non-explosion policy:** profile progression is monotone under green gates; exceptions are explicit and bounded.
+
+---
+
+## Checks as Lemmas
+- **Lemma L58-1:** promotion decisions are derivable from readiness artifacts alone.
+- **Lemma L58-2:** demotion triggers are complete and non-overlapping.
+- **Lemma L58-3:** recovery completion clears the originating trigger deterministically.
+- **Lemma L58-4:** lifecycle reports preserve provenance links to `in-54..57` artifacts.
+
+---
+
+## Success Criteria
+- [ ] Protocol can run in observe mode with complete artifact chain.
+- [ ] Promotion to stricter profiles is deterministic and auditable.
+- [ ] Demotions are actionable with bounded recovery paths.
+- [ ] Long-lived operation maintains drift resistance and localization quality.
+
+---
+
+## Failure Modes and Diagnostics
+- **FM58-1:** Gate ambiguity → conflicting promotion outcomes.
+- **FM58-2:** Hidden demotion trigger → silent reliability decay.
+- **FM58-3:** Recovery incompleteness → oscillating profile state.
+- **FM58-4:** Provenance gaps → unverifiable lifecycle decisions.


### PR DESCRIPTION
### Motivation
- Define a canonical, profile-indexed scenario algebra so test optimization is model-driven rather than name-driven.
- Provide a deterministic pipeline to project the existing test corpus into quotient classes for repeatable migration and execution decisions.
- Specify graded execution, governance ratchets, and a promotion lifecycle to ensure reliable adoption and drift control.

### Description
- Add five new in-step documents: `in/in-54.md` (scenario algebra and quotient policy), `in/in-55.md` (corpus projection and migration), `in/in-56.md` (graded execution strategy), `in/in-57.md` (governance ratchets), and `in/in-58.md` (convergence and promotion lifecycle). 
- Each document declares artifact contracts and required outputs such as `out/quotient_axis_registry.json`, `out/quotient_assignment.json`, `out/graded_trigger_map.json`, `out/quotient_governance_report.json`, and `out/quotient_protocol_readiness.json` to enable deterministic tooling and CI checks.
- Define obligations, admissibility rules, success criteria, and failure modes for extraction, routing, ratchets, and lifecycle decisions to make migration and execution auditable and machine-checkable.
- Reuse existing templates and governance roots (`in-28`, `in-53`, `POLICY_SEED.md`, `AGENTS.md`, etc.) and ensure determinism, provenance, and explicit unresolved reporting are first-class outputs.

### Testing
- No code-level unit tests were required because these are documentation/specification artifacts; validation focused on doc syntax and schema expectations.
- Ran repository doc/markdown validation and link/schema consistency checks against referenced artifacts and guidelines, and those checks passed. 
- Reviewed dependency references to `POLICY_SEED.md`, `glossary.md`, `CONTRIBUTING.md`, `README.md`, and `AGENTS.md` as recorded in each document's review metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7b3a812483249eb2a6b6ca1b1b0a)