### PR TITLE
Introduce TC SIGv2 Agda decomposition with compatibility shell and dual-tracked CONSTRv2/GLUEv2

### DIFF
--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTRv2.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTRv2.agda
@@ -1,0 +1,67 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.CONSTRv2 where
+
+open import Agda.Builtin.List using (List; []; _∷_)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Nat using (Nat)
+open import Agda.Builtin.Bool using (Bool; true; false)
+
+open import UniversalCurve.TC.SIGv2
+
+mkPoint : String → String → TracePoint
+mkPoint span phase = mkTracePoint span phase
+
+requiredKey : String → PayloadKey
+requiredKey key = mkPayloadKey key true
+
+optionalKey : String → PayloadKey
+optionalKey key = mkPayloadKey key false
+
+surface : String → Nat → CommandSurface
+surface name since = mkCommandSurface name since
+
+kanSandwich : String → String → KanSandwich
+kanSandwich ingress egress = mkKanSandwich ingress egress
+
+stratifiedSite : String → Nat → StratifiedSite
+stratifiedSite name strata = mkStratifiedSite name strata
+
+quantaleMetric : String → String → QuantaleMetric
+quantaleMetric carrier law = mkQuantaleMetric carrier law
+
+cotower : Nat → String → Cotower
+cotower height carrier = mkCotower height carrier
+
+towerOps : String → String → TowerOps
+towerOps compose contract = mkTowerOps compose contract
+
+stabilization : String → Nat → Stabilization
+stabilization witness epoch = mkStabilization witness epoch
+
+buildTraceContractV2 :
+  List TracePoint →
+  List PayloadKey →
+  List CommandSurface →
+  KanSandwich →
+  StratifiedSite →
+  QuantaleMetric →
+  Cotower →
+  TowerOps →
+  Stabilization →
+  TraceContractV2
+buildTraceContractV2 points keys surfaces ks site metric tower ops stable =
+  mkTraceContractV2 points keys surfaces ks site metric tower ops stable
+
+sampleContractV2 : TraceContractV2
+sampleContractV2 =
+  buildTraceContractV2
+    (mkPoint "aspf.emit" "analysis" ∷ mkPoint "dto.encode" "projection" ∷ [])
+    (requiredKey "entries" ∷ optionalKey "metadata" ∷ [])
+    (surface "gabion check-delta" 1 ∷ surface "gabion dataflow-audit" 1 ∷ [])
+    (kanSandwich "runtime ingress" "evidence egress")
+    (stratifiedSite "ambiguity lattice" 3)
+    (quantaleMetric "evidence-distance" "monotone-join")
+    (cotower 2 "continuation snapshots")
+    (towerOps "compose-carriers" "contract-carriers")
+    (stabilization "fixed-point witness" 1)

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.GLUEv2 where
+
+open import Agda.Builtin.List using (List)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Bool using (Bool; false)
+
+open import UniversalCurve.TC.SIGv2
+open import UniversalCurve.TC.CONSTRv2
+
+record RuntimeMapping : Set where
+  constructor mkRuntimeMapping
+  field
+    tcConcept : String
+    runtimeSurface : String
+    bridgeCoverage : String
+
+record BridgePlanV2 : Set where
+  constructor mkBridgePlanV2
+  field
+    contract : TraceContractV2
+    mappings : List RuntimeMapping
+    productionEnforced : Bool
+
+mkMapping : String → String → String → RuntimeMapping
+mkMapping concept surface coverage = mkRuntimeMapping concept surface coverage
+
+bridgePlanV2 : List RuntimeMapping → BridgePlanV2
+bridgePlanV2 maps = mkBridgePlanV2 sampleContractV2 maps false

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda
@@ -2,35 +2,6 @@
 
 module UniversalCurve.TC.SIG where
 
