### PR TITLE
Add witness-backed structure reuse rewrite artifacts

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -4207,12 +4207,26 @@ def _evaluate_witness_obligation_non_regression_predicate(
             if mapped_item is not None:
                 obligations.append(mapped_item)
     missing_required: list[str] = []
+    aspf_identity_mismatches: list[str] = []
+    post_aspf_structure_class = mapping_or_empty(
+        context.post_entry.get("aspf_structure_class")
+    )
     for item in obligations:
         required = bool(item.get("required"))
         witness_ref = str(item.get("witness_ref", "") or "")
         witness_kind = str(item.get("kind", "witness") or "witness")
         if required and not witness_ref:
             missing_required.append(f"{witness_kind}:missing")
+        if witness_kind == "aspf_structure_class_equivalence":
+            expected_identity = mapping_or_none(item.get("canonical_identity_contract"))
+            post_identity_payload = mapping_or_none(
+                context.post_entry.get("canonical_identity_contract")
+            )
+            if expected_identity is not None and expected_identity != post_identity_payload:
+                aspf_identity_mismatches.append("canonical_identity_contract")
+            expected_structure_class = mapping_or_none(item.get("aspf_structure_class"))
+            if expected_structure_class is not None and expected_structure_class != post_aspf_structure_class:
+                aspf_identity_mismatches.append("aspf_structure_class")
     post_identity = context.post_entry.get("canonical_identity_contract")
     pre_identity = context.pre.get("canonical_identity_contract")
     identity_ok = True
@@ -4220,7 +4234,7 @@ def _evaluate_witness_obligation_non_regression_predicate(
         identity_ok = pre_identity == post_identity
     elif post_identity is None:
         identity_ok = False
-    passed = (not missing_required) and identity_ok
+    passed = (not missing_required) and identity_ok and (not aspf_identity_mismatches)
     return {
         "kind": kind,
         "passed": passed,
@@ -4232,7 +4246,9 @@ def _evaluate_witness_obligation_non_regression_predicate(
         },
         "observed": {
             "missing_required": missing_required,
+            "aspf_identity_mismatches": aspf_identity_mismatches,
             "identity_contract": post_identity,
+            "aspf_structure_class": post_aspf_structure_class,
         },
     }
 
@@ -13993,6 +14009,96 @@ def compute_structure_reuse(
     )
     suggested: list[JSONObject] = []
     replacement_map: dict[str, list[JSONObject]] = {}
+
+    def _reuse_site_from_location(
+        *,
+        location: str,
+        fallback_value: object,
+    ) -> JSONObject:
+        location_parts = location.split("::")
+        path_value = location_parts[0] if location_parts else ""
+        function_value = location_parts[1] if len(location_parts) > 1 else ""
+        bundle_payload: list[str] = []
+        if len(location_parts) > 2 and location_parts[2].startswith("bundle:"):
+            raw_bundle = location_parts[2][len("bundle:") :]
+            bundle_payload = [part for part in raw_bundle.split(",") if part]
+        elif type(fallback_value) is list:
+            bundle_payload = [str(item) for item in cast(list[object], fallback_value)]
+        return {
+            "path": path_value,
+            "function": function_value,
+            "bundle": bundle_payload,
+        }
+
+    def _build_suggested_plan_artifact(
+        *,
+        suggestion: JSONObject,
+    ) -> JSONObject:
+        kind = str(suggestion.get("kind", ""))
+        suggestion_name = str(suggestion.get("suggested_name", ""))
+        hash_value = str(suggestion.get("hash", ""))
+        locations = sequence_or_none(suggestion.get("locations")) or ()
+        sorted_locations = sort_once(
+            [str(location) for location in locations if type(location) is str],
+            source="compute_structure_reuse.suggested_plan.locations",
+        )
+        primary_location = sorted_locations[0] if sorted_locations else ""
+        site = _reuse_site_from_location(
+            location=primary_location,
+            fallback_value=suggestion.get("value"),
+        )
+        witness_obligations = list(
+            sequence_or_none(suggestion.get("witness_obligations")) or []
+        )
+        return {
+            "plan_id": f"reuse:{kind}:{hash_value}:{suggestion_name}",
+            "status": "UNVERIFIED",
+            "site": site,
+            "pre": {
+                "canonical_identity_contract": suggestion.get("canonical_identity_contract"),
+                "aspf_structure_class": suggestion.get("aspf_structure_class"),
+            },
+            "rewrite": {
+                "kind": "BUNDLE_ALIGN" if kind == "bundle" else "AMBIENT_REWRITE",
+                "selector": {
+                    "hash": hash_value,
+                    "locations": sorted_locations,
+                },
+                "parameters": {
+                    "candidates": [suggestion_name] if suggestion_name else [],
+                    "strategy": "reuse-lemma" if kind != "bundle" else "reuse-align",
+                },
+            },
+            "evidence": {
+                "provenance_id": f"reuse:{hash_value}",
+                "coherence_id": f"aspf:{hash_value}",
+                "witness_obligations": witness_obligations,
+            },
+            "post_expectation": {
+                "match_strata": "exact",
+                "canonical_structure_class_equivalent": True,
+            },
+            "verification": {
+                "mode": "re-audit",
+                "status": "UNVERIFIED",
+                "predicates": [
+                    {"kind": "base_conservation", "expect": True},
+                    *(
+                        [{"kind": "ctor_coherence", "expect": True}]
+                        if kind == "bundle"
+                        else []
+                    ),
+                    {
+                        "kind": "match_strata",
+                        "expect": "exact",
+                        "candidates": [suggestion_name] if suggestion_name else [],
+                    },
+                    {"kind": "remainder_non_regression", "expect": "no-new-remainder"},
+                    {"kind": "witness_obligation_non_regression", "expect": "stable"},
+                ],
+            },
+        }
+
     for entry in reused:
         check_deadline()
         kind = entry.get("kind")
@@ -14006,6 +14112,11 @@ def compute_structure_reuse(
                     "count": count,
                     "suggested_name": f"_gabion_{kind}_lemma_{hash_value[:8]}",
                     "locations": entry.get("locations", []),
+                    "aspf_structure_class": entry.get("aspf_structure_class"),
+                    "canonical_identity_contract": {
+                        "identity_kind": "canonical_aspf_structure_class_equivalence",
+                        "representative": hash_value,
+                    },
                 }
                 if "value" in entry:
                     suggestion["value"] = entry.get("value")
@@ -14031,6 +14142,29 @@ def compute_structure_reuse(
                         warnings.append(
                             f"Missing declared bundle name for {list(key)}"
                         )
+                suggestion["witness_obligations"] = [
+                    {
+                        "kind": "reuse_suggestion_site",
+                        "required": True,
+                        "witness_ref": str(location),
+                    }
+                    for location in sequence_or_none(suggestion.get("locations")) or ()
+                    if type(location) is str
+                ]
+                suggestion["witness_obligations"].append(
+                    {
+                        "kind": "aspf_structure_class_equivalence",
+                        "required": True,
+                        "witness_ref": f"aspf:{hash_value}",
+                        "aspf_structure_class": suggestion.get("aspf_structure_class"),
+                        "canonical_identity_contract": suggestion.get(
+                            "canonical_identity_contract"
+                        ),
+                    }
+                )
+                suggestion["rewrite_plan_artifact"] = _build_suggested_plan_artifact(
+                    suggestion=suggestion
+                )
                 suggested.append(suggestion)
     replacement_map = _build_reuse_replacement_map(suggested)
     reuse_payload: JSONObject = {
@@ -14073,7 +14207,7 @@ def render_reuse_lemma_stubs(reuse: JSONObject) -> str:
     suggested = reuse.get("suggested_lemmas") or []
     lines = [
         "# Generated by gabion structure-reuse",
-        "# TODO: replace stubs with actual lemma definitions.",
+        "# Structured rewrite-plan artifacts for suggested reuse lemmas.",
         "",
     ]
     if not suggested:
@@ -14084,6 +14218,7 @@ def render_reuse_lemma_stubs(reuse: JSONObject) -> str:
         mapping_or_empty(raw_entry)
         for raw_entry in suggested
     ]
+    plan_artifacts: list[JSONObject] = []
     for entry in sort_once(
         suggested_entries,
         key=lambda e: (str(e.get("kind", "")), str(e.get("suggested_name", ""))),
@@ -14091,20 +14226,20 @@ def render_reuse_lemma_stubs(reuse: JSONObject) -> str:
         check_deadline()
         name = entry.get("suggested_name")
         if type(name) is str and name:
-            kind = entry.get("kind", "lemma")
-            count = entry.get("count", 0)
-            value = entry.get("value")
-            child_count = entry.get("child_count")
-            lines.append(f"def {name}() -> None:")
-            lines.append('    """Auto-generated lemma stub."""')
-            lines.append(f"    # kind: {kind}")
-            lines.append(f"    # count: {count}")
-            if value is not None:
-                lines.append(f"    # value: {value}")
-            if child_count is not None:
-                lines.append(f"    # child_count: {child_count}")
-            lines.append("    ...")
-            lines.append("")
+            raw_plan = mapping_or_none(entry.get("rewrite_plan_artifact"))
+            if raw_plan is not None:
+                plan_artifacts.append({str(key): raw_plan[key] for key in raw_plan})
+    payload: JSONObject = {
+        "format_version": 1,
+        "artifact_kind": "reuse_rewrite_plan_bundle",
+        "plans": sort_once(
+            plan_artifacts,
+            source="render_reuse_lemma_stubs.plan_artifacts",
+            key=lambda plan: str(plan.get("plan_id", "")),
+        ),
+    }
+    lines.append(json.dumps(payload, indent=2, sort_keys=False))
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/src/gabion/analysis/dataflow_decision_surfaces.py
+++ b/src/gabion/analysis/dataflow_decision_surfaces.py
@@ -211,6 +211,15 @@ def compute_fingerprint_rewrite_plans(
                     "remainder": entry.get("remainder") or {},
                     "synth_version": synth_version,
                     **(
+                        {
+                            "canonical_identity_contract": entry.get(
+                                "canonical_identity_contract"
+                            )
+                        }
+                        if entry.get("canonical_identity_contract") is not None
+                        else {}
+                    ),
+                    **(
                         {"exception_obligations_summary": pre_exception_summary}
                         if pre_exception_summary is not None
                         else {}
@@ -292,6 +301,17 @@ def compute_fingerprint_rewrite_plans(
                                     "witness_ref": coherence_id,
                                     "required": coherence_id is not None,
                                     "kind": "coherence",
+                                },
+                                {
+                                    "witness_ref": str(
+                                        entry.get("provenance_id")
+                                        or f"aspf-class:{site.path}:{site.function}:{bundle_key}"
+                                    ),
+                                    "required": entry.get("canonical_identity_contract") is not None,
+                                    "kind": "aspf_structure_class_equivalence",
+                                    "canonical_identity_contract": entry.get(
+                                        "canonical_identity_contract"
+                                    ),
                                 },
                             ],
                         },

--- a/tests/test_dataflow_audit_coverage_gaps.py
+++ b/tests/test_dataflow_audit_coverage_gaps.py
@@ -1327,7 +1327,7 @@ def test_render_reuse_stubs_and_refactor_plan_order_branches() -> None:
         ]
     }
     stubs = da.render_reuse_lemma_stubs(reuse)
-    assert "def lemma_name" in stubs
+    assert "reuse_rewrite_plan_bundle" in stubs
 
     text = da.render_refactor_plan(
         {
@@ -2261,7 +2261,7 @@ def test_additional_branch_edges_rendering_variants() -> None:
     stubs = da.render_reuse_lemma_stubs(
         {"suggested_lemmas": [{"kind": "bundle", "suggested_name": "lemma", "count": 1}]}
     )
-    assert "def lemma" in stubs
+    assert "\"plans\"" in stubs
 
     # render_refactor_plan empty order branch.
     plan_text = da.render_refactor_plan({"bundles": [{"bundle": ["x"], "order": [], "cycles": []}]})

--- a/tests/test_rewrite_plan_verification.py
+++ b/tests/test_rewrite_plan_verification.py
@@ -452,3 +452,50 @@ def test_verify_rewrite_plan_witness_obligation_shape_edges() -> None:
         post_provenance=[_post_entry(canonical_identity_contract={"representative": "rep:a"})],
     )
     assert mixed_obligation_items["accepted"] is True
+
+
+def test_verify_rewrite_plan_enforces_aspf_structure_class_equivalence() -> None:
+    da = _load()
+    plan = _plan(
+        pre={
+            "base_keys": ["int"],
+            "ctor_keys": [],
+            "remainder": {"base": 1, "ctor": 1},
+            "canonical_identity_contract": {"representative": "rep:a"},
+        },
+        evidence={
+            "provenance_id": "prov:a.py:f:a",
+            "coherence_id": "coh:a.py:f:a",
+            "witness_obligations": [
+                {
+                    "kind": "aspf_structure_class_equivalence",
+                    "required": True,
+                    "witness_ref": "aspf:prov:a.py:f:a",
+                    "canonical_identity_contract": {"representative": "rep:a"},
+                    "aspf_structure_class": {"digest": "h1", "kind": "bundle", "key": ["a"]},
+                }
+            ],
+        },
+        verification={"predicates": [{"kind": "witness_obligation_non_regression", "expect": "stable"}]},
+    )
+    accepted = da.verify_rewrite_plan(
+        plan,
+        post_provenance=[
+            _post_entry(
+                canonical_identity_contract={"representative": "rep:a"},
+                aspf_structure_class={"digest": "h1", "kind": "bundle", "key": ["a"]},
+            )
+        ],
+    )
+    assert accepted["accepted"] is True
+
+    rejected = da.verify_rewrite_plan(
+        plan,
+        post_provenance=[
+            _post_entry(
+                canonical_identity_contract={"representative": "rep:a"},
+                aspf_structure_class={"digest": "h2", "kind": "bundle", "key": ["a"]},
+            )
+        ],
+    )
+    assert rejected["accepted"] is False

--- a/tests/test_structure_reuse.py
+++ b/tests/test_structure_reuse.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+
+
+def _parse_stub_payload(stubs: str) -> dict[str, object]:
+    start = stubs.find("{")
+    return json.loads(stubs[start:])
 
 def _load():
     repo_root = Path(__file__).resolve().parents[1]
@@ -42,7 +49,10 @@ def test_compute_structure_reuse_detects_repeated_subtrees() -> None:
     assert any(entry.get("value") == ["a", "b"] for entry in bundle_entries)
     suggestions = reuse.get("suggested_lemmas", [])
     assert any(
-        entry.get("kind") == "bundle" and entry.get("suggested_name")
+        entry.get("kind") == "bundle"
+        and entry.get("suggested_name")
+        and entry.get("witness_obligations")
+        and entry.get("rewrite_plan_artifact")
         for entry in suggestions
     )
     replacement_map = reuse.get("replacement_map", {})
@@ -66,7 +76,9 @@ def test_render_reuse_lemma_stubs_includes_names() -> None:
         ],
     }
     stubs = da.render_reuse_lemma_stubs(reuse)
-    assert "_gabion_bundle_lemma_deadbeef" in stubs
+    payload = _parse_stub_payload(stubs)
+    assert payload.get("artifact_kind") == "reuse_rewrite_plan_bundle"
+    assert payload.get("plans") == []
 
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse._record::child_count,value E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::min_count E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::stale_001c41908b1c
 def test_structure_reuse_prefers_declared_bundle_names(tmp_path: Path) -> None:
@@ -101,3 +113,52 @@ def test_structure_reuse_prefers_declared_bundle_names(tmp_path: Path) -> None:
         for entry in suggestions
     )
     assert reuse.get("warnings") == []
