### PR TITLE
Normalize dataflow cache identities to canonical _CacheIdentity wrapper

### DIFF
--- a/tests/test_dataflow_audit_coverage_gaps.py
+++ b/tests/test_dataflow_audit_coverage_gaps.py
@@ -3817,7 +3817,10 @@ def test_missing_resume_and_plan_branches(tmp_path: Path) -> None:
     max_variants = da._ANALYSIS_INDEX_RESUME_MAX_VARIANTS
     previous_payload = {
         da._ANALYSIS_INDEX_RESUME_VARIANTS_KEY: {
-            f"id_{idx}": {"format_version": 1, "index_cache_identity": f"id_{idx}"}
+            f"aspf:sha1:{idx:040x}": {
+                "format_version": 1,
+                "index_cache_identity": f"aspf:sha1:{idx:040x}",
+            }
             for idx in range(max_variants + 2)
         }
     }
@@ -4189,14 +4192,15 @@ def test_additional_dataflow_helper_branch_edges(tmp_path: Path) -> None:
     assert function_info_empty_reasons is not None
     assert function_info_empty_reasons.decision_surface_reasons == {}
 
+    canonical_id = "aspf:sha1:1111111111111111111111111111111111111111"
     variants = da._analysis_index_resume_variants(
         {
             da._ANALYSIS_INDEX_RESUME_VARIANTS_KEY: {
-                "id-1": {"format_version": 1, "value": "ok"}
+                canonical_id: {"format_version": 1, "value": "ok"}
             }
         }
     )
-    assert variants["id-1"]["value"] == "ok"
+    assert variants[canonical_id]["value"] == "ok"
 
     assert (
         da._analysis_index_resume_variants(
@@ -4211,8 +4215,8 @@ def test_additional_dataflow_helper_branch_edges(tmp_path: Path) -> None:
         by_qual={},
         symbol_table=da.SymbolTable(),
         class_index={},
-        index_cache_identity="index",
-        projection_cache_identity="projection",
+        index_cache_identity="aspf:sha1:2222222222222222222222222222222222222222",
+        projection_cache_identity="aspf:sha1:3333333333333333333333333333333333333333",
     )
     stage_result = da._analysis_index_stage_cache(
         analysis_index,


### PR DESCRIPTION
### Motivation
- Reduce ambiguity and runtime branching in cache identity handling by consolidating legacy 40-hex digest fallbacks into a single canonical identity form and converting at boundaries only.
- Provide a typed identity representation for use in stage-cache keys, resume variants, and projection metadata to make control flow and equality explicit and easier to reason about.
- Preserve read compatibility with older artifacts while ensuring new writes always emit canonical identities.

### Description
- Introduced a frozen dataclass `_CacheIdentity` with `from_digest` and `from_boundary` helpers and a canonical `aspf:sha1:<digest>` prefix and validation regex in `src/gabion/analysis/dataflow_audit.py`.
- Changed `_canonical_cache_identity` to return `_CacheIdentity` and updated stage-cache key construction (`_parse_stage_cache_key`, `_index_stage_cache_identity`, `_projection_stage_cache_identity`) to use `identity.value` for cache keys.
- Replaced alias-set matching logic with `from_boundary` parsing and direct equality checks in `_cache_identity_matches`, and simplified `_cache_identity_aliases` to emit canonical value only (empty when invalid).
- Reworked resume variant handling: `_analysis_index_resume_variant_payload` normalizes legacy identities at read boundary, `_analysis_index_resume_variants` normalizes variant keys to canonical values, `_with_analysis_index_resume_variants` enforces canonical identities and writes canonical values into payloads, and `_resume_variant_for_identity` now accepts a `_CacheIdentity` and performs direct lookup.
- Updated `_serialize_analysis_index_resume_payload` and `_load_analysis_index_resume_payload` to require/compare canonical identities (via `_CacheIdentity.from_boundary`) and to use resume-variant lookup against canonical keys.
- Updated tests to assert canonical-only write semantics while keeping legacy-read compatibility, and refreshed the test evidence artifact (`out/test_evidence.json`).

### Testing
- Ran policy checks: `scripts/policy_check.py --workflows` and `scripts/policy_check.py --ambiguity-contract`, both completed successfully after the refactor.
- Ran targeted pytest for modified surfaces: `tests/test_dataflow_audit_helpers.py` and `tests/test_dataflow_audit_coverage_gaps.py` (via `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts=''`), which passed; selected runs reported `16 passed` for helper-focused selection and `2 passed` for coverage-gap selection during development.
- Ran the full test selection for the audit suite (`PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/test_dataflow_audit_helpers.py tests/test_dataflow_audit_coverage_gaps.py`) and observed all selected tests and the broader collection pass (`253 passed` in the final run).
- Re-generated evidence via `scripts/extract_test_evidence.py` which completed successfully and updated `out/test_evidence.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d345d9888324beb875262130a2a7)