### PR TITLE
Add UniversalCurve TC research Agda modules and design bridge

### DIFF
--- a/in/universal-curve-lab-bundle/README.md
+++ b/in/universal-curve-lab-bundle/README.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 3
+doc_revision: 4
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: universal_curve_lab_readme
 doc_role: research_overview
@@ -15,6 +15,7 @@ doc_relations:
     - in/universal-curve-lab-bundle/docs/overview.md
     - in/universal-curve-lab-bundle/docs/proofs.md
     - in/universal-curve-lab-bundle/docs/experiments.md
+    - in/universal-curve-lab-bundle/docs/tc-design-bridge.md
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
 doc_owner: maintainer
 ---
@@ -28,9 +29,17 @@ A research/engineering lab for **probabilistic canonical labeling** of finite wi
 
 Structure:
 - `agda/` constructive core and executable specs
+- `agda/UniversalCurve/TC/` Trace-Contract research modules
+  - `SIG.agda` concept signatures for traces, payload keys, and command surfaces
+  - `CONSTR.agda` constructor helpers + sample contract instances
+  - `GLUE.agda` mapping bundles from TC concepts to runtime-facing descriptors
 - `python/` empirical harnesses + artifact generation
 - `notes/` lab notes + proof sketches
 - `docs/` overview + proof schemas + experiment protocol
 - `artifacts/` exported runs / forests / tables
+
+TC status: modules under `agda/UniversalCurve/TC/` are **research/inspiration
+scope** only unless and until a separate promotion step explicitly adopts them
+into production Gabion enforcement surfaces.
 
 License: MIT (`LICENSE`).

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTR.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTR.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.CONSTR where
+
+open import Agda.Builtin.List using (List; []; _∷_)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Nat using (Nat)
+open import Agda.Builtin.Bool using (Bool; true; false)
+
+open import UniversalCurve.TC.SIG
+
+mkPoint : String → String → TracePoint
+mkPoint span phase = mkTracePoint span phase
+
+requiredKey : String → PayloadKey
+requiredKey key = mkPayloadKey key true
+
+optionalKey : String → PayloadKey
+optionalKey key = mkPayloadKey key false
+
+surface : String → Nat → CommandSurface
+surface name since = mkCommandSurface name since
+
+buildTraceContract :
+  List TracePoint →
+  List PayloadKey →
+  List CommandSurface →
+  TraceContract
+buildTraceContract points keys surfaces =
+  mkTraceContract points keys surfaces
+
+sampleContract : TraceContract
+sampleContract =
+  buildTraceContract
+    (mkPoint "aspf.emit" "analysis" ∷ mkPoint "dto.encode" "projection" ∷ [])
+    (requiredKey "entries" ∷ optionalKey "metadata" ∷ [])
+    (surface "gabion check-delta" 1 ∷ surface "gabion dataflow-audit" 1 ∷ [])

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUE.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUE.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.GLUE where
+
+open import Agda.Builtin.List using (List)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Bool using (Bool; false)
+
+open import UniversalCurve.TC.SIG
+open import UniversalCurve.TC.CONSTR
+
+record RuntimeMapping : Set where
+  constructor mkRuntimeMapping
+  field
+    tcConcept : String
+    runtimeSurface : String
+
+record BridgePlan : Set where
+  constructor mkBridgePlan
+  field
+    contract : TraceContract
+    mappings : List RuntimeMapping
+    productionEnforced : Bool
+
+mkMapping : String → String → RuntimeMapping
+mkMapping concept surface = mkRuntimeMapping concept surface
+
+bridgePlan : List RuntimeMapping → BridgePlan
+bridgePlan maps = mkBridgePlan sampleContract maps false

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.SIG where
+
+open import Agda.Builtin.List using (List)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Nat using (Nat)
+open import Agda.Builtin.Bool using (Bool)
+
+-- TC (Trace Contract) signatures are intentionally minimal for research staging.
+-- They model shape and labels only; runtime enforcement lives in Gabion handlers.
+
+record TracePoint : Set where
+  constructor mkTracePoint
+  field
+    spanLabel : String
+    phaseLabel : String
+
+record PayloadKey : Set where
+  constructor mkPayloadKey
+  field
+    keyName : String
+    required : Bool
+
+record CommandSurface : Set where
+  constructor mkCommandSurface
+  field
+    commandName : String
+    stableSince : Nat
+
+record TraceContract : Set where
+  constructor mkTraceContract
+  field
+    points : List TracePoint
+    payloadKeys : List PayloadKey
+    commandSurfaces : List CommandSurface

