### PR TITLE
Integration: consolidate ASPF core hub PRs (#272/#274/#264)

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -510,10 +510,12 @@ def build_opportunities_payload(
         visitor=emitter,
     )
     opportunities = emitter.build_rows()
+    rewrite_plans = emitter.build_rewrite_plans()
     return {
         "format_version": _OPPORTUNITY_FORMAT_VERSION,
         "trace_id": state.trace_id,
         "opportunities": opportunities,
+        "rewrite_plans": rewrite_plans,
     }
 
 

--- a/src/gabion/analysis/aspf_stream.py
+++ b/src/gabion/analysis/aspf_stream.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Mapping, Protocol
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator, Mapping, Protocol, cast
 
 from gabion.json_types import JSONObject
+from gabion.order_contract import sort_once
 
 from . import aspf_resume_state
 from .aspf_core import AspfOneCell, AspfTwoCellWitness
@@ -67,6 +70,182 @@ class AspfEventVisitor(Protocol):
     def on_finalize(self, event: RunFinalized) -> None: ...
 
 
+class AspfEventSink(Protocol):
+    def write_one_cell(self, event: OneCellRecorded) -> None: ...
+
+    def write_two_cell(self, event: TwoCellWitnessRecorded) -> None: ...
+
+    def write_cofibration(self, event: CofibrationRecorded) -> None: ...
+
+    def write_surface_update(self, event: SemanticSurfaceUpdated) -> None: ...
+
+    def write_finalize(self, event: RunFinalized) -> None: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class AspfTraceSinkIndex:
+    one_cell_count: int
+    two_cell_witness_count: int
+    cofibration_count: int
+    delta_record_count: int
+    surface_representatives: Mapping[str, str]
+    one_cells_path: Path
+    two_cell_witnesses_path: Path
+    cofibrations_path: Path
+    delta_records_path: Path
+
+    def iter_one_cells(self) -> Iterator[JSONObject]:
+        return _iter_jsonl(path=self.one_cells_path)
+
+    def iter_two_cell_witnesses(self) -> Iterator[JSONObject]:
+        return _iter_jsonl(path=self.two_cell_witnesses_path)
+
+    def iter_cofibrations(self) -> Iterator[JSONObject]:
+        return _iter_jsonl(path=self.cofibrations_path)
+
+    def iter_delta_records(self) -> Iterator[JSONObject]:
+        return _iter_jsonl(path=self.delta_records_path)
+
+
+@dataclass
+class AspfJsonlEventSink(AspfEventSink):
+    sink_root: Path
+    one_cells_path: Path
+    two_cell_witnesses_path: Path
+    cofibrations_path: Path
+    delta_records_path: Path
+    surface_representatives: dict[str, str]
+    one_cell_count: int = 0
+    two_cell_witness_count: int = 0
+    cofibration_count: int = 0
+    delta_record_count: int = 0
+
+    @classmethod
+    def create(cls, *, sink_root: Path) -> AspfJsonlEventSink:
+        sink_root.mkdir(parents=True, exist_ok=True)
+        return cls(
+            sink_root=sink_root,
+            one_cells_path=sink_root / "one_cells.jsonl",
+            two_cell_witnesses_path=sink_root / "two_cell_witnesses.jsonl",
+            cofibrations_path=sink_root / "cofibrations.jsonl",
+            delta_records_path=sink_root / "delta_records.jsonl",
+            surface_representatives={},
+        )
+
+    def write_one_cell(self, event: OneCellRecorded) -> None:
+        payload = event.cell.as_dict()
+        payload["kind"] = str(event.kind)
+        payload["surface"] = str(event.surface)
+        payload["metadata"] = event.metadata_payload
+        _append_jsonl(self.one_cells_path, payload)
+        self.one_cell_count += 1
+
+        analysis_state_value = event.metadata_payload.get("analysis_state")
+        analysis_state = (
+            str(analysis_state_value) if analysis_state_value is not None else None
+        )
+        mutation_target = f"one_cells.{self.one_cell_count}"
+        delta_record = aspf_resume_state.append_delta_record(
+            records=[],
+            event_kind=event.kind,
+            phase=event.cell.basis_path[0] if event.cell.basis_path else "runtime",
+            analysis_state=analysis_state,
+            mutation_target=mutation_target,
+            mutation_value={
+                "source": str(event.cell.source),
+                "target": str(event.cell.target),
+                "representative": event.cell.representative,
+                "surface": event.surface,
+                "metadata": event.metadata_payload,
+            },
+            one_cell_ref=mutation_target,
+        )
+        _append_jsonl(self.delta_records_path, delta_record)
+        self.delta_record_count += 1
+
+    def write_two_cell(self, event: TwoCellWitnessRecorded) -> None:
+        _append_jsonl(self.two_cell_witnesses_path, event.witness.as_dict())
+        self.two_cell_witness_count += 1
+
+    def write_cofibration(self, event: CofibrationRecorded) -> None:
+        _append_jsonl(self.cofibrations_path, event.carrier.as_dict())
+        self.cofibration_count += 1
+
+    def write_surface_update(self, event: SemanticSurfaceUpdated) -> None:
+        self.surface_representatives[event.surface] = event.representative
+        delta_record = aspf_resume_state.append_delta_record(
+            records=[],
+            event_kind="semantic_surface_projection",
+            phase=event.phase,
+            analysis_state=None,
+            mutation_target=f"semantic_surfaces.{event.surface}",
+            mutation_value=event.normalized_value,
+            one_cell_ref=None,
+        )
+        _append_jsonl(self.delta_records_path, delta_record)
+        self.delta_record_count += 1
+
+    def write_finalize(self, event: RunFinalized) -> None:
+        return None
+
+    def close(self) -> None:
+        manifest = {
+            "one_cell_count": self.one_cell_count,
+            "two_cell_witness_count": self.two_cell_witness_count,
+            "cofibration_count": self.cofibration_count,
+            "delta_record_count": self.delta_record_count,
+            "surface_representatives": {
+                surface: self.surface_representatives[surface]
+                for surface in sort_once(
+                    self.surface_representatives,
+                    source="aspf_stream.AspfJsonlEventSink.close.surface_representatives",
+                )
+            },
+        }
+        (self.sink_root / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def build_index(self) -> AspfTraceSinkIndex:
+        return AspfTraceSinkIndex(
+            one_cell_count=self.one_cell_count,
+            two_cell_witness_count=self.two_cell_witness_count,
+            cofibration_count=self.cofibration_count,
+            delta_record_count=self.delta_record_count,
+            surface_representatives=dict(self.surface_representatives),
+            one_cells_path=self.one_cells_path,
+            two_cell_witnesses_path=self.two_cell_witnesses_path,
+            cofibrations_path=self.cofibrations_path,
+            delta_records_path=self.delta_records_path,
+        )
+
+
+@dataclass
+class AspfSinkVisitor:
+    sink: AspfEventSink
+
+    def visit_one_cell_recorded(self, event: OneCellRecorded) -> None:
+        self.sink.write_one_cell(event)
+
+    def visit_two_cell_witness_recorded(self, event: TwoCellWitnessRecorded) -> None:
+        self.sink.write_two_cell(event)
+
+    def visit_cofibration_recorded(self, event: CofibrationRecorded) -> None:
+        self.sink.write_cofibration(event)
+
+    def visit_semantic_surface_updated(self, event: SemanticSurfaceUpdated) -> None:
+        self.sink.write_surface_update(event)
+
+    def visit_run_finalized(self, event: RunFinalized) -> None:
+        self.sink.write_finalize(event)
+
+    def on_finalize(self, event: RunFinalized) -> None:
+        return None
+
+
 class AspfInMemoryCompatibilityVisitor:
     """Reconstructs legacy in-memory side effects for transition compatibility."""
 
@@ -123,3 +302,22 @@ class AspfInMemoryCompatibilityVisitor:
 
     def on_finalize(self, event: RunFinalized) -> None:
         pass
+
+
+def _append_jsonl(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=False))
+        handle.write("\n")
+
+
+def _iter_jsonl(*, path: Path) -> Iterator[JSONObject]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line:
+                continue
+            payload = cast(Mapping[str, object], json.loads(line))
+            yield {str(key): payload[key] for key in payload}

--- a/tests/test_aspf_execution_fibration.py
+++ b/tests/test_aspf_execution_fibration.py
@@ -402,6 +402,50 @@ def test_execution_trace_state_preserves_preconfigured_event_visitors(tmp_path: 
     assert state.event_visitors == [visitor]
 
 
+def test_start_execution_trace_registers_streaming_sink(tmp_path: Path) -> None:
+    state = aspf_execution_fibration.start_execution_trace(
+        root=tmp_path,
+        payload=_trace_payload(
+            trace_json=tmp_path / "trace.json",
+            surfaces=["groups_by_path"],
+        ),
+    )
+    assert state is not None
+    assert state.event_sinks
+
+
+def test_finalize_execution_trace_derives_payload_from_sink_index(tmp_path: Path) -> None:
+    state = aspf_execution_fibration.start_execution_trace(
+        root=tmp_path,
+        payload=_trace_payload(
+            trace_json=tmp_path / "trace.json",
+            surfaces=["groups_by_path"],
+        ),
+    )
+    assert state is not None
+
+    aspf_execution_fibration.register_semantic_surface(
+        state=state,
+        surface="groups_by_path",
+        value={"pkg/mod.py": {"fn": [{"a"}]}, "count": 1},
+    )
+    state.one_cells.clear()
+    state.one_cell_metadata.clear()
+    state.two_cell_witnesses.clear()
+    state.cofibrations.clear()
+    state.surface_representatives.clear()
+    state.delta_records.clear()
+
+    artifacts = aspf_execution_fibration.finalize_execution_trace(
+        state=state,
+        root=tmp_path,
+        semantic_surface_payloads={"groups_by_path": {"pkg/mod.py": {"fn": [{"a"}]}}},
+    )
+    assert artifacts is not None
+    assert artifacts.trace_payload["one_cells"]
+    assert artifacts.trace_payload["delta_record_count"] > 0
+
+
 def _one_cell_payload(*, representative: str) -> dict[str, object]:
     return {
         "source": "surface:groups_by_path:domain",

--- a/tests/test_aspf_execution_fibration.py
+++ b/tests/test_aspf_execution_fibration.py
@@ -253,6 +253,13 @@ def test_build_opportunities_payload_emits_materialize_and_fungible_candidates(
     kinds = {str(row.get("kind")) for row in rows if isinstance(row, dict)}
     assert "materialize_load_fusion" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    rewrite_plans = opportunities["rewrite_plans"]
+    assert isinstance(rewrite_plans, list)
+    fungible_plan = next(
+        plan for plan in rewrite_plans if isinstance(plan, dict) and plan.get("opportunity_id") == "opp:fungible-substitution:groups_by_path"
+    )
+    assert fungible_plan["actionability"] == "actionable"
+    assert fungible_plan["required_witnesses"] == ["w:groups-fungible"]
 
 
 # gabion:evidence E:call_footprint::tests/test_aspf_execution_fibration.py::test_finalize_execution_trace_allows_state_object_roundtrip_import::aspf_execution_fibration.py::gabion.analysis.aspf_execution_fibration.finalize_execution_trace

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -103,27 +103,25 @@ def test_null_visitor_noop_methods_are_callable() -> None:
 
 def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
     emitter = OpportunityPayloadEmitter()
-    replay_trace_payload_to_visitor(
-        trace_payload={
-            "one_cells": [],
-            "surface_representatives": {
-                "groups_by_path": "rep:shared",
-                "rewrite_plans": "rep:shared",
-            },
-            "two_cell_witnesses": [
-                {
-                    "witness_id": "w:2",
-                    "left_representative": "rep:shared",
-                    "right_representative": "rep:baseline",
-                },
-                {
-                    "witness_id": "w:1",
-                    "left_representative": "rep:shared",
-                    "right_representative": "rep:legacy",
-                },
-            ],
-            "cofibration_witnesses": [],
+    adapt_live_event_stream_to_visitor(
+        one_cells=[],
+        surface_representatives={
+            "groups_by_path": "rep:shared",
+            "rewrite_plans": "rep:shared",
         },
+        two_cell_witnesses=[
+            {
+                "witness_id": "w:2",
+                "left_representative": "rep:shared",
+                "right_representative": "rep:baseline",
+            },
+            {
+                "witness_id": "w:1",
+                "left_representative": "rep:shared",
+                "right_representative": "rep:legacy",
+            },
+        ],
+        cofibration_witnesses=[],
         visitor=emitter,
     )
 

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -6,8 +6,8 @@ from gabion.analysis.aspf import Alt, Forest, Node
 from gabion.analysis.aspf_visitors import (
     NullAspfTraversalVisitor,
     OpportunityPayloadEmitter,
-    replay_equivalence_payload_to_visitor,
-    replay_trace_payload_to_visitor,
+    adapt_event_log_reader_iterator_to_visitor,
+    adapt_live_event_stream_to_visitor,
     traverse_forest_to_visitor,
 )
 
@@ -40,37 +40,33 @@ def test_traverse_forest_to_visitor_uses_deterministic_order() -> None:
 
 def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     emitter = OpportunityPayloadEmitter()
-    replay_trace_payload_to_visitor(
-        trace_payload={
-            "one_cells": [
-                {
-                    "kind": "resume_load",
-                    "metadata": {"import_state_path": "state/a.json"},
-                },
-                {
-                    "kind": "resume_write",
-                    "metadata": {"state_path": "state/a.json"},
-                },
-            ],
-            "surface_representatives": {
-                "violation_summary": "rep:b",
-                "groups_by_path": "rep:a",
+    adapt_live_event_stream_to_visitor(
+        one_cells=[
+            {
+                "kind": "resume_load",
+                "metadata": {"import_state_path": "state/a.json"},
             },
-            "two_cell_witnesses": [],
-            "cofibration_witnesses": [],
+            {
+                "kind": "resume_write",
+                "metadata": {"state_path": "state/a.json"},
+            },
+        ],
+        surface_representatives={
+            "violation_summary": "rep:b",
+            "groups_by_path": "rep:a",
         },
+        two_cell_witnesses=[],
+        cofibration_witnesses=[],
         visitor=emitter,
     )
-    replay_equivalence_payload_to_visitor(
-        equivalence_payload={
-            "surface_table": [
-                {
-                    "surface": "groups_by_path",
-                    "classification": "non_drift",
-                    "witness_id": "w:1",
-                }
-            ]
-        },
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=[
+            {
+                "surface": "groups_by_path",
+                "classification": "non_drift",
+                "witness_id": "w:1",
+            }
+        ],
         visitor=emitter,
     )
 

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -75,6 +75,15 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     assert "materialize_load_fusion" in kinds
     assert "reusable_boundary_artifact" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    fungible = next(
+        row for row in rows if isinstance(row, dict) and row.get("kind") == "fungible_execution_path_substitution"
+    )
+    assert fungible["actionability"] == "actionable"
+    assert fungible["confidence_provenance"] == "morphism_witness"
+
+    plans = emitter.build_rewrite_plans()
+    assert plans
+    assert plans[0]["opportunity_id"].startswith("opp:")
 
 
 def test_null_visitor_noop_methods_are_callable() -> None:
@@ -90,3 +99,35 @@ def test_null_visitor_noop_methods_are_callable() -> None:
     visitor.on_trace_cofibration(index=0, cofibration={})
     visitor.on_trace_surface_representative(surface="groups_by_path", representative="rep")
     visitor.on_equivalence_surface_row(index=0, row={})
+
+
+def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
+    emitter = OpportunityPayloadEmitter()
+    replay_trace_payload_to_visitor(
+        trace_payload={
+            "one_cells": [],
+            "surface_representatives": {
+                "groups_by_path": "rep:shared",
+                "rewrite_plans": "rep:shared",
+            },
+            "two_cell_witnesses": [
+                {
+                    "witness_id": "w:2",
+                    "left_representative": "rep:shared",
+                    "right_representative": "rep:baseline",
+                },
+                {
+                    "witness_id": "w:1",
+                    "left_representative": "rep:shared",
+                    "right_representative": "rep:legacy",
+                },
+            ],
+            "cofibration_witnesses": [],
+        },
+        visitor=emitter,
+    )
+
+    plans = emitter.build_rewrite_plans()
+    reusable = next(plan for plan in plans if plan["opportunity_id"].startswith("opp:reusable-boundary:"))
+    assert reusable["required_witnesses"] == ["w:1", "w:2"]
+    assert reusable["priority"] == 0.74


### PR DESCRIPTION
## Summary
Consolidation PR for the ASPF core overlap hub.

Subsumes:
- #272
- #274
- #264

## Notes
- Cherry-picked in leverage order: #272 -> #274 -> #264
- Preserves sink-index streaming finalization, canonical replay adapter protocol, and typed opportunity decision projection.
- Resolved evidence conflict by post-validation evidence regeneration.
- Added one integration correction commit to align visitor tests to the canonical adapter API.

## Validation
- `mise exec -- python scripts/policy_check.py --workflows`
- `mise exec -- python scripts/policy_check.py --ambiguity-contract`
- `mise exec -- python scripts/policy_check.py --normative-map`
- `mise exec -- python -m pytest -q tests/test_aspf_execution_fibration.py tests/test_aspf_visitors.py`
- `mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`
