### PR TITLE
Migrate ambiguity/deadline projections to SuiteSite carriers

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -6749,6 +6749,8 @@ def _suite_order_relation(
     alt_degree: Counter[NodeId] = Counter()
     for alt in forest.alts:
         check_deadline()
+        if alt.kind == "SpecFacet":
+            continue
         for node_id in alt.inputs:
             check_deadline()
             alt_degree[node_id] += 1
@@ -6810,6 +6812,20 @@ def _suite_order_relation(
         suite_index[
             (path, qual, suite_kind, span_line, span_col, span_end_line, span_end_col)
         ] = node_id
+    relation = sort_once(
+        relation,
+        key=lambda row: (
+            int(row.get("depth", 0) or 0),
+            int(row.get("complexity", 0) or 0),
+            str(row.get("suite_path", "") or ""),
+            str(row.get("suite_qual", "") or ""),
+            int(row.get("span_line", -1) or -1),
+            int(row.get("span_col", -1) or -1),
+            int(row.get("span_end_line", -1) or -1),
+            int(row.get("span_end_col", -1) or -1),
+        ),
+        source="src/gabion/analysis/dataflow_audit.py:_suite_order_relation.relation",
+    )
     return relation, suite_index
 
 
@@ -6860,18 +6876,8 @@ def _materialize_suite_order_spec(
 
 def _ambiguity_suite_relation(
     forest: Forest,
-) -> tuple[list[dict[str, JSONValue]], dict[tuple[str, str], NodeId]]:
+) -> list[dict[str, JSONValue]]:
     relation: list[dict[str, JSONValue]] = []
-    function_index: dict[tuple[str, str], NodeId] = {}
-    for node_id, node in forest.nodes.items():
-        check_deadline()
-        if node_id.kind != "FunctionSite":
-            continue
-        path = str(node.meta.get("path", "") or "")
-        qual = str(node.meta.get("qual", "") or "")
-        if not path or not qual:
-            continue
-        function_index[(path, qual)] = node_id
     for alt in forest.alts:
         check_deadline()
         if alt.kind != "CallCandidate":
@@ -6916,18 +6922,7 @@ def _ambiguity_suite_relation(
                         "phase": str(alt.evidence.get("phase", "") or ""),
                     }
                 )
-    return relation, function_index
-
-
-def _ambiguity_suite_row_to_site(
-    row: Mapping[str, JSONValue],
-    function_index: Mapping[tuple[str, str], NodeId],
-):
-    path = str(row.get("suite_path", "") or "")
-    qual = str(row.get("suite_qual", "") or "")
-    if not path or not qual:
-        return None
-    return function_index.get((path, qual))
+    return relation
 
 
 def _ambiguity_suite_row_to_suite(
@@ -6972,7 +6967,7 @@ def _materialize_ambiguity_suite_agg_spec(
     *,
     forest: Forest,
 ) -> None:
-    relation, function_index = _ambiguity_suite_relation(forest)
+    relation = _ambiguity_suite_relation(forest)
     if not relation:
         return
     projected = apply_spec(AMBIGUITY_SUITE_AGG_SPEC, relation)
@@ -6980,7 +6975,7 @@ def _materialize_ambiguity_suite_agg_spec(
         spec=AMBIGUITY_SUITE_AGG_SPEC,
         projected=projected,
         forest=forest,
-        row_to_site=lambda row: _ambiguity_suite_row_to_site(row, function_index),
+        row_to_site=lambda row: _ambiguity_suite_row_to_suite(row, forest),
     )
 
 
@@ -6988,7 +6983,7 @@ def _materialize_ambiguity_virtual_set_spec(
     *,
     forest: Forest,
 ) -> None:
-    relation, _ = _ambiguity_suite_relation(forest)
+    relation = _ambiguity_suite_relation(forest)
     if not relation:
         return
 
@@ -7038,6 +7033,8 @@ def _summarize_deadline_obligations(
                 "detail": str(entry.get("detail", "") or ""),
                 "site_path": path,
                 "site_function": function,
+                "site_suite_id": str(site.get("suite_id", "") or ""),
+                "site_suite_kind": str(site.get("suite_kind", "") or ""),
                 "span_line": line,
                 "span_col": col,
                 "span_end_line": end_line,
@@ -7054,6 +7051,7 @@ def _summarize_deadline_obligations(
             return None
         span = _spec_row_span(row)
         path_name = Path(path).name
+        suite_kind = str(row.get("site_suite_kind", "") or "")
         require_not_none(
             span,
             reason="projection spec row missing span",
@@ -7061,6 +7059,8 @@ def _summarize_deadline_obligations(
             path=path,
             function=function,
         )
+        if suite_kind:
+            return forest.add_suite_site(path_name, function, suite_kind, span=span)
         return forest.add_site(path_name, function, span)
 
     _materialize_projection_spec_rows(

--- a/src/gabion/analysis/projection_registry.py
+++ b/src/gabion/analysis/projection_registry.py
@@ -179,6 +179,11 @@ AMBIGUITY_SUITE_AGG_SPEC = ProjectionSpec(
                 "fields": [
                     "suite_path",
                     "suite_qual",
+                    "suite_kind",
+                    "span_line",
+                    "span_col",
+                    "span_end_line",
+                    "span_end_col",
                     "kind",
                     "phase",
                 ]
@@ -190,6 +195,11 @@ AMBIGUITY_SUITE_AGG_SPEC = ProjectionSpec(
                 "fields": [
                     "suite_path",
                     "suite_qual",
+                    "suite_kind",
+                    "span_line",
+                    "span_col",
+                    "span_end_line",
+                    "span_end_col",
                     "kind",
                     "phase",
                 ]
@@ -201,6 +211,9 @@ AMBIGUITY_SUITE_AGG_SPEC = ProjectionSpec(
                 "by": [
                     "suite_path",
                     "suite_qual",
+                    "suite_kind",
+                    "span_line",
+                    "span_col",
                     "kind",
                     "phase",
                 ]

--- a/tests/test_ambiguity_helpers.py
+++ b/tests/test_ambiguity_helpers.py
@@ -268,6 +268,9 @@ def test_ambiguity_suite_agg_materializes_spec_facets(tmp_path: Path) -> None:
     assert any(
         alt.kind == "SpecFacet"
         and alt.evidence.get("spec_name") == "ambiguity_suite_agg"
+        and forest.nodes.get(alt.inputs[1], None) is not None
+        and forest.nodes[alt.inputs[1]].kind == "SuiteSite"
+        and forest.nodes[alt.inputs[1]].meta.get("suite_kind") == "call"
         for alt in forest.alts
     )
 


### PR DESCRIPTION
### Motivation

- Remove function-level fallback/aggregation for ambiguity and deadline projections by reifying obligations on the SuiteSite carrier so suite-scoped facets are first-class and legacy aggregation remains a compatibility projection.
- Stabilize the `suite_order` projection as a quotient reification that is idempotent under re-internment and deterministic across insertion order to prove parity with legacy function-level outputs.
- Add regression harnesses to prove quotient/internment parity and to protect carrier-level semantics during migration.

### Description

- Reworked `src/gabion/analysis/dataflow_audit.py` to attach ambiguity aggregation and deadline summary projection rows to `SuiteSite` carriers directly, and to emit suite metadata (`site_suite_kind`/`site_suite_id`) for projection rows so boundary adapters can still fall back to function sites when required.
- Hardened `suite_order` materialization by excluding existing `SpecFacet` alts from alt-degree complexity counting and by deterministically sorting relation rows before projection to remove insertion-order nondeterminism and ensure reinternment idempotence (`_suite_order_relation`, `_materialize_suite_order_spec`).
- Updated projection schema in `src/gabion/analysis/projection_registry.py` (`AMBIGUITY_SUITE_AGG_SPEC`) to include suite identity/span fields (`suite_kind`, `span_line`, `span_col`, `span_end_line`, `span_end_col`) so projection outputs remain a compatibility view while carrier attachments are suite-native.
- Added regression tests and assertions in `tests/test_deadline_coverage.py` and `tests/test_ambiguity_helpers.py` to validate: suite-site binding for ambiguity facets, suite-kind-aware deadline spec materialization, `suite_order` idempotence under repeated materialization, and parity under suite insertion order.
- Refreshed `out/test_evidence.json` to record updated test-evidence mappings after test-surface changes.

### Testing

- Ran policy checks: `PYTHONPATH=src:. mise exec -- python scripts/policy_check.py --workflows` and `--ambiguity-contract`, both executed (note: `mise` emitted a network/tool-resolution warning but checks ran).
- Executed targeted pytest runs for the new regressions, first running the four newly-added/targeted tests which initially exposed insertion-order drift, then after fixes re-ran: `PYTHONPATH=src pytest -q -o addopts='' tests/test_ambiguity_helpers.py::test_ambiguity_suite_agg_materializes_spec_facets tests/test_deadline_coverage.py::test_deadline_summary_materializes_spec_facets tests/test_deadline_coverage.py::test_suite_order_projection_is_quotient_idempotent_under_reinternment tests/test_deadline_coverage.py::test_suite_order_projection_parity_under_suite_insertion_order` which passed after the stability fixes.
- Ran broader module tests: `PYTHONPATH=src pytest -q -o addopts='' tests/test_ambiguity_helpers.py tests/test_deadline_coverage.py` which completed successfully (`51 passed`).
- Ran test-evidence extraction `PYTHONPATH=src:. mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`, and updated `out/test_evidence.json` to reflect the new test mappings (diff intentionally committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3995cb08324a84e3a2ddfed3a9f)