+
+
+def test_compute_structure_reuse_candidate_generation_is_deterministic() -> None:
+    da = _load()
+    snapshot_a = {
+        "root": ".",
+        "files": [
+            {"path": "z.py", "functions": [{"name": "z", "bundles": [["k", "v"], ["x"]]}]},
+            {"path": "a.py", "functions": [{"name": "a", "bundles": [["v", "k"], ["x"]]}]},
+        ],
+    }
+    snapshot_b = {
+        "root": ".",
+        "files": list(reversed(snapshot_a["files"])),
+    }
+    reuse_a = da.compute_structure_reuse(snapshot_a, min_count=2)
+    reuse_b = da.compute_structure_reuse(snapshot_b, min_count=2)
+    sig_a = [
+        (entry.get("hash"), entry.get("kind"), entry.get("suggested_name"))
+        for entry in reuse_a.get("suggested_lemmas", [])
+    ]
+    sig_b = [
+        (entry.get("hash"), entry.get("kind"), entry.get("suggested_name"))
+        for entry in reuse_b.get("suggested_lemmas", [])
+    ]
+    assert sig_a == sig_b
+
+
+def test_render_reuse_lemma_stubs_emits_plan_artifacts_from_reuse_suggestions() -> None:
+    da = _load()
+    snapshot = {
+        "root": ".",
+        "files": [
+            {"path": "a.py", "functions": [{"name": "f", "bundles": [["x", "y"]]}]},
+            {"path": "b.py", "functions": [{"name": "g", "bundles": [["y", "x"]]}]},
+        ],
+    }
+    reuse = da.compute_structure_reuse(snapshot, min_count=2)
+    stubs = da.render_reuse_lemma_stubs(reuse)
+    payload = _parse_stub_payload(stubs)
+    plans = payload.get("plans", [])
+    assert plans
+    assert any(
+        any(
+            obligation.get("kind") == "aspf_structure_class_equivalence"
+            for obligation in plan.get("evidence", {}).get("witness_obligations", [])
+        )
+        for plan in plans
+    )

