### PR TITLE
Introduce typed ASPF opportunity decisions and emit rewrite_plans

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -495,10 +495,12 @@ def build_opportunities_payload(
         visitor=emitter,
     )
     opportunities = emitter.build_rows()
+    rewrite_plans = emitter.build_rewrite_plans()
     return {
         "format_version": _OPPORTUNITY_FORMAT_VERSION,
         "trace_id": state.trace_id,
         "opportunities": opportunities,
+        "rewrite_plans": rewrite_plans,
     }
 
 

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 import hashlib
 from typing import Mapping, Protocol, cast
 
@@ -205,11 +206,84 @@ class TracePayloadEmitter(NullAspfTraversalVisitor):
         self.surface_representatives[str(surface)] = str(representative)
 
 
+class OpportunityConfidenceProvenance(StrEnum):
+    MORPHISM_WITNESS = "morphism_witness"
+    REPRESENTATIVE_CONFLUENCE = "representative_confluence"
+    INGRESS_OBSERVATION = "ingress_observation"
+
+
+class OpportunityWitnessRequirement(StrEnum):
+    NONE = "none"
+    REPRESENTATIVE_PAIR = "representative_pair"
+    TWO_CELL_WITNESS = "two_cell_witness"
+
+
+class OpportunityActionabilityState(StrEnum):
+    ACTIONABLE = "actionable"
+    OBSERVATIONAL = "observational"
+
+
+@dataclass(frozen=True)
+class OpportunityDecisionProtocol:
+    opportunity_id: str
+    kind: str
+    affected_surfaces: tuple[str, ...]
+    witness_ids: tuple[str, ...]
+    reason: str
+    confidence_provenance: OpportunityConfidenceProvenance
+    witness_requirement: OpportunityWitnessRequirement
+    actionability: OpportunityActionabilityState
+
+    def confidence(self) -> float:
+        score = 0.36
+        if self.confidence_provenance is OpportunityConfidenceProvenance.INGRESS_OBSERVATION:
+            score += 0.14
+        if self.confidence_provenance is OpportunityConfidenceProvenance.REPRESENTATIVE_CONFLUENCE:
+            score += 0.18
+        if self.confidence_provenance is OpportunityConfidenceProvenance.MORPHISM_WITNESS:
+            score += 0.26
+        if self.witness_requirement is OpportunityWitnessRequirement.TWO_CELL_WITNESS:
+            score += 0.14
+        if self.witness_ids:
+            score += min(0.18, 0.06 * len(self.witness_ids))
+        return round(min(score, 0.99), 2)
+
+    def as_row(self) -> JSONObject:
+        return {
+            "opportunity_id": self.opportunity_id,
+            "kind": self.kind,
+            "confidence": self.confidence(),
+            "confidence_provenance": self.confidence_provenance,
+            "witness_requirement": self.witness_requirement,
+            "actionability": self.actionability,
+            "affected_surfaces": list(self.affected_surfaces),
+            "witness_ids": list(self.witness_ids),
+            "reason": self.reason,
+        }
+
+    def as_rewrite_plan(self) -> JSONObject:
+        return {
+            "plan_id": f"rewrite:{self.opportunity_id}",
+            "kind": "aspf_opportunity",
+            "priority": self.confidence(),
+            "actionability": self.actionability,
+            "opportunity_id": self.opportunity_id,
+            "affected_surfaces": list(self.affected_surfaces),
+            "required_witnesses": list(self.witness_ids),
+            "decision_basis": {
+                "confidence_provenance": self.confidence_provenance,
+                "witness_requirement": self.witness_requirement,
+            },
+            "summary": self.reason,
+        }
+
+
 @dataclass
 class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
     _materialize_kinds_by_resume_ref: dict[str, set[str]] = field(default_factory=dict)
     _representative_to_surfaces: dict[str, list[str]] = field(default_factory=dict)
-    _fungible_rows: list[JSONObject] = field(default_factory=list)
+    _representative_witness_ids: dict[str, set[str]] = field(default_factory=dict)
+    _fungible_opportunities: list[OpportunityDecisionProtocol] = field(default_factory=list)
 
     def on_trace_one_cell(self, *, index: int, one_cell: Mapping[str, object]) -> None:
         kind = str(one_cell.get("kind", ""))
@@ -231,6 +305,21 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
     ) -> None:
         self._representative_to_surfaces.setdefault(representative, []).append(surface)
 
+    def on_trace_two_cell_witness(
+        self,
+        *,
+        index: int,
+        witness: Mapping[str, object],
+    ) -> None:
+        witness_id = str(witness.get("witness_id", "")).strip()
+        if not witness_id:
+            return
+        left = str(witness.get("left_representative", "")).strip()
+        right = str(witness.get("right_representative", "")).strip()
+        for representative in (left, right):
+            if representative:
+                self._representative_witness_ids.setdefault(representative, set()).add(witness_id)
+
     def on_equivalence_surface_row(
         self,
         *,
@@ -244,37 +333,44 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
             and bool(surface)
             and witness_id not in (None, "")
         ):
