### PR TITLE
Add Protocol-based ASPF traversal API and visitor emitters

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -36,6 +36,13 @@ from .aspf_morphisms import (
     DomainToAspfCofibration,
     DomainToAspfCofibrationEntry,
 )
+from .aspf_visitors import (
+    OpportunityPayloadEmitter,
+    StatePayloadEmitter,
+    TracePayloadEmitter,
+    replay_equivalence_payload_to_visitor,
+    replay_trace_payload_to_visitor,
+)
 
 DEFAULT_PHASE1_SEMANTIC_SURFACES: tuple[str, ...] = (
     "groups_by_path",
@@ -334,7 +341,19 @@ def register_semantic_surface(
 
 
 def build_trace_payload(state: AspfExecutionTraceState) -> JSONObject:
-    one_cells_payload: list[JSONValue] = []
+    replay_payload: JSONObject = {
+        "one_cells": [],
+        "two_cell_witnesses": [witness.as_dict() for witness in state.two_cell_witnesses],
+        "cofibration_witnesses": [carrier.as_dict() for carrier in state.cofibrations],
+        "surface_representatives": {
+            surface: state.surface_representatives[surface]
+            for surface in sort_once(
+                state.surface_representatives,
+                source="aspf_execution_fibration.build_trace_payload.surface_representatives",
+            )
+        },
+    }
+    one_cells_payload = cast(list[JSONObject], replay_payload["one_cells"])
     for index, cell in enumerate(state.one_cells):
         one_cell_payload = cell.as_dict()
         metadata = (
@@ -346,6 +365,9 @@ def build_trace_payload(state: AspfExecutionTraceState) -> JSONObject:
         one_cell_payload["surface"] = str(metadata.get("surface", ""))
         one_cell_payload["metadata"] = _as_json_value(metadata.get("metadata", {}))
         one_cells_payload.append(one_cell_payload)
+
+    emitter = TracePayloadEmitter()
+    replay_trace_payload_to_visitor(trace_payload=replay_payload, visitor=emitter)
     return {
         "format_version": _TRACE_FORMAT_VERSION,
         "trace_id": state.trace_id,
@@ -378,16 +400,10 @@ def build_trace_payload(state: AspfExecutionTraceState) -> JSONObject:
             ),
             "aspf_semantic_surface": list(state.controls.aspf_semantic_surface),
         },
-        "one_cells": one_cells_payload,
-        "two_cell_witnesses": [witness.as_dict() for witness in state.two_cell_witnesses],
-        "cofibration_witnesses": [carrier.as_dict() for carrier in state.cofibrations],
-        "surface_representatives": {
-            surface: state.surface_representatives[surface]
-            for surface in sort_once(
-                state.surface_representatives,
-                source="aspf_execution_fibration.build_trace_payload.surface_representatives",
-            )
-        },
+        "one_cells": emitter.one_cells,
+        "two_cell_witnesses": emitter.two_cell_witnesses,
+        "cofibration_witnesses": emitter.cofibration_witnesses,
+        "surface_representatives": emitter.surface_representatives,
         "imported_trace_count": len(state.imported_trace_payloads),
         "delta_record_count": len(state.delta_records),
     }
@@ -463,14 +479,16 @@ def build_opportunities_payload(
     state: AspfExecutionTraceState,
     equivalence_payload: Mapping[str, object],
 ) -> JSONObject:
-    opportunities: list[JSONObject] = []
-    opportunities.extend(_materialize_load_opportunities(state))
-    opportunities.extend(_reusable_artifact_opportunities(state))
-    opportunities.extend(_fungible_execution_opportunities(equivalence_payload))
-    opportunities = sorted(
-        opportunities,
-        key=lambda item: str(item.get("opportunity_id", "")),
+    emitter = OpportunityPayloadEmitter()
+    replay_trace_payload_to_visitor(
+        trace_payload=build_trace_payload(state),
+        visitor=emitter,
     )
+    replay_equivalence_payload_to_visitor(
+        equivalence_payload=equivalence_payload,
+        visitor=emitter,
+    )
+    opportunities = emitter.build_rows()
     return {
         "format_version": _OPPORTUNITY_FORMAT_VERSION,
         "trace_id": state.trace_id,
@@ -635,6 +653,10 @@ def _build_state_payload(
     resume_projection: Mapping[str, object],
     delta_ledger_payload: Mapping[str, object],
 ) -> JSONObject:
+    emitter = StatePayloadEmitter()
+    emitter.set_trace_payload(trace_payload)
+    emitter.set_equivalence_payload(equivalence_payload)
+    emitter.set_opportunities_payload(opportunities_payload)
     session_id, step_id = _session_and_step_from_path(state_path)
     state_material = stable_compact_text(
         {
@@ -668,15 +690,9 @@ def _build_state_payload(
             if resume_compatibility_status is not None
             else None
         ),
-        "trace": {str(key): _as_json_value(trace_payload[key]) for key in trace_payload},
-        "equivalence": {
-            str(key): _as_json_value(equivalence_payload[key])
-            for key in equivalence_payload
-        },
-        "opportunities": {
-            str(key): _as_json_value(opportunities_payload[key])
-            for key in opportunities_payload
-        },
+        "trace": emitter.trace,
+        "equivalence": emitter.equivalence,
+        "opportunities": emitter.opportunities,
         "semantic_surfaces": {
             str(key): _as_json_value(semantic_surface_payloads[key])
             for key in semantic_surface_payloads
@@ -1010,4 +1026,3 @@ def _fungible_execution_opportunities(
             }
         )
     return opportunities
-

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from typing import Mapping, Protocol, cast
+
+from gabion.analysis.aspf import Alt, Forest, Node
+from gabion.json_types import JSONObject, JSONValue
+from gabion.order_contract import sort_once
+
+
+class AspfTraversalVisitor(Protocol):
+    """Semantic-core visitor contract for ASPF traversal dispatch.
+
+    Boundary normalization is expected to happen at ingress parsers (for example,
+    ``load_trace_payload``). Traversal helpers below assume normalized payloads and
+    perform deterministic visitor dispatch for semantic-core consumers.
+    """
+
+    def on_forest_node(self, *, node: Node) -> None: ...
+
+    def on_forest_alt(self, *, alt: Alt) -> None: ...
+
+    def on_trace_one_cell(
+        self,
+        *,
+        index: int,
+        one_cell: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None: ...
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None: ...
+
+
+@dataclass
+class NullAspfTraversalVisitor:
+    def on_forest_node(self, *, node: Node) -> None:
+        return None
+
+    def on_forest_alt(self, *, alt: Alt) -> None:
+        return None
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        return None
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None:
+        return None
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None:
+        return None
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        return None
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None:
+        return None
+
+
+def traverse_forest_to_visitor(*, forest: Forest, visitor: AspfTraversalVisitor) -> None:
+    nodes = sort_once(
+        forest.nodes.values(),
+        key=lambda node: node.node_id.sort_key(),
+        source="aspf_visitors.traverse_forest_to_visitor.nodes",
+    )
+    for node in nodes:
+        visitor.on_forest_node(node=node)
+    alts = sort_once(
+        forest.alts,
+        key=lambda alt: alt.sort_key(),
+        source="aspf_visitors.traverse_forest_to_visitor.alts",
+    )
+    for alt in alts:
+        visitor.on_forest_alt(alt=alt)
+
+
+def replay_trace_payload_to_visitor(
+    *,
+    trace_payload: Mapping[str, object],
+    visitor: AspfTraversalVisitor,
+) -> None:
+    one_cells = cast(list[object], trace_payload.get("one_cells", []))
+    for index, raw_one_cell in enumerate(one_cells):
+        if isinstance(raw_one_cell, Mapping):
+            visitor.on_trace_one_cell(index=index, one_cell=raw_one_cell)
+
+    two_cell_witnesses = cast(list[object], trace_payload.get("two_cell_witnesses", []))
+    for index, raw_witness in enumerate(two_cell_witnesses):
+        if isinstance(raw_witness, Mapping):
+            visitor.on_trace_two_cell_witness(index=index, witness=raw_witness)
+
+    cofibrations = cast(list[object], trace_payload.get("cofibration_witnesses", []))
+    for index, raw_cofibration in enumerate(cofibrations):
+        if isinstance(raw_cofibration, Mapping):
+            visitor.on_trace_cofibration(index=index, cofibration=raw_cofibration)
+
+    surface_payload = trace_payload.get("surface_representatives", {})
+    if isinstance(surface_payload, Mapping):
+        ordered_surfaces = sort_once(
+            [str(surface) for surface in surface_payload],
+            source="aspf_visitors.replay_trace_payload_to_visitor.surface_representatives",
+        )
+        for surface in ordered_surfaces:
+            representative = surface_payload.get(surface)
+            if isinstance(representative, str):
+                visitor.on_trace_surface_representative(
+                    surface=surface,
+                    representative=representative,
+                )
+
+
+def replay_equivalence_payload_to_visitor(
+    *,
+    equivalence_payload: Mapping[str, object],
+    visitor: AspfTraversalVisitor,
+) -> None:
+    rows = equivalence_payload.get("surface_table", [])
+    if not isinstance(rows, list):
+        return
+    for index, raw_row in enumerate(rows):
+        if isinstance(raw_row, Mapping):
+            visitor.on_equivalence_surface_row(index=index, row=raw_row)
+
+
+@dataclass
+class TracePayloadEmitter(NullAspfTraversalVisitor):
+    one_cells: list[JSONValue] = field(default_factory=list)
+    two_cell_witnesses: list[JSONValue] = field(default_factory=list)
+    cofibration_witnesses: list[JSONValue] = field(default_factory=list)
+    surface_representatives: dict[str, str] = field(default_factory=dict)
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        self.one_cells.append({str(key): cast(JSONValue, one_cell[key]) for key in one_cell})
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None:
+        self.two_cell_witnesses.append(
+            {str(key): cast(JSONValue, witness[key]) for key in witness}
+        )
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None:
+        self.cofibration_witnesses.append(
+            {str(key): cast(JSONValue, cofibration[key]) for key in cofibration}
+        )
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        self.surface_representatives[str(surface)] = str(representative)
+
+
+@dataclass
+class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
+    _materialize_kinds_by_resume_ref: dict[str, set[str]] = field(default_factory=dict)
+    _representative_to_surfaces: dict[str, list[str]] = field(default_factory=dict)
+    _fungible_rows: list[JSONObject] = field(default_factory=list)
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        kind = str(one_cell.get("kind", ""))
+        metadata = one_cell.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            return
+        resume_ref = ""
+        for candidate_key in ("state_path", "import_state_path"):
+            candidate = str(metadata.get(candidate_key, "")).strip()
+            if candidate:
+                resume_ref = candidate
+                break
+        if not resume_ref:
+            return
+        self._materialize_kinds_by_resume_ref.setdefault(resume_ref, set()).add(kind)
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        self._representative_to_surfaces.setdefault(representative, []).append(surface)
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None:
+        if str(row.get("classification")) != "non_drift":
+            return
+        surface = str(row.get("surface", "")).strip()
+        witness_id = row.get("witness_id")
+        if not surface or witness_id in (None, ""):
+            return
+        self._fungible_rows.append(
+            {
+                "opportunity_id": f"opp:fungible-substitution:{surface}",
+                "kind": "fungible_execution_path_substitution",
+                "confidence": 0.82,
+                "affected_surfaces": [surface],
+                "witness_ids": [str(witness_id)],
+                "reason": "2-cell witness links baseline/current representatives",
+            }
+        )
+
+    def build_rows(self) -> list[JSONObject]:
+        rows: list[JSONObject] = []
+        for resume_ref in sort_once(
+            self._materialize_kinds_by_resume_ref,
+            source="aspf_visitors.OpportunityPayloadEmitter.materialize.resume_ref",
+        ):
+            kinds = self._materialize_kinds_by_resume_ref[resume_ref]
+            fused = int("resume_load" in kinds and "resume_write" in kinds)
+            rows.append(
+                {
+                    "opportunity_id": f"opp:materialize-load-fusion:{resume_ref}",
+                    "kind": ("materialize_load_observed", "materialize_load_fusion")[fused],
+                    "confidence": (0.51, 0.74)[fused],
+                    "affected_surfaces": [],
+                    "witness_ids": [],
+                    "reason": (
+                        "resume boundary observed state reference",
+                        "resume load and write boundaries share state reference",
+                    )[fused],
+                }
+            )
+
+        for representative in sort_once(
+            self._representative_to_surfaces,
+            source="aspf_visitors.OpportunityPayloadEmitter.representative",
+        ):
+            surfaces = tuple(
+                sort_once(
+                    self._representative_to_surfaces[representative],
+                    source="aspf_visitors.OpportunityPayloadEmitter.representative_surfaces",
+                )
+            )
+            digest = hashlib.sha256(representative.encode("utf-8")).hexdigest()[:12]
+            rows.append(
+                {
+                    "opportunity_id": f"opp:reusable-boundary:{digest}",
+                    "kind": "reusable_boundary_artifact",
+                    "confidence": 0.67,
+                    "affected_surfaces": list(surfaces),
+                    "witness_ids": [],
+                    "reason": "multiple semantic surfaces share deterministic representative",
+                }
+            )
+
+        rows.extend(self._fungible_rows)
+        return sorted(rows, key=lambda item: str(item.get("opportunity_id", "")))
+
+
+@dataclass
+class StatePayloadEmitter:
+    trace: JSONObject = field(default_factory=dict)
+    equivalence: JSONObject = field(default_factory=dict)
+    opportunities: JSONObject = field(default_factory=dict)
+
+    def set_trace_payload(self, payload: Mapping[str, object]) -> None:
+        self.trace = {str(key): cast(JSONValue, payload[key]) for key in payload}
+
+    def set_equivalence_payload(self, payload: Mapping[str, object]) -> None:
+        self.equivalence = {str(key): cast(JSONValue, payload[key]) for key in payload}
+
+    def set_opportunities_payload(self, payload: Mapping[str, object]) -> None:
+        self.opportunities = {str(key): cast(JSONValue, payload[key]) for key in payload}

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from gabion.analysis.aspf import Alt, Forest, Node
+from gabion.analysis.aspf_visitors import (
+    NullAspfTraversalVisitor,
+    OpportunityPayloadEmitter,
+    replay_equivalence_payload_to_visitor,
+    replay_trace_payload_to_visitor,
+    traverse_forest_to_visitor,
+)
+
+
+@dataclass
+class _ForestOrderCaptureVisitor(NullAspfTraversalVisitor):
+    node_kinds: list[str] = field(default_factory=list)
+    alt_kinds: list[str] = field(default_factory=list)
+
+    def on_forest_node(self, *, node: Node) -> None:
+        self.node_kinds.append(node.kind)
+
+    def on_forest_alt(self, *, alt: Alt) -> None:
+        self.alt_kinds.append(alt.kind)
+
+
+def test_traverse_forest_to_visitor_uses_deterministic_order() -> None:
+    forest = Forest()
+    alpha = forest.add_node("KindB", ("b",), {"name": "b"})
+    beta = forest.add_node("KindA", ("a",), {"name": "a"})
+    forest.add_alt("AltB", (alpha, beta))
+    forest.add_alt("AltA", (beta,))
+
+    visitor = _ForestOrderCaptureVisitor()
+    traverse_forest_to_visitor(forest=forest, visitor=visitor)
+
+    assert visitor.node_kinds == ["KindA", "KindB"]
+    assert visitor.alt_kinds == ["AltA", "AltB"]
+
+
+def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
+    emitter = OpportunityPayloadEmitter()
+    replay_trace_payload_to_visitor(
+        trace_payload={
+            "one_cells": [
+                {
+                    "kind": "resume_load",
+                    "metadata": {"import_state_path": "state/a.json"},
+                },
+                {
+                    "kind": "resume_write",
+                    "metadata": {"state_path": "state/a.json"},
+                },
+            ],
+            "surface_representatives": {
+                "violation_summary": "rep:b",
+                "groups_by_path": "rep:a",
+            },
+            "two_cell_witnesses": [],
+            "cofibration_witnesses": [],
+        },
+        visitor=emitter,
+    )
+    replay_equivalence_payload_to_visitor(
+        equivalence_payload={
+            "surface_table": [
+                {
+                    "surface": "groups_by_path",
+                    "classification": "non_drift",
+                    "witness_id": "w:1",
+                }
+            ]
+        },
+        visitor=emitter,
+    )
+
+    rows = emitter.build_rows()
+    kinds = [str(row.get("kind")) for row in rows]
+    assert "materialize_load_fusion" in kinds
+    assert "reusable_boundary_artifact" in kinds
+    assert "fungible_execution_path_substitution" in kinds


### PR DESCRIPTION
### Motivation
- Provide a single, Protocol-driven traversal pattern for ASPF forests and persisted trace payloads so semantic-core consumers can share deterministic dispatch logic instead of duplicating batch builders. 
- Make trace/opportunities/state emission follow the same traversal contract to improve composability and align with the repo's boundary-normalization and decision-protocol guidance. 

### Description
- Add a focused visitor module `src/gabion/analysis/aspf_visitors.py` that defines the `AspfTraversalVisitor` Protocol and deterministic adapters: `traverse_forest_to_visitor`, `replay_trace_payload_to_visitor`, and `replay_equivalence_payload_to_visitor`, and documents that boundary normalization is expected at ingress parsers. 
- Implement concrete emitters `TracePayloadEmitter`, `OpportunityPayloadEmitter`, and `StatePayloadEmitter` inside `aspf_visitors.py` so replay/traversal populates canonical payload shapes via visitor callbacks. 
- Refactor `src/gabion/analysis/aspf_execution_fibration.py` to use the visitor adapters/emitters: `build_trace_payload()` now replays into `TracePayloadEmitter`, `build_opportunities_payload()` uses `OpportunityPayloadEmitter` by replaying trace+equivalence payloads, and `_build_state_payload()` delegates materialization to `StatePayloadEmitter`. 
- Add unit tests `tests/test_aspf_visitors.py` to verify deterministic forest traversal order and persisted-trace replay into opportunity generation. 

### Testing
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf_execution_fibration.py -q` which succeeded with `7 passed`. 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf_execution_fibration.py tests/test_aspf_visitors.py -q` which succeeded with `9 passed`, including the new `tests/test_aspf_visitors.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a123fe5b308324853c5b7fe6bcf63f)