### PR TITLE
Integrate ASPF stream/traversal/resume refactors (subsumes #252 #253 #254 #255)

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -544,11 +544,11 @@ def finalize_execution_trace(
     }
     resume_projection = aspf_resume_state.replay_resume_projection(
         snapshot=resume_snapshot,
-        delta_records=state.delta_records,
+        delta_records=iter(state.delta_records),
     )
     delta_ledger_payload = aspf_resume_state.build_delta_ledger_payload(
         trace_id=state.trace_id,
-        records=state.delta_records,
+        records=iter(state.delta_records),
     )
     trace_path = state.controls.aspf_trace_json or (root / "artifacts/out/aspf_trace.json")
     equivalence_path = root / "artifacts/out/aspf_equivalence.json"
@@ -563,7 +563,7 @@ def finalize_execution_trace(
     _write_json(opportunities_path, opportunities_payload)
     aspf_resume_state.write_delta_jsonl(
         path=delta_jsonl_path,
-        records=state.delta_records,
+        records=iter(state.delta_records),
     )
     state_path = state.controls.aspf_state_json or (
         root / "artifacts/out/aspf_state/default/0001_aspf.snapshot.json"

--- a/src/gabion/analysis/aspf_resume_state.py
+++ b/src/gabion/analysis/aspf_resume_state.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 from pathlib import Path
-from typing import Mapping, Sequence, cast
+from typing import Iterable, Iterator, Mapping, Sequence, cast
 
 from gabion.json_types import JSONObject, JSONValue
 
@@ -56,20 +56,32 @@ def build_delta_ledger_payload(
 def write_delta_jsonl(
     *,
     path: Path,
-    records: Sequence[Mapping[str, object]],
+    records: Iterable[Mapping[str, object]],
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    lines: list[str] = []
-    for raw in records:
-        payload = {str(key): _as_json_value(raw[key]) for key in raw}
-        lines.append(json.dumps(payload, sort_keys=False))
-    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    with path.open("w", encoding="utf-8") as handle:
+        for raw in records:
+            payload = {str(key): _as_json_value(raw[key]) for key in raw}
+            handle.write(json.dumps(payload, sort_keys=False))
+            handle.write("\n")
+
+
+def append_delta_jsonl_record(
+    *,
+    path: Path,
+    record: Mapping[str, object],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {str(key): _as_json_value(record[key]) for key in record}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=False))
+        handle.write("\n")
 
 
 def replay_resume_projection(
     *,
     snapshot: Mapping[str, object],
-    delta_records: Sequence[Mapping[str, object]],
+    delta_records: Iterable[Mapping[str, object]],
 ) -> JSONObject:
     projection: JSONObject = {str(key): _as_json_value(snapshot[key]) for key in snapshot}
     for record in delta_records:
@@ -87,23 +99,64 @@ def load_resume_projection_from_state_files(
     *,
     state_paths: Sequence[Path],
 ) -> tuple[JSONObject | None, tuple[JSONObject, ...]]:
+    latest_projection = load_latest_resume_projection_from_state_files(state_paths=state_paths)
+    return latest_projection, tuple(iter_delta_records_from_state_files(state_paths=state_paths))
+
+
+def iter_delta_records_from_state_files(
+    *,
+    state_paths: Sequence[Path],
+) -> Iterator[JSONObject]:
+    for path in state_paths:
+        payload = _load_json(path)
+        yield from _iter_delta_records_from_state_payload(payload=payload)
+
+
+def iter_delta_records_from_jsonl_paths(
+    *,
+    jsonl_paths: Sequence[Path],
+) -> Iterator[JSONObject]:
+    for path in jsonl_paths:
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                loaded = json.loads(line)
+                assert isinstance(loaded, Mapping)
+                yield {str(key): _as_json_value(loaded[key]) for key in loaded}
+
+
+def iter_delta_records(
+    *,
+    state_paths: Sequence[Path] = (),
+    jsonl_paths: Sequence[Path] = (),
+) -> Iterator[JSONObject]:
+    yield from iter_delta_records_from_state_files(state_paths=state_paths)
+    yield from iter_delta_records_from_jsonl_paths(jsonl_paths=jsonl_paths)
+
+
+def load_latest_resume_projection_from_state_files(
+    *,
+    state_paths: Sequence[Path],
+) -> JSONObject | None:
     latest_projection: JSONObject | None = None
-    all_records: list[JSONObject] = []
     for path in state_paths:
         payload = _load_json(path)
         resume = payload.get("resume_projection")
         assert isinstance(resume, Mapping)
         latest_projection = {str(key): _as_json_value(resume[key]) for key in resume}
-        ledger = payload.get("delta_ledger")
-        assert isinstance(ledger, Mapping)
-        raw_records = ledger.get("records")
-        assert isinstance(raw_records, list)
-        for raw_record in raw_records:
-            assert isinstance(raw_record, Mapping)
-            all_records.append(
-                {str(key): _as_json_value(raw_record[key]) for key in raw_record}
-            )
-    return latest_projection, tuple(all_records)
+    return latest_projection
+
+
+def _iter_delta_records_from_state_payload(*, payload: Mapping[str, object]) -> Iterator[JSONObject]:
+    ledger = payload.get("delta_ledger")
+    assert isinstance(ledger, Mapping)
+    raw_records = ledger.get("records")
+    assert isinstance(raw_records, list)
+    for raw_record in raw_records:
+        assert isinstance(raw_record, Mapping)
+        yield {str(key): _as_json_value(raw_record[key]) for key in raw_record}
 
 
 def _load_json(path: Path) -> JSONObject:

--- a/src/gabion/analysis/aspf_stream.py
+++ b/src/gabion/analysis/aspf_stream.py
@@ -18,7 +18,7 @@ class OneCellRecorded:
     state: AspfExecutionTraceState
     cell: AspfOneCell
     kind: str
-    surface: str | None
+    surface: str
     metadata_payload: JSONObject
 
 
@@ -50,7 +50,7 @@ class RunFinalized:
     equivalence_payload: Mapping[str, object]
     opportunities_payload: Mapping[str, object]
     delta_ledger_payload: Mapping[str, object]
-    state_payload: Mapping[str, object] | None
+    state_payload: Mapping[str, object]
 
 
 class AspfEventVisitor(Protocol):
@@ -72,9 +72,13 @@ class AspfInMemoryCompatibilityVisitor:
 
     def visit_one_cell_recorded(self, event: OneCellRecorded) -> None:
         event.state.one_cells.append(event.cell)
+        analysis_state_value = event.metadata_payload.get("analysis_state")
+        analysis_state = (
+            str(analysis_state_value) if analysis_state_value is not None else None
+        )
         raw_metadata: JSONObject = {
             "kind": event.kind,
-            "surface": event.surface or "",
+            "surface": event.surface,
             "metadata": event.metadata_payload,
         }
         event.state.one_cell_metadata.append(raw_metadata)
@@ -84,11 +88,7 @@ class AspfInMemoryCompatibilityVisitor:
             records=event.state.delta_records,
             event_kind=event.kind,
             phase=str(phase),
-            analysis_state=(
-                str(event.metadata_payload.get("analysis_state"))
-                if isinstance(event.metadata_payload.get("analysis_state"), str)
-                else None
-            ),
+            analysis_state=analysis_state,
             mutation_target=mutation_target,
             mutation_value={
                 "source": str(event.cell.source),
@@ -119,7 +119,7 @@ class AspfInMemoryCompatibilityVisitor:
         )
 
     def visit_run_finalized(self, event: RunFinalized) -> None:
-        return None
+        pass
 
     def on_finalize(self, event: RunFinalized) -> None:
-        return None
+        pass

--- a/src/gabion/analysis/aspf_stream.py
+++ b/src/gabion/analysis/aspf_stream.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, Protocol
+
+from gabion.json_types import JSONObject
+
+from . import aspf_resume_state
+from .aspf_core import AspfOneCell, AspfTwoCellWitness
+from .aspf_morphisms import CofibrationWitnessCarrier
+
+if TYPE_CHECKING:
+    from .aspf_execution_fibration import AspfExecutionTraceState
+
+
+@dataclass(frozen=True)
+class OneCellRecorded:
+    state: AspfExecutionTraceState
+    cell: AspfOneCell
+    kind: str
+    surface: str | None
+    metadata_payload: JSONObject
+
+
+@dataclass(frozen=True)
+class TwoCellWitnessRecorded:
+    state: AspfExecutionTraceState
+    witness: AspfTwoCellWitness
+
+
+@dataclass(frozen=True)
+class CofibrationRecorded:
+    state: AspfExecutionTraceState
+    carrier: CofibrationWitnessCarrier
+
+
+@dataclass(frozen=True)
+class SemanticSurfaceUpdated:
+    state: AspfExecutionTraceState
+    surface: str
+    representative: str
+    normalized_value: object
+    phase: str
+
+
+@dataclass(frozen=True)
+class RunFinalized:
+    state: AspfExecutionTraceState
+    trace_payload: Mapping[str, object]
+    equivalence_payload: Mapping[str, object]
+    opportunities_payload: Mapping[str, object]
+    delta_ledger_payload: Mapping[str, object]
+    state_payload: Mapping[str, object] | None
+
+
+class AspfEventVisitor(Protocol):
+    def visit_one_cell_recorded(self, event: OneCellRecorded) -> None: ...
+
+    def visit_two_cell_witness_recorded(self, event: TwoCellWitnessRecorded) -> None: ...
+
+    def visit_cofibration_recorded(self, event: CofibrationRecorded) -> None: ...
+
+    def visit_semantic_surface_updated(self, event: SemanticSurfaceUpdated) -> None: ...
+
+    def visit_run_finalized(self, event: RunFinalized) -> None: ...
+
+    def on_finalize(self, event: RunFinalized) -> None: ...
+
+
+class AspfInMemoryCompatibilityVisitor:
+    """Reconstructs legacy in-memory side effects for transition compatibility."""
+
+    def visit_one_cell_recorded(self, event: OneCellRecorded) -> None:
+        event.state.one_cells.append(event.cell)
+        raw_metadata: JSONObject = {
+            "kind": event.kind,
+            "surface": event.surface or "",
+            "metadata": event.metadata_payload,
+        }
+        event.state.one_cell_metadata.append(raw_metadata)
+        mutation_target = f"one_cells.{len(event.state.one_cells)}"
+        phase = event.cell.basis_path[0] if event.cell.basis_path else "runtime"
+        aspf_resume_state.append_delta_record(
+            records=event.state.delta_records,
+            event_kind=event.kind,
+            phase=str(phase),
+            analysis_state=(
+                str(event.metadata_payload.get("analysis_state"))
+                if isinstance(event.metadata_payload.get("analysis_state"), str)
+                else None
+            ),
+            mutation_target=mutation_target,
+            mutation_value={
+                "source": str(event.cell.source),
+                "target": str(event.cell.target),
+                "representative": event.cell.representative,
+                "surface": event.surface,
+                "metadata": event.metadata_payload,
+            },
+            one_cell_ref=mutation_target,
+        )
+
+    def visit_two_cell_witness_recorded(self, event: TwoCellWitnessRecorded) -> None:
+        event.state.two_cell_witnesses.append(event.witness)
+
+    def visit_cofibration_recorded(self, event: CofibrationRecorded) -> None:
+        event.state.cofibrations.append(event.carrier)
+
+    def visit_semantic_surface_updated(self, event: SemanticSurfaceUpdated) -> None:
+        event.state.surface_representatives[event.surface] = event.representative
+        aspf_resume_state.append_delta_record(
+            records=event.state.delta_records,
+            event_kind="semantic_surface_projection",
+            phase=event.phase,
+            analysis_state=None,
+            mutation_target=f"semantic_surfaces.{event.surface}",
+            mutation_value=event.normalized_value,
+            one_cell_ref=None,
+        )
+
+    def visit_run_finalized(self, event: RunFinalized) -> None:
+        return None
+
+    def on_finalize(self, event: RunFinalized) -> None:
+        return None

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from typing import Mapping, Protocol, cast
+
+from gabion.analysis.aspf import Alt, Forest, Node
+from gabion.json_types import JSONObject, JSONValue
+from gabion.order_contract import sort_once
+
+
+class AspfTraversalVisitor(Protocol):
+    """Semantic-core visitor contract for ASPF traversal dispatch.
+
+    Boundary normalization is expected to happen at ingress parsers (for example,
+    ``load_trace_payload``). Traversal helpers below assume normalized payloads and
+    perform deterministic visitor dispatch for semantic-core consumers.
+    """
+
+    def on_forest_node(self, *, node: Node) -> None: ...
+
+    def on_forest_alt(self, *, alt: Alt) -> None: ...
+
+    def on_trace_one_cell(
+        self,
+        *,
+        index: int,
+        one_cell: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None: ...
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None: ...
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None: ...
+
+
+@dataclass
+class NullAspfTraversalVisitor:
+    def on_forest_node(self, *, node: Node) -> None:
+        return None
+
+    def on_forest_alt(self, *, alt: Alt) -> None:
+        return None
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        return None
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None:
+        return None
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None:
+        return None
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        return None
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None:
+        return None
+
+
+def traverse_forest_to_visitor(*, forest: Forest, visitor: AspfTraversalVisitor) -> None:
+    nodes = sort_once(
+        forest.nodes.values(),
+        key=lambda node: node.node_id.sort_key(),
+        source="aspf_visitors.traverse_forest_to_visitor.nodes",
+    )
+    for node in nodes:
+        visitor.on_forest_node(node=node)
+    alts = sort_once(
+        forest.alts,
+        key=lambda alt: alt.sort_key(),
+        source="aspf_visitors.traverse_forest_to_visitor.alts",
+    )
+    for alt in alts:
+        visitor.on_forest_alt(alt=alt)
+
+
+def replay_trace_payload_to_visitor(
+    *,
+    trace_payload: Mapping[str, object],
+    visitor: AspfTraversalVisitor,
+) -> None:
+    one_cells = cast(list[object], trace_payload.get("one_cells", []))
+    for index, raw_one_cell in enumerate(one_cells):
+        if isinstance(raw_one_cell, Mapping):
+            visitor.on_trace_one_cell(index=index, one_cell=raw_one_cell)
+
+    two_cell_witnesses = cast(list[object], trace_payload.get("two_cell_witnesses", []))
+    for index, raw_witness in enumerate(two_cell_witnesses):
+        if isinstance(raw_witness, Mapping):
+            visitor.on_trace_two_cell_witness(index=index, witness=raw_witness)
+
+    cofibrations = cast(list[object], trace_payload.get("cofibration_witnesses", []))
+    for index, raw_cofibration in enumerate(cofibrations):
+        if isinstance(raw_cofibration, Mapping):
+            visitor.on_trace_cofibration(index=index, cofibration=raw_cofibration)
+
+    surface_payload = trace_payload.get("surface_representatives", {})
+    if isinstance(surface_payload, Mapping):
+        ordered_surfaces = sort_once(
+            [str(surface) for surface in surface_payload],
+            source="aspf_visitors.replay_trace_payload_to_visitor.surface_representatives",
+        )
+        for surface in ordered_surfaces:
+            representative = surface_payload.get(surface)
+            if isinstance(representative, str):
+                visitor.on_trace_surface_representative(
+                    surface=surface,
+                    representative=representative,
+                )
+
+
+def replay_equivalence_payload_to_visitor(
+    *,
+    equivalence_payload: Mapping[str, object],
+    visitor: AspfTraversalVisitor,
+) -> None:
+    rows = equivalence_payload.get("surface_table", [])
+    if not isinstance(rows, list):
+        return
+    for index, raw_row in enumerate(rows):
+        if isinstance(raw_row, Mapping):
+            visitor.on_equivalence_surface_row(index=index, row=raw_row)
+
+
+@dataclass
+class TracePayloadEmitter(NullAspfTraversalVisitor):
+    one_cells: list[JSONValue] = field(default_factory=list)
+    two_cell_witnesses: list[JSONValue] = field(default_factory=list)
+    cofibration_witnesses: list[JSONValue] = field(default_factory=list)
+    surface_representatives: dict[str, str] = field(default_factory=dict)
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        self.one_cells.append({str(key): cast(JSONValue, one_cell[key]) for key in one_cell})
+
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None:
+        self.two_cell_witnesses.append(
+            {str(key): cast(JSONValue, witness[key]) for key in witness}
+        )
+
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None:
+        self.cofibration_witnesses.append(
+            {str(key): cast(JSONValue, cofibration[key]) for key in cofibration}
+        )
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        self.surface_representatives[str(surface)] = str(representative)
+
+
+@dataclass
+class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
+    _materialize_kinds_by_resume_ref: dict[str, set[str]] = field(default_factory=dict)
+    _representative_to_surfaces: dict[str, list[str]] = field(default_factory=dict)
+    _fungible_rows: list[JSONObject] = field(default_factory=list)
+
+    def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
+        kind = str(one_cell.get("kind", ""))
+        metadata = one_cell.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            return
+        resume_ref = ""
+        for candidate_key in ("state_path", "import_state_path"):
+            candidate = str(metadata.get(candidate_key, "")).strip()
+            if candidate:
+                resume_ref = candidate
+                break
+        if not resume_ref:
+            return
+        self._materialize_kinds_by_resume_ref.setdefault(resume_ref, set()).add(kind)
+
+    def on_trace_surface_representative(
+        self,
+        *,
+        surface: str,
+        representative: str,
+    ) -> None:
+        self._representative_to_surfaces.setdefault(representative, []).append(surface)
+
+    def on_equivalence_surface_row(
+        self,
+        *,
+        index: int,
+        row: Mapping[str, object],
+    ) -> None:
+        if str(row.get("classification")) != "non_drift":
+            return
+        surface = str(row.get("surface", "")).strip()
+        witness_id = row.get("witness_id")
+        if not surface or witness_id in (None, ""):
+            return
+        self._fungible_rows.append(
+            {
+                "opportunity_id": f"opp:fungible-substitution:{surface}",
+                "kind": "fungible_execution_path_substitution",
+                "confidence": 0.82,
+                "affected_surfaces": [surface],
+                "witness_ids": [str(witness_id)],
+                "reason": "2-cell witness links baseline/current representatives",
+            }
+        )
+
+    def build_rows(self) -> list[JSONObject]:
+        rows: list[JSONObject] = []
+        for resume_ref in sort_once(
+            self._materialize_kinds_by_resume_ref,
+            source="aspf_visitors.OpportunityPayloadEmitter.materialize.resume_ref",
+        ):
+            kinds = self._materialize_kinds_by_resume_ref[resume_ref]
+            fused = int("resume_load" in kinds and "resume_write" in kinds)
+            rows.append(
+                {
+                    "opportunity_id": f"opp:materialize-load-fusion:{resume_ref}",
+                    "kind": ("materialize_load_observed", "materialize_load_fusion")[fused],
+                    "confidence": (0.51, 0.74)[fused],
+                    "affected_surfaces": [],
+                    "witness_ids": [],
+                    "reason": (
+                        "resume boundary observed state reference",
+                        "resume load and write boundaries share state reference",
+                    )[fused],
+                }
+            )
+
+        for representative in sort_once(
+            self._representative_to_surfaces,
+            source="aspf_visitors.OpportunityPayloadEmitter.representative",
+        ):
+            surfaces = tuple(
+                sort_once(
+                    self._representative_to_surfaces[representative],
+                    source="aspf_visitors.OpportunityPayloadEmitter.representative_surfaces",
+                )
+            )
+            digest = hashlib.sha256(representative.encode("utf-8")).hexdigest()[:12]
+            rows.append(
+                {
+                    "opportunity_id": f"opp:reusable-boundary:{digest}",
+                    "kind": "reusable_boundary_artifact",
+                    "confidence": 0.67,
+                    "affected_surfaces": list(surfaces),
+                    "witness_ids": [],
+                    "reason": "multiple semantic surfaces share deterministic representative",
+                }
+            )
+
+        rows.extend(self._fungible_rows)
+        return sorted(rows, key=lambda item: str(item.get("opportunity_id", "")))
+
+
+@dataclass
+class StatePayloadEmitter:
+    trace: JSONObject = field(default_factory=dict)
+    equivalence: JSONObject = field(default_factory=dict)
+    opportunities: JSONObject = field(default_factory=dict)
+
+    def set_trace_payload(self, payload: Mapping[str, object]) -> None:
+        self.trace = {str(key): cast(JSONValue, payload[key]) for key in payload}
+
+    def set_equivalence_payload(self, payload: Mapping[str, object]) -> None:
+        self.equivalence = {str(key): cast(JSONValue, payload[key]) for key in payload}
+
+    def set_opportunities_payload(self, payload: Mapping[str, object]) -> None:
+        self.opportunities = {str(key): cast(JSONValue, payload[key]) for key in payload}

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -673,8 +673,8 @@ def _load_aspf_resume_state(
     *,
     import_state_paths: Sequence[Path],
 ) -> JSONObject | None:
-    projection, records = aspf_resume_state.load_resume_projection_from_state_files(
-        state_paths=import_state_paths
+    projection = aspf_resume_state.load_latest_resume_projection_from_state_files(
+        state_paths=import_state_paths,
     )
     latest_manifest_digest: str | None = None
     latest_resume_source: str | None = None
@@ -689,7 +689,12 @@ def _load_aspf_resume_state(
         latest_resume_source = resume_source or latest_resume_source
     payload: JSONObject = {
         "resume_projection": projection if projection is not None else {},
-        "delta_records": [dict(record) for record in records],
+        "delta_records": [
+            dict(record)
+            for record in aspf_resume_state.iter_delta_records_from_state_files(
+                state_paths=import_state_paths,
+            )
+        ],
         "analysis_manifest_digest": latest_manifest_digest,
         "resume_source": latest_resume_source,
     }

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -2412,9 +2412,19 @@ def _parse_lint_line(line: str) -> LintEntryDTO | None:
 
 def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:
     entry = _parse_lint_line(line)
-    if entry is None:
-        return None
-    return entry.model_dump()
+    return entry.model_dump() if entry is not None else None
+
+
+def _lint_entries_from_lines(lines: Sequence[str]) -> list[dict[str, object]]:
+    decision = LintEntriesDecision(
+        kind="derive_from_lines",
+        lint_lines=tuple(str(line) for line in lines),
+        lint_entries_payload=(),
+    )
+    return cast(
+        list[dict[str, object]],
+        decision.normalize_entries(parse_lint_entry_fn=_parse_lint_line_as_payload),
+    )
 
 
 def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:

--- a/tests/test_aspf_execution_fibration.py
+++ b/tests/test_aspf_execution_fibration.py
@@ -366,3 +366,118 @@ def test_aspf_event_visitor_receives_finalize_hook(tmp_path: Path) -> None:
     assert collector.one_cells == 1
     assert collector.finalized == 1
     assert collector.on_finalize_calls == 1
+
+
+# gabion:evidence E:function_site::aspf_execution_fibration.py::gabion.analysis.aspf_execution_fibration.AspfExecutionTraceState.__post_init__
+def test_execution_trace_state_preserves_preconfigured_event_visitors(tmp_path: Path) -> None:
+    class _Visitor:
+        def visit_one_cell_recorded(self, event) -> None:
+            pass
+
+        def visit_two_cell_witness_recorded(self, event) -> None:
+            pass
+
+        def visit_cofibration_recorded(self, event) -> None:
+            pass
+
+        def visit_semantic_surface_updated(self, event) -> None:
+            pass
+
+        def visit_run_finalized(self, event) -> None:
+            pass
+
+        def on_finalize(self, event) -> None:
+            pass
+
+    visitor = _Visitor()
+    state = aspf_execution_fibration.AspfExecutionTraceState(
+        trace_id="aspf-trace:test",
+        controls=aspf_execution_fibration.controls_from_payload(
+            {"aspf_trace_json": str(tmp_path / "trace.json")}
+        ),
+        started_at_utc="2026-01-01T00:00:00Z",
+        command_profile="check.run",
+        event_visitors=[visitor],
+    )
+    assert state.event_visitors == [visitor]
+
+
+def _one_cell_payload(*, representative: str) -> dict[str, object]:
+    return {
+        "source": "surface:groups_by_path:domain",
+        "target": "surface:groups_by_path:carrier",
+        "representative": representative,
+        "basis_path": ["groups_by_path", "post", "projection"],
+    }
+
+
+# gabion:evidence E:function_site::aspf_execution_fibration.py::gabion.analysis.aspf_execution_fibration._merge_two_cells
+def test_merge_imported_trace_parses_two_cell_witness_payloads(tmp_path: Path) -> None:
+    state = aspf_execution_fibration.start_execution_trace(
+        root=tmp_path,
+        payload=_trace_payload(
+            trace_json=tmp_path / "trace.json",
+            surfaces=["groups_by_path"],
+        ),
+    )
+    assert state is not None
+
+    aspf_execution_fibration.merge_imported_trace(
+        state=state,
+        trace_payload={
+            "surface_representatives": {"groups_by_path": "rep:baseline"},
+            "one_cells": [],
+            "two_cell_witnesses": [
+                {
+                    "left": _one_cell_payload(representative="rep:baseline"),
+                    "right": _one_cell_payload(representative="rep:current"),
+                    "witness_id": "w:imported",
+                    "reason": "imported witness",
+                }
+            ],
+            "cofibration_witnesses": [],
+        },
+    )
+
+    assert len(state.two_cell_witnesses) == 1
+    assert state.two_cell_witnesses[0].witness_id == "w:imported"
+
+
+# gabion:evidence E:function_site::aspf_execution_fibration.py::gabion.analysis.aspf_execution_fibration._merge_known_witnesses
+def test_build_equivalence_payload_uses_baseline_two_cell_witness_index(tmp_path: Path) -> None:
+    state = aspf_execution_fibration.start_execution_trace(
+        root=tmp_path,
+        payload=_trace_payload(
+            trace_json=tmp_path / "trace.json",
+            surfaces=["groups_by_path"],
+        ),
+    )
+    assert state is not None
+    current_cell = aspf_execution_fibration.register_semantic_surface(
+        state=state,
+        surface="groups_by_path",
+        value={"pkg/mod.py": {"fn": [{"a"}]}},
+    )
+    baseline_rep = "rep:baseline"
+    equivalence = aspf_execution_fibration.build_equivalence_payload(
+        state=state,
+        baseline_traces=[
+            {
+                "surface_representatives": {"groups_by_path": baseline_rep},
+                "two_cell_witnesses": [
+                    {
+                        "left": _one_cell_payload(representative=baseline_rep),
+                        "right": _one_cell_payload(representative=current_cell.representative),
+                        "witness_id": "w:baseline-index",
+                        "reason": "baseline index witness",
+                    }
+                ],
+            }
+        ],
+    )
+
+    rows = equivalence["surface_table"]
+    assert isinstance(rows, list)
+    row = next(item for item in rows if isinstance(item, dict))
+    assert row["classification"] == "non_drift"
+    assert row["witness_id"] == "w:baseline-index"

--- a/tests/test_aspf_resume_state.py
+++ b/tests/test_aspf_resume_state.py
@@ -86,3 +86,20 @@ def test_load_resume_projection_compatibility_wrapper_uses_streaming_internals(
 
     assert projection == {"projection_value": 2}
     assert [record["seq"] for record in records] == [1, 2]
+
+
+def test_iter_delta_records_from_jsonl_paths_skips_blank_lines(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "delta.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"seq": 1, "mutation_target": "a", "mutation_value": {"v": 1}}),
+                "",
+                json.dumps({"seq": 2, "mutation_target": "b", "mutation_value": {"v": 2}}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    records = list(aspf_resume_state.iter_delta_records_from_jsonl_paths(jsonl_paths=(jsonl_path,)))
+    assert [record["seq"] for record in records] == [1, 2]

--- a/tests/test_aspf_resume_state.py
+++ b/tests/test_aspf_resume_state.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gabion.analysis import aspf_resume_state
+
+
+def _state_payload(*, projection_value: int, seq: int) -> dict[str, object]:
+    return {
+        "resume_projection": {"projection_value": projection_value},
+        "delta_ledger": {
+            "format_version": 1,
+            "trace_id": "aspf-trace:test",
+            "records": [
+                {
+                    "seq": seq,
+                    "event_kind": "resume",
+                    "phase": "load",
+                    "analysis_state": None,
+                    "mutation_target": "semantic_surfaces.groups_by_path",
+                    "mutation_value": {"v": projection_value},
+                    "one_cell_ref": None,
+                }
+            ],
+        },
+    }
+
+
+def test_iter_delta_records_streams_state_and_jsonl_inputs(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.snapshot.json"
+    state_path.write_text(json.dumps(_state_payload(projection_value=3, seq=1)), encoding="utf-8")
+
+    jsonl_path = tmp_path / "delta.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"seq": 2, "mutation_target": "x", "mutation_value": {"v": 5}}),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    records = list(
+        aspf_resume_state.iter_delta_records(
+            state_paths=(state_path,),
+            jsonl_paths=(jsonl_path,),
+        )
+    )
+
+    assert [record["seq"] for record in records] == [1, 2]
+    assert records[0]["mutation_value"] == {"v": 3}
+    assert records[1]["mutation_value"] == {"v": 5}
+
+
+def test_append_delta_jsonl_record_appends_single_line_payload(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "out" / "delta.jsonl"
+
+    aspf_resume_state.append_delta_jsonl_record(
+        path=jsonl_path,
+        record={"seq": 1, "mutation_target": "a", "mutation_value": {"k": "v"}},
+    )
+    aspf_resume_state.append_delta_jsonl_record(
+        path=jsonl_path,
+        record={"seq": 2, "mutation_target": "b", "mutation_value": {"k": "w"}},
+    )
+
+    lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["seq"] == 1
+    assert json.loads(lines[1])["seq"] == 2
+
+
+def test_load_resume_projection_compatibility_wrapper_uses_streaming_internals(
+    tmp_path: Path,
+) -> None:
+    first_state = tmp_path / "0001.snapshot.json"
+    second_state = tmp_path / "0002.snapshot.json"
+    first_state.write_text(json.dumps(_state_payload(projection_value=1, seq=1)), encoding="utf-8")
+    second_state.write_text(json.dumps(_state_payload(projection_value=2, seq=2)), encoding="utf-8")
+
+    projection, records = aspf_resume_state.load_resume_projection_from_state_files(
+        state_paths=(first_state, second_state)
+    )
+
+    assert projection == {"projection_value": 2}
+    assert [record["seq"] for record in records] == [1, 2]

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from gabion.analysis.aspf import Alt, Forest, Node
+from gabion.analysis.aspf_visitors import (
+    NullAspfTraversalVisitor,
+    OpportunityPayloadEmitter,
+    replay_equivalence_payload_to_visitor,
+    replay_trace_payload_to_visitor,
+    traverse_forest_to_visitor,
+)
+
+
+@dataclass
+class _ForestOrderCaptureVisitor(NullAspfTraversalVisitor):
+    node_kinds: list[str] = field(default_factory=list)
+    alt_kinds: list[str] = field(default_factory=list)
+
+    def on_forest_node(self, *, node: Node) -> None:
+        self.node_kinds.append(node.kind)
+
+    def on_forest_alt(self, *, alt: Alt) -> None:
+        self.alt_kinds.append(alt.kind)
+
+
+def test_traverse_forest_to_visitor_uses_deterministic_order() -> None:
+    forest = Forest()
+    alpha = forest.add_node("KindB", ("b",), {"name": "b"})
+    beta = forest.add_node("KindA", ("a",), {"name": "a"})
+    forest.add_alt("AltB", (alpha, beta))
+    forest.add_alt("AltA", (beta,))
+
+    visitor = _ForestOrderCaptureVisitor()
+    traverse_forest_to_visitor(forest=forest, visitor=visitor)
+
+    assert visitor.node_kinds == ["KindA", "KindB"]
+    assert visitor.alt_kinds == ["AltA", "AltB"]
+
+
+def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
+    emitter = OpportunityPayloadEmitter()
+    replay_trace_payload_to_visitor(
+        trace_payload={
+            "one_cells": [
+                {
+                    "kind": "resume_load",
+                    "metadata": {"import_state_path": "state/a.json"},
+                },
+                {
+                    "kind": "resume_write",
+                    "metadata": {"state_path": "state/a.json"},
+                },
+            ],
+            "surface_representatives": {
+                "violation_summary": "rep:b",
+                "groups_by_path": "rep:a",
+            },
+            "two_cell_witnesses": [],
+            "cofibration_witnesses": [],
+        },
+        visitor=emitter,
+    )
+    replay_equivalence_payload_to_visitor(
+        equivalence_payload={
+            "surface_table": [
+                {
+                    "surface": "groups_by_path",
+                    "classification": "non_drift",
+                    "witness_id": "w:1",
+                }
+            ]
+        },
+        visitor=emitter,
+    )
+
+    rows = emitter.build_rows()
+    kinds = [str(row.get("kind")) for row in rows]
+    assert "materialize_load_fusion" in kinds
+    assert "reusable_boundary_artifact" in kinds
+    assert "fungible_execution_path_substitution" in kinds

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -79,3 +79,18 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     assert "materialize_load_fusion" in kinds
     assert "reusable_boundary_artifact" in kinds
     assert "fungible_execution_path_substitution" in kinds
+
+
+def test_null_visitor_noop_methods_are_callable() -> None:
+    visitor = NullAspfTraversalVisitor()
+    forest = Forest()
+    node = forest.add_node("Kind", ("n",), {"name": "n"})
+    alt = forest.add_alt("Alt", (node,))
+
+    visitor.on_forest_node(node=node)
+    visitor.on_forest_alt(alt=alt)
+    visitor.on_trace_one_cell(index=0, one_cell={})
+    visitor.on_trace_two_cell_witness(index=0, witness={})
+    visitor.on_trace_cofibration(index=0, cofibration={})
+    visitor.on_trace_surface_representative(surface="groups_by_path", representative="rep")
+    visitor.on_equivalence_surface_row(index=0, row={})


### PR DESCRIPTION
## Summary
- Consolidates the ASPF overlap set into one integration unit: #252, #253, #254, #255.
- Preserves visitor/event-stream architecture while reconciling cross-PR overlap in `aspf_execution_fibration.py`.
- Includes forward remediation for ACP policy violations, strict-coverage gaps, and server lint-helper compatibility drift discovered during integration validation.

## Included PR content
- #252 typed ASPF event stream and visitor compatibility hooks.
- #254 streaming baseline ingestion and witness indexing for equivalence payloads.
- #253 streaming resume-state/delta iterators and server resume loading updates.
- #255 Protocol-based traversal/replay visitor emitters for trace/opportunity/state payloads.

## Integration remediations
- ACP-safe normalization in `aspf_visitors.py` and `aspf_stream.py` (remove sentinel returns/runtime narrowing patterns in deterministic core paths).
- Restored server compatibility helper `_lint_entries_from_lines` while retaining typed lint-decision normalization.
- Removed obsolete opportunity helper paths superseded by visitor emitters.
- Added focused tests for previously uncovered ASPF merge/witness paths and visitor no-op surfaces.
- Refreshed `out/test_evidence.json`.

## Validation
- `scripts/policy_check.py --workflows`
- `scripts/policy_check.py --ambiguity-contract`
- Targeted pytest for ASPF + server resume/lint edges
- `scripts/extract_test_evidence.py --out out/test_evidence.json`
- Full strict coverage gate at 100%

Subsumes #252 #253 #254 #255.
