### PR TITLE
Add SliceBridge-based stabilization interfaces in Agda TC v2

### DIFF
--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.GLUEv2 where
+
+open import Agda.Builtin.Equality using (_≡_)
+open import Data.Sum using (_⊎_)
+
+open import UniversalCurve.TC.SIGv2
+
+StabilizationProvenance : Set
+StabilizationProvenance = NonMaxCoverWitness ⊎ Boundary ⊎ Unknown
+
+record GLUEv2 : Set₁ where
+  constructor mkGLUEv2
+  field
+    bridge : SliceBridge
+    admittedImage : SliceBridge.Hist⋆Slice bridge → Set
+    refine : SliceBridge.Hist⋆Slice bridge → SliceBridge.Hist⋆Slice bridge
+    gateProvenance :
+      (s₀ : SliceBridge.Hist₀Slice bridge) →
+      (p : StabilizationProvenance) →
+      admittedImage (refine (SliceBridge.embed bridge s₀)) →
+      StabilizationProvenance
+    gateProvenance-preserved :
+      (s₀ : SliceBridge.Hist₀Slice bridge) →
+      (p : StabilizationProvenance) →
+      (admitted : admittedImage (refine (SliceBridge.embed bridge s₀))) →
+      gateProvenance s₀ p admitted ≡ p

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.SIGv2 where
+
+open import Agda.Builtin.Equality using (_≡_)
+
+record SliceBridge : Set₁ where
+  constructor mkSliceBridge
+  field
+    Hist₀Slice : Set
+    Hist⋆Slice : Set
+    embed : Hist₀Slice → Hist⋆Slice
+    project : Hist⋆Slice → Hist₀Slice
+    project-embed : (s₀ : Hist₀Slice) → project (embed s₀) ≡ s₀
+
+record NonMaxCoverWitness : Set where
+  constructor mkNonMaxCoverWitness
+
+record Boundary : Set where
+  constructor mkBoundary
+
+record Unknown : Set where
+  constructor mkUnknown

--- a/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/Stabilization.agda
+++ b/in/universal-curve-lab-bundle/agda/UniversalCurve/TC/Stabilization.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --safe #-}
+
+module UniversalCurve.TC.Stabilization where
+
+open import Agda.Builtin.Equality using (_≡_)
+
+open import UniversalCurve.TC.SIGv2
+open import UniversalCurve.TC.GLUEv2
+
+horizon :
+  (bridge : SliceBridge) →
+  SliceBridge.Hist₀Slice bridge →
+  SliceBridge.Hist⋆Slice bridge
+horizon bridge s₀ = SliceBridge.embed bridge s₀
+
+horizon-provenance :
+  (glue : GLUEv2) →
+  (s₀ : SliceBridge.Hist₀Slice (GLUEv2.bridge glue)) →
+  (p : StabilizationProvenance) →
+  (admitted : GLUEv2.admittedImage glue
+    (GLUEv2.refine glue (horizon (GLUEv2.bridge glue) s₀))) →
+  GLUEv2.gateProvenance glue s₀ p admitted ≡ p
+horizon-provenance glue s₀ p admitted =
+  GLUEv2.gateProvenance-preserved glue s₀ p admitted


### PR DESCRIPTION
### Motivation
- Make slice embedding/projection between `Hist₀` and `Hist⋆` a first-class, verifiable boundary object to avoid placeholder-style shape assumptions. 
- Ensure stabilization provenance is preserved across refinement/admitted-image gating so horizon memory cannot be erased by refinement mappings.
- Refactor horizon to consume an explicit bridge record to centralize boundary normalization and enable a single decision surface for projection/embedding laws.

### Description
- Added `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/SIGv2.agda` defining the `SliceBridge` record with `Hist₀Slice`, `Hist⋆Slice`, `embed`, `project`, and the round-trip law `project-embed`, and added witness carrier records `NonMaxCoverWitness`, `Boundary`, and `Unknown`.
- Added `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/GLUEv2.agda` defining `StabilizationProvenance = NonMaxCoverWitness ⊎ Boundary ⊎ Unknown` and the `GLUEv2` record which carries a `bridge`, `admittedImage`, `refine`, and a `gateProvenance` function plus `gateProvenance-preserved` proof that the provenance is preserved through the admitted/refine flow.
- Added `in/universal-curve-lab-bundle/agda/UniversalCurve/TC/Stabilization.agda` refactoring `horizon` to accept a `SliceBridge` and returning `SliceBridge.Hist⋆Slice`, and added `horizon-provenance` which reuses the `GLUEv2` preservation witness.

### Testing
- Checked `agda --version` to try to typecheck Agda files but Agda is not installed in this environment (`agda: command not found`).
- Ran `mise trust` to allow repo tooling (succeeded), but `mise exec -- python scripts/policy_check.py --workflows` failed because the pinned Python toolchain could not be provisioned in this environment.
- Ran fallback `PYTHONPATH=src python3 scripts/policy_check.py --workflows` and `--ambiguity-contract` which failed due to missing Python dependency `libcst` in the environment.
- Attempted targeted test run `PYTHONPATH=src python3 -m pytest tests -k universal_curve` which failed because `pytest` is not available in this environment.
- No Agda typechecking or in-repo automated policy checks completed successfully due to missing external toolchain/dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d4051b208324861ee417b7135fec)