### PR TITLE
Normalize ASPF Alt evidence payloads and add ordering-invariance tests

### DIFF
--- a/src/gabion/analysis/aspf_evidence.py
+++ b/src/gabion/analysis/aspf_evidence.py
@@ -1,0 +1,21 @@
+# gabion:boundary_normalization_module
+from __future__ import annotations
+
+from typing import cast
+
+from gabion.runtime import stable_encode
+
+
+def normalize_alt_evidence_payload(evidence: object) -> dict[str, object]:
+    """Canonicalize Alt evidence shape and ordering for ASPF alternatives."""
+
+    payload = evidence if evidence is not None else {}
+    canonical = stable_encode.stable_json_value(
+        payload,
+        source="aspf_evidence.normalize_alt_evidence_payload",
+    )
+    match canonical:
+        case dict() as payload_map:
+            return cast(dict[str, object], payload_map)
+        case _:
+            return {}


### PR DESCRIPTION
### Motivation
- Evidence carriers used by ASPF alts must be canonicalized at the boundary so interning, replay, diffs and snapshots are invariant to non-semantic key/ordering differences.
- There were scattered ad-hoc sorts and potential circularity in normalization; a single dedicated normalizer centralizes the behavior and reduces branchy callsites.

### Description
- Added `normalize_alt_evidence_payload` in `src/gabion/analysis/aspf_evidence.py` to canonicalize evidence shape and deterministic key ordering via `stable_encode.stable_json_value`.
- Enforced normalization on all Alt creation paths by calling the normalizer from `Alt.__post_init__` and delegating `_canonicalize_evidence` to the new helper so both direct `Alt(...)` and `Forest.add_alt(...)` ingress are normalized.
- Kept `Forest.add_alt` interning logic and structural key computation but now uses the normalized evidence for structural identity.
- Added regression tests in `tests/test_aspf.py` exercising direct Alt construction normalization, interning equivalence for nested evidence with different key orders, and `forest.to_json()` invariance under evidence-order permutations; updated `out/test_evidence.json` to reflect new test mappings.

### Testing
- Ran workflow policy checks with `PYTHONPATH=.:src mise exec -- python scripts/policy_check.py --workflows` which completed (the run emitted a non-fatal `mise` network warning while resolving tool metadata but checks completed).
- Ran the ambiguity contract check with `PYTHONPATH=.:src mise exec -- python scripts/policy_check.py --ambiguity-contract`, fixed an initial ACP-003 narrowing issue, and the check passed after adjustment.
- Executed the targeted unit tests with `PYTHONPATH=.:src mise exec -- python -m pytest -o addopts='' tests/test_aspf.py`, and all new and existing ASPF tests passed (`18 passed`).
- Regenerated the evidence carrier with `PYTHONPATH=.:src mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and committed the updated `out/test_evidence.json` to capture the new/shifted test mappings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d34ce3d88324b5f70c9a11bc40bc)