### PR TITLE
Remove lint-lines compatibility shim in server normalization

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -2415,18 +2415,6 @@ def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:
     return entry.model_dump() if entry is not None else None
 
 
-def _lint_entries_from_lines(lines: Sequence[str]) -> list[dict[str, object]]:
-    decision = LintEntriesDecision(
-        kind="derive_from_lines",
-        lint_lines=tuple(str(line) for line in lines),
-        lint_entries_payload=(),
-    )
-    return cast(
-        list[dict[str, object]],
-        decision.normalize_entries(parse_lint_entry_fn=_parse_lint_line_as_payload),
-    )
-
-
 def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:
     lint_decision = LintEntriesDecision.from_response(response)
     lint_lines = list(lint_decision.lint_lines)

--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -3993,16 +3993,21 @@ def test_execute_impact_query_accepts_git_diff(tmp_path: Path) -> None:
     assert result.get("changes")
 
 
-# gabion:evidence E:call_footprint::tests/test_server_execute_command_edges.py::test_server_lint_normalization_helpers_cover_invalid_rows::server.py::gabion.server._lint_entries_from_lines::server.py::gabion.server._normalize_dataflow_response::server.py::gabion.server._parse_lint_line
+# gabion:evidence E:call_footprint::tests/test_server_execute_command_edges.py::test_server_lint_normalization_helpers_cover_invalid_rows::server.py::gabion.server._normalize_dataflow_response::server.py::gabion.server._parse_lint_line::server.py::gabion.server._parse_lint_line_as_payload
 def test_server_lint_normalization_helpers_cover_invalid_rows() -> None:
     assert server._parse_lint_line("not a lint row") is None
     assert server._parse_lint_line("pkg/mod.py:1:2:   ") is None
-    entries = server._lint_entries_from_lines(
-        [
-            "pkg/mod.py:1:2: DF001 bad",
-            "invalid row",
-        ]
-    )
+    entries = [
+        entry
+        for entry in (
+            server._parse_lint_line_as_payload(line)
+            for line in [
+                "pkg/mod.py:1:2: DF001 bad",
+                "invalid row",
+            ]
+        )
+        if entry is not None
+    ]
     assert entries == [
         {
             "path": "pkg/mod.py",


### PR DESCRIPTION
## Summary
- Removes the temporary `_lint_entries_from_lines` compatibility helper from `server.py`.
- Keeps lint normalization on the explicit typed decision surface (`LintEntriesDecision` + `_parse_lint_line_as_payload`).
- Updates the server edge test to validate the streamlined path directly.
- Refreshes `out/test_evidence.json`.

## Validation
- `scripts/policy_check.py --workflows`
- `scripts/policy_check.py --ambiguity-contract`
- `pytest` for affected lint normalization tests
- evidence refresh (`out/test_evidence.json`)