--- a/tests/test_structure_reuse_edges.py
+++ b/tests/test_structure_reuse_edges.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 def _load():
@@ -10,6 +11,10 @@ def _load():
 
 def _write(path: Path, content: str) -> None:
     path.write_text(content)
+
+def _parse_stub_payload(stubs: str) -> dict[str, object]:
+    start = stubs.find("{")
+    return json.loads(stubs[start:])
 
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse._record::child_count,value E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::min_count E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::stale_d2bc5b030089
 def test_compute_structure_reuse_handles_edges(tmp_path: Path) -> None:
@@ -98,14 +103,16 @@ def test_render_reuse_lemma_stubs_with_child_count() -> None:
         ]
     }
     stubs = da.render_reuse_lemma_stubs(reuse)
-    assert "child_count" in stubs
+    payload = _parse_stub_payload(stubs)
+    assert payload["plans"] == []
 
 # gabion:evidence E:function_site::dataflow_audit.py::gabion.analysis.dataflow_audit.render_reuse_lemma_stubs E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.render_reuse_lemma_stubs::stale_da5c52227c64
 def test_render_reuse_lemma_stubs_skips_invalid_names() -> None:
     da = _load()
     reuse = {"suggested_lemmas": [{"suggested_name": None, "kind": "bundle"}]}
     stubs = da.render_reuse_lemma_stubs(reuse)
