### PR TITLE
Refactor ASPF opportunity identity to canonical carrier payloads

### DIFF
--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -126,6 +126,14 @@ def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
     )
 
     plans = emitter.build_rewrite_plans()
-    reusable = next(plan for plan in plans if plan["opportunity_id"].startswith("opp:reusable-boundary:"))
+    reusable = next(
+        plan
+        for plan in plans
+        if plan["opportunity_id"].startswith(
+            "opp:reusable-boundary:Opportunity:ReusableBoundaryRepresentative:"
+        )
+    )
     assert reusable["required_witnesses"] == ["w:1", "w:2"]
     assert reusable["priority"] == 0.74
+    assert reusable["canonical_identity"]["node_id"]["kind"] == "Opportunity:ReusableBoundaryRepresentative"
+    assert reusable["opportunity_hash"]


### PR DESCRIPTION
### Motivation

- Ensure ASPF opportunity identities are derived from canonical ASPF carrier tuples (NodeId/fingerprint) rather than opaque hash prefixes for clearer, stable identity and easier downstream validation. 
- Treat structure-class digests as auxiliary compatibility metadata while making the NodeId-backed canonical identity the primary structural carrier.

### Description

- Changed `OpportunityDecisionProtocol` to include an explicit `canonical_identity` JSON payload and an optional `opportunity_hash` compatibility field, and emit `canonical_identity` in `as_row()` and `as_rewrite_plan()` outputs. 
- Reworked reusable-boundary opportunity IDs to be derived from the canonical `NodeId` components (e.g. `Opportunity:ReusableBoundaryRepresentative` + representative key) instead of using the prior hash-prefix scheme, while preserving the short hash as `opportunity_hash`. 
- Added helper `_node_id_identity_payload(node_id: NodeId)` to produce `node_id` + `node_fingerprint` payloads used as canonical identity carriers. 
- Updated `AspfStructureClass` so `canonical_identity` (NodeId + fingerprint + child fingerprints) is the primary payload and `digest()` is retained as an auxiliary compatibility field in `structure_class_payload()`. 
- Updated tests to assert the new canonical identity fields and compatibility hash behavior in rewrite-plan outputs (`tests/test_aspf_visitors.py`).

### Testing

- Ran policy checks with `scripts/policy_check.py` using `PYTHONPATH=src` for `--workflows` and `--ambiguity-contract`; both checks completed (the environment emitted a `mise` network warning while resolving remote tooling but checks ran successfully). 
- Ran unit tests for the affected surfaces with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_structure_reuse_edges.py` and observed `11 passed`. 
- Generated test-evidence with `PYTHONPATH=src mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and verified no diffs (`git diff --exit-code out/test_evidence.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e3e83f6c8324b1ab6572a877b7fa)