--- a/in/universal-curve-lab-bundle/docs/tc-design-bridge.md
+++ b/in/universal-curve-lab-bundle/docs/tc-design-bridge.md
@@ -1,0 +1,45 @@
+---
+doc_revision: 1
+reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
+doc_id: universal_curve_lab_tc_design_bridge
+doc_role: research_mapping
+doc_scope:
+  - in
+  - research
+  - universal_curve_lab
+  - tc
+doc_authority: informative
+doc_requires:
+  - in/universal-curve-lab-bundle/README.md
+  - glossary.md#contract
+doc_relations:
+  refines:
+    - in/universal-curve-lab-bundle/README.md
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_owner: maintainer
+---
+# TC design bridge (research scope)
+
+This bridge maps the **TC module concepts** in `agda/UniversalCurve/TC/` to existing
+Gabion runtime surfaces so experiments can stay aligned with practical outputs.
+
+> Status: **research/inspiration only**. These mappings are descriptive and do not
+> claim production enforcement in Gabion runtime paths.
+
+## Concept-to-surface map
+
+| TC concept (Agda) | Gabion runtime surface | Notes |
+| --- | --- | --- |
+| `TracePoint` (`SIG`) | ASPF traces emitted by audit/check command pipelines | Conceptual alignment with span/phase-style trace slices used for evidence exports. |
+| `PayloadKey` (`SIG`) | DTO payload keys in serialized audit/check results | Models required vs optional payload fields at a research-contract level. |
+| `CommandSurface` (`SIG`) | `gabion` command outputs (e.g., check/audit style commands) | Treats command names + maturity epoch as a typed surface descriptor. |
+| Constructor helpers (`CONSTR`) | Runtime payload assembly pathways | Mirrors how handlers build output records, but currently only as lab constructors. |
+| `BridgePlan` (`GLUE`) | Cross-surface traceability docs and prototype adapters | Encodes mapping bundles and an explicit non-production-enforced flag. |
+
+## Intended usage
+
+- Keep TC signatures stable while iterating on experimental adapters.
+- Use this map to evaluate whether a TC concept should later be promoted into
+  first-class runtime contracts.
+- Preserve the current contract boundary: no direct claim that Agda TC modules
+  are wired into production command enforcement yet.


### PR DESCRIPTION
### Motivation

- Introduce a small, explicit research staging area for Trace-Contract (TC) concepts so lab artifacts can remain separate from runtime Gabion enforcement. 
- Provide a lightweight Agda specification of TC signatures and helpers to anchor experiments against a typed design surface. 
- Offer a mapping document that links TC concepts to existing Gabion runtime surfaces while clearly marking the work as research/inspiration only.

### Description

- Add `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda` defining `TracePoint`, `PayloadKey`, `CommandSurface`, and `TraceContract` as minimal TC signatures. 
- Add `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTR.agda` containing constructor helpers and a `sampleContract` instance for lab use. 
- Add `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUE.agda` defining `RuntimeMapping` and `BridgePlan` with an explicit `productionEnforced` flag set to `false`, plus a design bridge doc at `in/universal-curve-lab-bundle/docs/tc-design-bridge.md` mapping TC concepts to ASPF traces, DTO payload keys, and `gabion` command outputs. 
- Update `in/universal-curve-lab-bundle/README.md` to document the TC module tree and explicitly mark these modules as research/inspiration scope pending formal promotion.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff issues, which succeeded. 
- Inspected repository status with `git status --short` to confirm the working tree changes, which reported the new and modified files. 
- Performed manual review of the added Agda and markdown files for consistency and framing, which found no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1250c10d88324bcbf0cd55901b6c2)