### PR TITLE
Add typed lint and transport decision protocols

### DIFF
--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -110,6 +110,16 @@ class LintEntryDTO(BaseModel):
     code: str
     message: str
     severity: str = "warning"
+
+
+class LintEntriesResolutionDTO(BaseModel):
+    kind: Literal["provided_entries", "derive_from_lines", "empty"]
+    lint_lines: List[str] = []
+
+
+class TransportSelectionDTO(BaseModel):
+    carrier: Literal["auto", "lsp", "direct"] = "auto"
+    carrier_override_record: Optional[str] = None
 
 
 class AspfOneCellDTO(BaseModel):

--- a/tests/test_server_rewrite_plan_projection.py
+++ b/tests/test_server_rewrite_plan_projection.py
@@ -45,3 +45,20 @@ def test_rewrite_plan_schema_helpers_cover_non_dict_and_unknown_kind() -> None:
     assert rewrite_plan_mod.attach_plan_schema({"rewrite": "bad"}) == {"rewrite": "bad"}
     unknown = {"rewrite": {"kind": "NOT_A_KIND"}}
     assert rewrite_plan_mod.attach_plan_schema(unknown) == unknown
+
+
+# gabion:evidence E:function_site::tests/test_server_rewrite_plan_projection.py::test_server_projection_normalizes_lint_entry_trichotomy
+def test_server_projection_normalizes_lint_entry_trichotomy() -> None:
+    provided = _normalize_dataflow_response(
+        {
+            "lint_lines": ["x.py:1:1: X ignored"],
+            "lint_entries": [{"path": "a.py", "line": 1, "col": 2, "code": "E", "message": "provided"}],
+        }
+    )
+    assert provided["lint_entries"][0]["path"] == "a.py"
+
+    derived = _normalize_dataflow_response({"lint_lines": ["b.py:2:3: W derived message"]})
+    assert derived["lint_entries"][0]["path"] == "b.py"
+
+    empty = _normalize_dataflow_response({})
+    assert empty["lint_entries"] == []

--- a/tests/test_transport_policy.py
+++ b/tests/test_transport_policy.py
@@ -168,3 +168,10 @@ def test_resolve_transport_controls_reads_override_record_path_and_missing_path_
         transport_policy._load_override_record_json_from_path(
             str(tmp_path / "missing.json")
         )
+
+
+# gabion:evidence E:function_site::tests/test_transport_policy.py::test_transport_carrier_decision_trichotomy
+def test_transport_carrier_decision_trichotomy() -> None:
+    assert transport_policy.TransportCarrierDecision.from_carrier(None).mode == "auto"
+    assert transport_policy.TransportCarrierDecision.from_carrier("lsp").to_direct_requested() is False
+    assert transport_policy.TransportCarrierDecision.from_carrier("direct").to_direct_requested() is True


### PR DESCRIPTION
### Motivation
- Make the lint-entry trichotomy an explicit, typed decision protocol so downstream code consumes a single normalized outcome instead of ad-hoc branch/sentinel logic. 
- Ensure CLI transport gating is represented as a stable, typed surface so transport policy checks (LSP vs direct) are deterministic and schema-aligned. 
- Expose lightweight DTOs for these boundary decisions so server handlers and CLI code operate on a single, validated payload contract.

### Description
- Introduce `LintEntriesDecision` in `src/gabion/commands/check_contract.py` to encode the lint-entry trichotomy (`provided_entries` / `derive_from_lines` / `empty`) and provide a `normalize_entries` method for canonical output. 
- Update server normalization in `src/gabion/server.py` to consume `LintEntriesDecision.from_response(...)` and call a single parser (`_parse_lint_line_as_payload`) so deep normalization no longer performs ad-hoc branching. 
- Add a typed transport selection flow in `src/gabion/commands/transport_policy.py` via `TransportCarrierDecision` and wire `apply_cli_transport_flags` through the schema-backed `TransportSelectionDTO` to unify CLI inputs and transport decisions. 
- Expose stable schema DTOs in `src/gabion/schema.py`: `LintEntriesResolutionDTO` and `TransportSelectionDTO` to document and validate payload surfaces. 
- Add focused unit tests that exercise the new decision-protocol behavior: lint trichotomy (`tests/test_check_contract.py`, `tests/test_server_rewrite_plan_projection.py`) and transport carrier trichotomy (`tests/test_transport_policy.py`).

### Testing
- Ran the targeted pytest invocation: `PYTHONPATH=src python -m pytest -c /dev/null tests/test_check_contract.py tests/test_transport_policy.py tests/test_server_rewrite_plan_projection.py`, which completed successfully with all tests passing (16 passed, 1 warning). 
- Verified the new unit tests exercise: the `LintEntriesDecision` trichotomy normalization and the `TransportCarrierDecision` behavior, and confirmed server normalization uses the decision protocol output. 
- Note: an earlier attempt to run tests via the repo `mise` wrapper was blocked by an untrusted `mise.toml` configuration and was bypassed by invoking pytest directly with `PYTHONPATH=src` and an empty config file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a124cf2a64832498a7b59f18d0f4a4)