-            self._fungible_rows.append(
-                {
-                    "opportunity_id": f"opp:fungible-substitution:{surface}",
-                    "kind": "fungible_execution_path_substitution",
-                    "confidence": 0.82,
-                    "affected_surfaces": [surface],
-                    "witness_ids": [str(witness_id)],
-                    "reason": "2-cell witness links baseline/current representatives",
-                }
+            self._fungible_opportunities.append(
+                OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:fungible-substitution:{surface}",
+                    kind="fungible_execution_path_substitution",
+                    affected_surfaces=(surface,),
+                    witness_ids=(str(witness_id),),
+                    reason="2-cell witness links baseline/current representatives",
+                    confidence_provenance=OpportunityConfidenceProvenance.MORPHISM_WITNESS,
+                    witness_requirement=OpportunityWitnessRequirement.TWO_CELL_WITNESS,
+                    actionability=OpportunityActionabilityState.ACTIONABLE,
+                )
             )
 
-    def build_rows(self) -> list[JSONObject]:
-        rows: list[JSONObject] = []
+    def _build_decisions(self) -> list[OpportunityDecisionProtocol]:
+        decisions: list[OpportunityDecisionProtocol] = []
         for resume_ref in sort_once(
             self._materialize_kinds_by_resume_ref,
             source="aspf_visitors.OpportunityPayloadEmitter.materialize.resume_ref",
         ):
             kinds = self._materialize_kinds_by_resume_ref[resume_ref]
             fused = int("resume_load" in kinds and "resume_write" in kinds)
-            rows.append(
-                {
-                    "opportunity_id": f"opp:materialize-load-fusion:{resume_ref}",
-                    "kind": ("materialize_load_observed", "materialize_load_fusion")[fused],
-                    "confidence": (0.51, 0.74)[fused],
-                    "affected_surfaces": [],
-                    "witness_ids": [],
-                    "reason": (
+            decisions.append(
+                OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:materialize-load-fusion:{resume_ref}",
+                    kind=("materialize_load_observed", "materialize_load_fusion")[fused],
+                    affected_surfaces=(),
+                    witness_ids=(),
+                    reason=(
                         "resume boundary observed state reference",
                         "resume load and write boundaries share state reference",
                     )[fused],
-                }
+                    confidence_provenance=OpportunityConfidenceProvenance.INGRESS_OBSERVATION,
+                    witness_requirement=OpportunityWitnessRequirement.NONE,
+                    actionability=(
+                        OpportunityActionabilityState.OBSERVATIONAL,
+                        OpportunityActionabilityState.ACTIONABLE,
+                    )[fused],
+                )
             )
 
         for representative in sort_once(
@@ -288,19 +384,46 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
                 )
             )
             digest = hashlib.sha256(representative.encode("utf-8")).hexdigest()[:12]
-            rows.append(
-                {
-                    "opportunity_id": f"opp:reusable-boundary:{digest}",
-                    "kind": "reusable_boundary_artifact",
-                    "confidence": 0.67,
-                    "affected_surfaces": list(surfaces),
-                    "witness_ids": [],
-                    "reason": "multiple semantic surfaces share deterministic representative",
-                }
+            witness_ids = tuple(
+                sort_once(
+                    self._representative_witness_ids.get(representative, set()),
+                    source="aspf_visitors.OpportunityPayloadEmitter.representative_witnesses",
+                )
+            )
+            decisions.append(
+                OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:reusable-boundary:{digest}",
+                    kind="reusable_boundary_artifact",
+                    affected_surfaces=surfaces,
+                    witness_ids=witness_ids,
+                    reason="multiple semantic surfaces share deterministic representative",
+                    confidence_provenance=(
+                        OpportunityConfidenceProvenance.REPRESENTATIVE_CONFLUENCE
+                        if not witness_ids
+                        else OpportunityConfidenceProvenance.MORPHISM_WITNESS
+                    ),
+                    witness_requirement=OpportunityWitnessRequirement.REPRESENTATIVE_PAIR,
+                    actionability=(
+                        OpportunityActionabilityState.OBSERVATIONAL
+                        if len(surfaces) < 2
+                        else OpportunityActionabilityState.ACTIONABLE
+                    ),
+                )
             )
 
-        rows.extend(self._fungible_rows)
-        return sorted(rows, key=lambda item: str(item.get("opportunity_id", "")))
+        decisions.extend(self._fungible_opportunities)
+        return sorted(decisions, key=lambda item: item.opportunity_id)
+
+    def build_rows(self) -> list[JSONObject]:
+        return [decision.as_row() for decision in self._build_decisions()]
+
+    def build_rewrite_plans(self) -> list[JSONObject]:
+        decisions = [
+            decision
+            for decision in self._build_decisions()
+            if decision.actionability is OpportunityActionabilityState.ACTIONABLE
+        ]
+        return [decision.as_rewrite_plan() for decision in decisions]
 
 
 @dataclass