-    assert "def " not in stubs
+    payload = _parse_stub_payload(stubs)
+    assert payload["plans"] == []
 
 # gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse._record::child_count,value E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::min_count E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit.compute_structure_reuse::stale_65d45635a8c6
 def test_compute_structure_reuse_skips_non_list_bundle() -> None:


### PR DESCRIPTION
### Motivation
- Make structure-reuse suggestions actionable and verifiable by emitting explicit witness obligations and structured rewrite-plan artifacts instead of plain text stubs.
- Ensure suggested consolidations are justified by ASPF canonical class identity so rewrite verification can enforce non-regression by class equivalence.
- Add deterministic candidate-generation coverage so suggested-lemma outputs are stable across input ordering.

### Description
- Extended `compute_structure_reuse` (`src/gabion/analysis/dataflow_audit.py`) to enrich each suggestion with `aspf_structure_class` and `canonical_identity_contract` metadata, explicit `witness_obligations`, and a per-suggestion `rewrite_plan_artifact` JSON payload suitable for verification predicates.
- Replaced plain stub emission in `render_reuse_lemma_stubs` with a structured JSON artifact bundle (`artifact_kind: reuse_rewrite_plan_bundle`) that contains sorted, deterministic plan entries ready for `verify_rewrite_plan` workflows.
- Threaded ASPF identity into rewrite-plan generation in `compute_fingerprint_rewrite_plans` (`src/gabion/analysis/dataflow_decision_surfaces.py`) so plans carry `canonical_identity_contract` and an `aspf_structure_class_equivalence` witness obligation when available.
- Extended the witness non-regression predicate evaluator (`_evaluate_witness_obligation_non_regression_predicate`) to check for canonical identity and ASPF structure-class mismatches and to report them in the predicate `observed` payload.
- Added/updated tests to assert deterministic candidate generation and witness-backed, non-regression-verified rewrites, and adapted coverage-gap expectations:
  - `tests/test_structure_reuse.py` (added deterministic generation test and checks for plan artifacts),
  - `tests/test_structure_reuse_edges.py` (adapted to parse new structured payload),
  - `tests/test_rewrite_plan_verification.py` (added `aspf_structure_class_equivalence` verification test),
  - `tests/test_dataflow_audit_coverage_gaps.py` (updated expectations for structured renderer output).

### Testing
- Ran the repo policy checks: `python scripts/policy_check.py --workflows` and `python scripts/policy_check.py --ambiguity-contract`; these executed with an environment warning from `mise` about remote metadata but completed and produced expected outputs.
- Ran targeted pytest sessions with `PYTHONPATH=src:.` and `-o addopts=''` to avoid CI parallelization flags; the modified/added tests were executed and passed: `tests/test_rewrite_plan_verification.py` (18 passed), `tests/test_structure_reuse.py` + `tests/test_structure_reuse_edges.py` (12 passed), and the combined targeted run used for validation reported all selected tests passing (examples: `16 passed, 116 deselected` / `............. [100%]`).
- Ran `scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and refreshed `out/test_evidence.json` to reflect the new/modified tests and evidence mappings (the evidence file change is intentional and committed with the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d38c27448324b66853362032317b)