### PR TITLE
Refactor ASPF equivalence payload building to stream baseline traces

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Mapping, Sequence, cast
+from typing import Iterable, Iterator, Mapping, Sequence, cast
 
 from gabion.json_types import JSONObject, JSONValue
 from gabion.order_contract import sort_once
@@ -396,21 +396,25 @@ def build_trace_payload(state: AspfExecutionTraceState) -> JSONObject:
 def build_equivalence_payload(
     *,
     state: AspfExecutionTraceState,
-    baseline_traces: Sequence[Mapping[str, object]],
+    baseline_traces: Iterable[Mapping[str, object]],
 ) -> JSONObject:
-    baseline_candidates: dict[str, list[str]] = {}
+    baseline_candidates: dict[str, set[str]] = {}
+    known_witnesses = _witnesses_by_representative_pair(state=state)
     for payload in baseline_traces:
-        _merge_candidates(
+        _merge_candidate_sets(
             destination=baseline_candidates,
             candidates=_surface_candidates_from_trace_payload(payload),
         )
+        _merge_known_witnesses(
+            destination=known_witnesses,
+            payload=payload,
+        )
     table: list[JSONObject] = []
-    known_witnesses = _all_known_witnesses(state=state, baseline_traces=baseline_traces)
     for surface in state.controls.aspf_semantic_surface:
         current_representative = state.surface_representatives.get(surface)
         candidates = tuple(
             sort_once(
-                set(baseline_candidates.get(surface, [])),
+                baseline_candidates.get(surface, set()),
                 source=f"aspf_execution_fibration.build_equivalence_payload.{surface}.candidates",
             )
         )
@@ -427,7 +431,7 @@ def build_equivalence_payload(
         else:
             baseline_representative = current_representative or ""
         witness = _find_witness(
-            witnesses=known_witnesses,
+            witness_index=known_witnesses,
             baseline_representative=baseline_representative,
             current_representative=current_representative or "",
         )
@@ -503,11 +507,10 @@ def finalize_execution_trace(
         if state.controls.aspf_equivalence_against
         else (state.controls.aspf_import_trace + state.controls.aspf_import_state)
     )
-    baseline_traces = [load_trace_payload(path) for path in baseline_paths]
     trace_payload = build_trace_payload(state)
     equivalence_payload = build_equivalence_payload(
         state=state,
-        baseline_traces=baseline_traces,
+        baseline_traces=_iter_baseline_trace_payloads(baseline_paths),
     )
     opportunities_payload = build_opportunities_payload(
         state=state,
@@ -877,46 +880,62 @@ def _surface_candidates_from_trace_payload(
     return candidates
 
 
-def _merge_candidates(
+def _merge_candidate_sets(
     *,
-    destination: dict[str, list[str]],
+    destination: dict[str, set[str]],
     candidates: Mapping[str, list[str]],
 ) -> None:
     for surface in candidates:
-        existing = destination.setdefault(surface, [])
-        existing.extend(candidates[surface])
+        existing = destination.setdefault(surface, set())
+        existing.update(candidates[surface])
 
 
-def _all_known_witnesses(
+def _witnesses_by_representative_pair(
     *,
     state: AspfExecutionTraceState,
-    baseline_traces: Sequence[Mapping[str, object]],
-) -> list[AspfTwoCellWitness]:
-    baseline_witnesses = [
-        cast(AspfTwoCellWitness, parse_2cell_witness(entry))
-        for payload in baseline_traces
-        for entry in payload.get("two_cell_witnesses", [])
-    ]
-    return [*state.two_cell_witnesses, *baseline_witnesses]
+ ) -> dict[tuple[str, str], AspfTwoCellWitness]:
+    witnesses: dict[tuple[str, str], AspfTwoCellWitness] = {}
+    for witness in state.two_cell_witnesses:
+        _store_witness_by_pair(destination=witnesses, witness=witness)
+    return witnesses
+
+
+def _merge_known_witnesses(
+    *,
+    destination: dict[tuple[str, str], AspfTwoCellWitness],
+    payload: Mapping[str, object],
+) -> None:
+    for entry in payload.get("two_cell_witnesses", []):
+        witness = cast(AspfTwoCellWitness, parse_2cell_witness(entry))
+        _store_witness_by_pair(destination=destination, witness=witness)
+
+
+def _store_witness_by_pair(
+    *,
+    destination: dict[tuple[str, str], AspfTwoCellWitness],
+    witness: AspfTwoCellWitness,
+) -> None:
+    baseline = witness.left.representative
+    current = witness.right.representative
+    destination.setdefault((baseline, current), witness)
+    destination.setdefault((current, baseline), witness)
 
 
 def _find_witness(
     *,
-    witnesses: Sequence[AspfTwoCellWitness],
+    witness_index: Mapping[tuple[str, str], AspfTwoCellWitness],
     baseline_representative: str,
     current_representative: str,
 ) -> AspfTwoCellWitness | None:
-    return next(
-        (
-            witness
-            for witness in witnesses
-            if witness.links(
-                baseline_representative=baseline_representative,
-                current_representative=current_representative,
-            )
-        ),
+    return witness_index.get(
+        (baseline_representative, current_representative),
         None,
     )
+
+
+def _iter_baseline_trace_payloads(paths: Iterable[Path]) -> Iterator[JSONObject]:
+    for path in paths:
+        yield load_trace_payload(path)
 
 
 def _materialize_load_opportunities(state: AspfExecutionTraceState) -> list[JSONObject]:
@@ -1010,4 +1029,3 @@ def _fungible_execution_opportunities(
             }
         )
     return opportunities
-


### PR DESCRIPTION
### Motivation
- Reduce peak memory usage and enable incremental processing when comparing against large sets of baseline traces by avoiding eager list materialization.
- Make baseline ingestion incremental so trace payloads can be loaded path-by-path and merged on the fly.
- Improve witness lookup performance by switching from repeated list scans to an indexed accumulator keyed by representative pairs.

### Description
- Change `build_equivalence_payload` signature to accept `Iterable[Mapping[str, object]]` instead of a prebuilt `Sequence`, and update typing imports accordingly.
- Replace per-surface candidate lists with `set`-backed candidate aggregation and add `_merge_candidate_sets` to merge incrementally.
- Introduce a representative-pair witness index via `_witnesses_by_representative_pair`, `_merge_known_witnesses`, and `_store_witness_by_pair`, and switch `_find_witness` to lookup from this index.
- Replace eager baseline loading in `finalize_execution_trace` with a streaming generator `_iter_baseline_trace_payloads(paths)` that yields `load_trace_payload(path)` one-by-one.

### Testing
- `mise exec -- python -m pytest tests/test_aspf_execution_fibration.py` failed due to the local `mise.toml` being untrusted in the environment, not due to code errors.
- `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf_execution_fibration.py` ran the suite and all tests passed: 7 passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a123e072d88324b3d10975298c695d)