### PR TITLE
Add ASPF equivalence/coherence witness obligations to reuse suggestions

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -14232,6 +14232,9 @@ def compute_structure_reuse(
         witness_obligations = list(
             sequence_or_none(suggestion.get("witness_obligations")) or []
         )
+        aspf_witness_requirements = mapping_or_empty(
+            suggestion.get("aspf_witness_requirements")
+        )
         return {
             "plan_id": f"reuse:{kind}:{hash_value}:{suggestion_name}",
             "status": "UNVERIFIED",
@@ -14254,6 +14257,7 @@ def compute_structure_reuse(
             "evidence": {
                 "provenance_id": f"reuse:{hash_value}",
                 "coherence_id": f"aspf:{hash_value}",
+                "aspf_witness_requirements": aspf_witness_requirements,
                 "witness_obligations": witness_obligations,
             },
             "post_expectation": {
@@ -14344,6 +14348,25 @@ def compute_structure_reuse(
                         ),
                     }
                 )
+                suggestion["witness_obligations"].append(
+                    {
+                        "kind": "aspf_structure_class_coherence",
+                        "required": True,
+                        "witness_ref": f"aspf:coherence:{hash_value}",
+                        "coherence_ref": f"aspf:{hash_value}",
+                    }
+                )
+                suggestion["aspf_witness_requirements"] = {
+                    "equivalence": {
+                        "kind": "aspf_structure_class_equivalence",
+                        "witness_ref": f"aspf:{hash_value}",
+                    },
+                    "coherence": {
+                        "kind": "aspf_structure_class_coherence",
+                        "witness_ref": f"aspf:coherence:{hash_value}",
+                        "coherence_ref": f"aspf:{hash_value}",
+                    },
+                }
                 suggestion["rewrite_plan_artifact"] = _build_suggested_plan_artifact(
                     suggestion=suggestion
                 )
@@ -14354,6 +14377,27 @@ def compute_structure_reuse(
         "min_count": min_count,
         "reused": reused,
         "suggested_lemmas": suggested,
+        "heuristic_structural_repetition_candidates": [
+            {
+                "hash": entry.get("hash"),
+                "kind": entry.get("kind"),
+                "count": entry.get("count"),
+                "source": "heuristic_structural_repetition",
+            }
+            for entry in reused
+            if entry.get("kind") in {"bundle", "function"}
+        ],
+        "witness_validated_isomorphy_candidates": [
+            {
+                "hash": suggestion.get("hash"),
+                "kind": suggestion.get("kind"),
+                "suggested_name": suggestion.get("suggested_name"),
+                "source": "aspf_witness_requirements",
+                "aspf_witness_requirements": suggestion.get("aspf_witness_requirements"),
+            }
+            for suggestion in suggested
+            if mapping_or_none(suggestion.get("aspf_witness_requirements")) is not None
+        ],
         "replacement_map": replacement_map,
         "warnings": warnings,
     }

--- a/tests/test_structure_reuse.py
+++ b/tests/test_structure_reuse.py
@@ -52,9 +52,12 @@ def test_compute_structure_reuse_detects_repeated_subtrees() -> None:
         entry.get("kind") == "bundle"
         and entry.get("suggested_name")
         and entry.get("witness_obligations")
+        and entry.get("aspf_witness_requirements")
         and entry.get("rewrite_plan_artifact")
         for entry in suggestions
     )
+    assert reuse.get("heuristic_structural_repetition_candidates")
+    assert reuse.get("witness_validated_isomorphy_candidates")
     replacement_map = reuse.get("replacement_map", {})
     assert any(location.startswith("a.py::f") for location in replacement_map)
 
@@ -158,6 +161,13 @@ def test_render_reuse_lemma_stubs_emits_plan_artifacts_from_reuse_suggestions() 
     assert any(
         any(
             obligation.get("kind") == "aspf_structure_class_equivalence"
+            for obligation in plan.get("evidence", {}).get("witness_obligations", [])
+        )
+        for plan in plans
+    )
+    assert any(
+        any(
+            obligation.get("kind") == "aspf_structure_class_coherence"
             for obligation in plan.get("evidence", {}).get("witness_obligations", [])
         )
         for plan in plans


### PR DESCRIPTION
### Motivation
- Connect structure-reuse suggestions to explicit ASPF evidence so suggested lemmas carry machine-checkable witness obligations. 
- Ensure suggested rewrite artifacts surface obligations that are compatible with existing rewrite verification predicates (notably `witness_obligation_non_regression`).
- Distinguish raw heuristic repetition signals from witness-backed isomorphy candidates in reports to make downstream verification and triage explicit.

### Description
- Thread a new `aspf_witness_requirements` mapping from each reuse `suggestion` into the generated rewrite-plan artifact `evidence` in `_build_suggested_plan_artifact` so plan payloads expose explicit ASPF witness requirements. 
- Append an explicit `aspf_structure_class_coherence` witness obligation alongside the existing `aspf_structure_class_equivalence` obligation for each suggested lemma and populate `aspf_witness_requirements` with both `equivalence` and `coherence` entries. 
- Add two report partition fields to `compute_structure_reuse` output: `heuristic_structural_repetition_candidates` (raw repetition signals) and `witness_validated_isomorphy_candidates` (suggestions that include ASPF witness requirements). 
- Update `render_reuse_lemma_stubs` use-site expectations and add assertions in `tests/test_structure_reuse.py` to cover the additional obligations and the new report fields.

### Testing
- Ran `PYTHONPATH=src python scripts/policy_check.py --workflows` which completed successfully. 
- Ran `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` which completed successfully. 
- Ran unit tests with `PYTHONPATH=src pytest -q -o addopts='' tests/test_structure_reuse.py tests/test_structure_reuse_edges.py` which returned `12 passed`. 
- Ran the targeted rewrite verification test `PYTHONPATH=src pytest -q -o addopts='' tests/test_rewrite_plan_verification.py::test_verify_rewrite_plan_enforces_witness_obligations_non_regression` which returned `1 passed`, and regenerated `out/test_evidence.json` with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e40ecbbc8324aa4761b47de2ea5f)