### PR TITLE
Unify ASPF payload replay behind canonical event visitor adapters

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -49,8 +49,8 @@ from .aspf_visitors import (
     OpportunityPayloadEmitter,
     StatePayloadEmitter,
     TracePayloadEmitter,
-    replay_equivalence_payload_to_visitor,
-    replay_trace_payload_to_visitor,
+    adapt_event_log_reader_iterator_to_visitor,
+    adapt_live_event_stream_to_visitor,
 )
 
 DEFAULT_PHASE1_SEMANTIC_SURFACES: tuple[str, ...] = (
@@ -369,7 +369,22 @@ def build_trace_payload(state: AspfExecutionTraceState) -> JSONObject:
         one_cells_payload.append(one_cell_payload)
 
     emitter = TracePayloadEmitter()
-    replay_trace_payload_to_visitor(trace_payload=replay_payload, visitor=emitter)
+    adapt_live_event_stream_to_visitor(
+        one_cells=cast(list[Mapping[str, object]], replay_payload["one_cells"]),
+        two_cell_witnesses=cast(
+            list[Mapping[str, object]],
+            replay_payload["two_cell_witnesses"],
+        ),
+        cofibration_witnesses=cast(
+            list[Mapping[str, object]],
+            replay_payload["cofibration_witnesses"],
+        ),
+        surface_representatives=cast(
+            Mapping[str, str],
+            replay_payload["surface_representatives"],
+        ),
+        visitor=emitter,
+    )
     return {
         "format_version": _TRACE_FORMAT_VERSION,
         "trace_id": state.trace_id,
@@ -486,12 +501,28 @@ def build_opportunities_payload(
     equivalence_payload: Mapping[str, object],
 ) -> JSONObject:
     emitter = OpportunityPayloadEmitter()
-    replay_trace_payload_to_visitor(
-        trace_payload=build_trace_payload(state),
+    trace_payload = build_trace_payload(state)
+    adapt_live_event_stream_to_visitor(
+        one_cells=cast(list[Mapping[str, object]], trace_payload["one_cells"]),
+        two_cell_witnesses=cast(
+            list[Mapping[str, object]],
+            trace_payload["two_cell_witnesses"],
+        ),
+        cofibration_witnesses=cast(
+            list[Mapping[str, object]],
+            trace_payload["cofibration_witnesses"],
+        ),
+        surface_representatives=cast(
+            Mapping[str, str],
+            trace_payload["surface_representatives"],
+        ),
         visitor=emitter,
     )
-    replay_equivalence_payload_to_visitor(
-        equivalence_payload=equivalence_payload,
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=cast(
+            list[Mapping[str, object]],
+            equivalence_payload.get("surface_table", []),
+        ),
         visitor=emitter,
     )
     opportunities = emitter.build_rows()

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -6,8 +6,8 @@ from gabion.analysis.aspf import Alt, Forest, Node
 from gabion.analysis.aspf_visitors import (
     NullAspfTraversalVisitor,
     OpportunityPayloadEmitter,
-    replay_equivalence_payload_to_visitor,
-    replay_trace_payload_to_visitor,
+    adapt_event_log_reader_iterator_to_visitor,
+    adapt_live_event_stream_to_visitor,
     traverse_forest_to_visitor,
 )
 
@@ -40,37 +40,33 @@ def test_traverse_forest_to_visitor_uses_deterministic_order() -> None:
 
 def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     emitter = OpportunityPayloadEmitter()
-    replay_trace_payload_to_visitor(
-        trace_payload={
-            "one_cells": [
-                {
-                    "kind": "resume_load",
-                    "metadata": {"import_state_path": "state/a.json"},
-                },
-                {
-                    "kind": "resume_write",
-                    "metadata": {"state_path": "state/a.json"},
-                },
-            ],
-            "surface_representatives": {
-                "violation_summary": "rep:b",
-                "groups_by_path": "rep:a",
+    adapt_live_event_stream_to_visitor(
+        one_cells=[
+            {
+                "kind": "resume_load",
+                "metadata": {"import_state_path": "state/a.json"},
             },
-            "two_cell_witnesses": [],
-            "cofibration_witnesses": [],
+            {
+                "kind": "resume_write",
+                "metadata": {"state_path": "state/a.json"},
+            },
+        ],
+        surface_representatives={
+            "violation_summary": "rep:b",
+            "groups_by_path": "rep:a",
         },
+        two_cell_witnesses=[],
+        cofibration_witnesses=[],
         visitor=emitter,
     )
-    replay_equivalence_payload_to_visitor(
-        equivalence_payload={
-            "surface_table": [
-                {
-                    "surface": "groups_by_path",
-                    "classification": "non_drift",
-                    "witness_id": "w:1",
-                }
-            ]
-        },
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=[
+            {
+                "surface": "groups_by_path",
+                "classification": "non_drift",
+                "witness_id": "w:1",
+            }
+        ],
         visitor=emitter,
     )
 


### PR DESCRIPTION
### Motivation
- Create a single, low-level event visitor protocol to normalize how ASPF events are consumed across live streams and event-log readers.
- Replace bespoke payload-replay entrypoints with adapters so all ASPF-consuming tools are treated uniformly as visitor instances.
- Migrate existing emitters into adapter-compatible visitors to preserve legacy aggregation behavior while enabling a canonical ingestion path.

### Description
- Added canonical event dataclasses and a low-level protocol `AspfEventReplayVisitor` with methods `one_cell`, `two_cell`, `cofibration`, `surface_update`, and `run_boundary` in `src/gabion/analysis/aspf_visitors.py`.
- Implemented two adapters: `adapt_live_event_stream_to_visitor(...)` for live/event-stream ingestion and `adapt_event_log_reader_iterator_to_visitor(...)` for event-log iterators, dispatching deterministically into the canonical protocol.
- Adapted `TracePayloadEmitter` and `OpportunityPayloadEmitter` to implement the canonical event visitor interface while preserving their legacy aggregation logic.
- Rewired execution-fibration code to use the new adapters (`src/gabion/analysis/aspf_execution_fibration.py`) and updated tests (`tests/test_aspf_visitors.py`) to exercise the adapter-based ingestion paths.

### Testing
- Verified syntax integrity with `python -m py_compile src/gabion/analysis/aspf_visitors.py src/gabion/analysis/aspf_execution_fibration.py tests/test_aspf_visitors.py`, which succeeded.
- Ran `pytest tests/test_aspf_visitors.py` and higher-level `scripts/policy_check.py` attempts; these were blocked by missing runtime dependencies (`libcst`, `pygls`) and environment/toolchain trust issues, so the full automated test/policy stack could not complete in this container.
- Changes were committed locally and include updated unit test usage to the adapter APIs; further CI runs with the project dependencies installed are required to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d4317eb883249efe28bd0c17b3f6)