--- a/tests/test_aspf_execution_fibration.py
+++ b/tests/test_aspf_execution_fibration.py
@@ -253,6 +253,13 @@ def test_build_opportunities_payload_emits_materialize_and_fungible_candidates(
     kinds = {str(row.get("kind")) for row in rows if isinstance(row, dict)}
     assert "materialize_load_fusion" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    rewrite_plans = opportunities["rewrite_plans"]
+    assert isinstance(rewrite_plans, list)
+    fungible_plan = next(
+        plan for plan in rewrite_plans if isinstance(plan, dict) and plan.get("opportunity_id") == "opp:fungible-substitution:groups_by_path"
+    )
+    assert fungible_plan["actionability"] == "actionable"
+    assert fungible_plan["required_witnesses"] == ["w:groups-fungible"]
 
 
 # gabion:evidence E:call_footprint::tests/test_aspf_execution_fibration.py::test_finalize_execution_trace_allows_state_object_roundtrip_import::aspf_execution_fibration.py::gabion.analysis.aspf_execution_fibration.finalize_execution_trace

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -79,6 +79,15 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     assert "materialize_load_fusion" in kinds
     assert "reusable_boundary_artifact" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    fungible = next(
+        row for row in rows if isinstance(row, dict) and row.get("kind") == "fungible_execution_path_substitution"
+    )
+    assert fungible["actionability"] == "actionable"
+    assert fungible["confidence_provenance"] == "morphism_witness"
+
+    plans = emitter.build_rewrite_plans()
+    assert plans
+    assert plans[0]["opportunity_id"].startswith("opp:")
 
 
 def test_null_visitor_noop_methods_are_callable() -> None:
@@ -94,3 +103,35 @@ def test_null_visitor_noop_methods_are_callable() -> None:
     visitor.on_trace_cofibration(index=0, cofibration={})
     visitor.on_trace_surface_representative(surface="groups_by_path", representative="rep")
     visitor.on_equivalence_surface_row(index=0, row={})
+
+
+def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
+    emitter = OpportunityPayloadEmitter()
+    replay_trace_payload_to_visitor(
+        trace_payload={
+            "one_cells": [],
+            "surface_representatives": {
+                "groups_by_path": "rep:shared",
+                "rewrite_plans": "rep:shared",
+            },
+            "two_cell_witnesses": [
+                {
+                    "witness_id": "w:2",
+                    "left_representative": "rep:shared",
+                    "right_representative": "rep:baseline",
+                },
+                {
+                    "witness_id": "w:1",
+                    "left_representative": "rep:shared",
+                    "right_representative": "rep:legacy",
+                },
+            ],
+            "cofibration_witnesses": [],
+        },
+        visitor=emitter,
+    )
+
+    plans = emitter.build_rewrite_plans()
+    reusable = next(plan for plan in plans if plan["opportunity_id"].startswith("opp:reusable-boundary:"))
+    assert reusable["required_witnesses"] == ["w:1", "w:2"]
+    assert reusable["priority"] == 0.74


### PR DESCRIPTION
### Motivation

- Surface ASPF-derived opportunities as typed decision objects so downstream planners can act deterministically on provenance and witness evidence.
- Replace ad-hoc fixed confidence constants with witness-derived scoring tied to explicit morphism/representative evidence to improve decision fidelity.
- Project actionable opportunities into the existing planning surface (`rewrite_plans`) instead of only emitting JSON opportunity rows so orchestration can consume them directly.
- Provide tests that ensure 2-cell witnesses deterministically influence plan priority and required-witness lists.

### Description

- Add enums and a frozen dataclass `OpportunityDecisionProtocol` with `confidence_provenance`, `witness_requirement`, and `actionability` and a computed `confidence()` in `src/gabion/analysis/aspf_visitors.py`.
- Replace previous literal opportunity rows with a decision pipeline in `OpportunityPayloadEmitter` that collects representative-level witness ids, builds typed `OpportunityDecisionProtocol` instances, and exposes `build_rows()` and `build_rewrite_plans()` projection methods in `src/gabion/analysis/aspf_visitors.py`.
- Include the actionable rewrite-plan projection in the ASPF final payload by returning `rewrite_plans` from `build_opportunities_payload` in `src/gabion/analysis/aspf_execution_fibration.py` so planners can consume opportunities directly.
- Extend tests in `tests/test_aspf_visitors.py` and `tests/test_aspf_execution_fibration.py` to assert `actionability` and `confidence_provenance` on emitted rows, that `build_rewrite_plans()` emits actionable plans, and that 2-cell witness ordering produces deterministic `required_witnesses` and `priority` outcomes; refresh `out/test_evidence.json` to reflect the test surface changes.

### Testing

- Ran policy checks with `scripts/policy_check.py --workflows` and `scripts/policy_check.py --ambiguity-contract` (invoked via `mise exec` with `PYTHONPATH=src:.`) and they completed successfully.
- Ran the targeted pytest invocation `python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py` and the test suite passed (15 tests passed).
- Re-extracted test evidence with `python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to reflect the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d36f4a188324a256c83c0ea262b9)