-open import Agda.Builtin.List using (List)
-open import Agda.Builtin.String using (String)
-open import Agda.Builtin.Nat using (Nat)
-open import Agda.Builtin.Bool using (Bool)
-
--- TC (Trace Contract) signatures are intentionally minimal for research staging.
--- They model shape and labels only; runtime enforcement lives in Gabion handlers.
-
-record TracePoint : Set where
-  constructor mkTracePoint
-  field
-    spanLabel : String
-    phaseLabel : String
-
-record PayloadKey : Set where
-  constructor mkPayloadKey
-  field
-    keyName : String
-    required : Bool
-
-record CommandSurface : Set where
-  constructor mkCommandSurface
-  field
-    commandName : String
-    stableSince : Nat
-
-record TraceContract : Set where
-  constructor mkTraceContract
-  field
-    points : List TracePoint
-    payloadKeys : List PayloadKey
-    commandSurfaces : List CommandSurface
+-- Compatibility shell: retain legacy import path while re-exporting TC v2
+-- signatures and compatibility carriers.
+open import UniversalCurve.TC.SIGv2 public

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda
@@ -1,0 +1,93 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.SIGv2 where
+
+open import Agda.Builtin.List using (List)
+open import Agda.Builtin.String using (String)
+open import Agda.Builtin.Nat using (Nat)
+open import Agda.Builtin.Bool using (Bool)
+
+-- TC v2 introduces an explicit decomposition of contract concerns into
+-- sub-records that can be mapped independently to runtime surfaces.
+
+record TracePoint : Set where
+  constructor mkTracePoint
+  field
+    spanLabel : String
+    phaseLabel : String
+
+record PayloadKey : Set where
+  constructor mkPayloadKey
+  field
+    keyName : String
+    required : Bool
+
+record CommandSurface : Set where
+  constructor mkCommandSurface
+  field
+    commandName : String
+    stableSince : Nat
+
+record KanSandwich : Set where
+  constructor mkKanSandwich
+  field
+    ingressBoundary : String
+    egressBoundary : String
+
+record StratifiedSite : Set where
+  constructor mkStratifiedSite
+  field
+    siteName : String
+    stratumCount : Nat
+
+record QuantaleMetric : Set where
+  constructor mkQuantaleMetric
+  field
+    metricCarrier : String
+    metricLaw : String
+
+record Cotower : Set where
+  constructor mkCotower
+  field
+    cotowerHeight : Nat
+    cotowerCarrier : String
+
+record TowerOps : Set where
+  constructor mkTowerOps
+  field
+    composeOp : String
+    contractOp : String
+
+record Stabilization : Set where
+  constructor mkStabilization
+  field
+    witnessName : String
+    stabilizedAtEpoch : Nat
+
+record TraceContractV2 : Set where
+  constructor mkTraceContractV2
+  field
+    points : List TracePoint
+    payloadKeys : List PayloadKey
+    commandSurfaces : List CommandSurface
+    kanSandwich : KanSandwich
+    stratifiedSite : StratifiedSite
+    quantaleMetric : QuantaleMetric
+    cotower : Cotower
+    towerOps : TowerOps
+    stabilization : Stabilization
+
+-- Compatibility record preserved for existing imports that still target SIG.
+record TraceContract : Set where
+  constructor mkTraceContract
+  field
+    points : List TracePoint
+    payloadKeys : List PayloadKey
+    commandSurfaces : List CommandSurface
+
+forgetV2 : TraceContractV2 → TraceContract
+forgetV2 contract =
+  mkTraceContract
+    (TraceContractV2.points contract)
+    (TraceContractV2.payloadKeys contract)
+    (TraceContractV2.commandSurfaces contract)

--- a/in/universal-curve-lab-bundle/docs/tc-design-bridge.md
+++ b/in/universal-curve-lab-bundle/docs/tc-design-bridge.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: universal_curve_lab_tc_design_bridge
 doc_role: research_mapping
@@ -35,6 +35,24 @@ Gabion runtime surfaces so experiments can stay aligned with practical outputs.
 | `CommandSurface` (`SIG`) | `gabion` command outputs (e.g., check/audit style commands) | Treats command names + maturity epoch as a typed surface descriptor. |
 | Constructor helpers (`CONSTR`) | Runtime payload assembly pathways | Mirrors how handlers build output records, but currently only as lab constructors. |
 | `BridgePlan` (`GLUE`) | Cross-surface traceability docs and prototype adapters | Encodes mapping bundles and an explicit non-production-enforced flag. |
+
+## SIGv2 decomposition to runtime surfaces
+
+`SIGv2` introduces sub-records so bridge coverage can be tracked field-by-field while
+`SIG`, `CONSTR`, and `GLUE` remain compatibility modules.
+
+| `SIGv2` concept | Closest runtime surface today | Bridge coverage status |
+| --- | --- | --- |
+| `KanSandwich` | Ingress validation + evidence egress boundaries in command handlers | Mapped conceptually; **not runtime-enforced.** |
+| `StratifiedSite` | Layered ambiguity/correction semantics in policy and docs | Documented in governance language; **not runtime-enforced.** |
+| `QuantaleMetric` | Evidence-drift / projection-distance ideas in audit outputs | Descriptive naming only; **not runtime-enforced.** |
+| `Cotower` | Snapshot/baseline continuity across check-delta style runs | Operationally adjacent only; **not runtime-enforced.** |
+| `TowerOps` | Composition/normalization steps around payload shaping | No first-class runtime carrier; **not runtime-enforced.** |
+| `Stabilization` | Fixed-point style convergence expectations in policy loop docs | Conceptual traceability only; **not runtime-enforced.** |
+
+The v2 modules (`CONSTRv2.agda`, `GLUEv2.agda`) intentionally remain dual-tracked
+with the existing modules until each `SIGv2` field has explicit bridge coverage
+captured in this document and any future runtime contract docs.
 
 ## Intended usage
 


### PR DESCRIPTION
### Motivation
- Introduce a decomposed TC (Trace Contract) v2 surface so individual contract concerns can be mapped and evolved field-by-field. 
- Preserve existing runtime compatibility and avoid breaking current imports by keeping the legacy `SIG`, `CONSTR`, and `GLUE` surfaces available while exposing the v2 types for migration.

### Description
- Added `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda` defining sub-records `KanSandwich`, `StratifiedSite`, `QuantaleMetric`, `Cotower`, `TowerOps`, and `Stabilization` plus `TraceContractV2` and a compatibility projection `forgetV2`.
- Converted `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIG.agda` into a compatibility shell that `open import`s and re-exports `UniversalCurve.TC.SIGv2` so existing imports continue to work.
- Added dual-tracked modules `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/CONSTRv2.agda` and `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda` implementing v2 constructors/builders and `BridgePlanV2` while leaving the original `CONSTR.agda` and `GLUE.agda` in place.
- Updated `in/universal-curve-lab-bundle/docs/tc-design-bridge.md` (bumped `doc_revision`) with a new "SIGv2 decomposition to runtime surfaces" section that maps v2 concepts to current runtime surfaces and explicitly labels gaps as **not runtime-enforced**.

### Testing
- Ran `git diff --check` which completed with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3fd30a48324beada8df9941e1f4)