### PR TITLE
Expand execution pattern matching for aliased, attribute, and async callables

### DIFF
--- a/tests/test_dataflow_audit_helpers.py
+++ b/tests/test_dataflow_audit_helpers.py
@@ -1085,6 +1085,84 @@ def test_pattern_schema_suggestions_include_execution_and_dataflow_axes() -> Non
         for line in suggestions
     )
 
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_execution_pattern_detection_supports_alias_attribute_and_async_callables::dataflow_audit.py::gabion.analysis.dataflow_audit._detect_execution_pattern_matches::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
+def test_execution_pattern_detection_supports_alias_attribute_and_async_callables() -> None:
+    da = _load()
+    source = (
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+
+    matches = da._detect_execution_pattern_matches(source=source)
+    ids = {entry.pattern_id for entry in matches}
+
+    assert "indexed_pass_runner" in ids
+    assert "indexed_pass_graph_builder" in ids
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_execution_pattern_residue_is_stable_under_source_order_permutations::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_matches::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_lines::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
+def test_execution_pattern_residue_is_stable_under_source_order_permutations() -> None:
+    da = _load()
+    source_a = (
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+    source_b = (
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+
+    lines_a = da._pattern_schema_residue_lines(
+        da._pattern_schema_residue_entries(
+            da._pattern_schema_matches(groups_by_path={}, source=source_a)
+        )
+    )
+    lines_b = da._pattern_schema_residue_lines(
+        da._pattern_schema_residue_entries(
+            da._pattern_schema_matches(groups_by_path={}, source=source_b)
+        )
+    )
+
+    assert lines_a == lines_b
+    assert any("indexed_pass_graph_builder" in line for line in lines_a)
+
+
 # gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_pattern_schema_residue_entries_cover_both_axes::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_matches::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_entries::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_lines::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
 def test_pattern_schema_residue_entries_cover_both_axes() -> None:
     da = _load()


### PR DESCRIPTION
### Motivation
- Execution-pattern detection currently missed several callable shapes (attribute calls, dotted names, simple local aliases, and async defs) that should unify under the same execution/dataflow pattern schema and emit a shared `pattern_schema.v2` identity. 
- Surface call-graph builder motifs (functions calling `_build_call_graph`) using the same indexed-pass schema family so execution and dataflow axes unify for the same carrier shapes.

### Description
- Added a new execution rule `_INDEXED_PASS_GRAPH_RULE` (pattern_id `indexed_pass_graph_builder`) to `_EXECUTION_PATTERN_RULES` so call-graph builder functions emit the `indexed_pass_cluster` execution schema.
- Extended callable detection by adding `_callable_name_variants` and enhancing `_iter_execution_function_facts` to accept both `FunctionDef` and `AsyncFunctionDef`, normalize `ast.Attribute` dotted/callee names, and resolve simple local alias assignments to callable variants before matching rules.
- Kept schema construction on the existing shared contract by continuing to use `PatternSchema.build` / `PatternInstance.build` which target `pattern_schema.v2` so new matches unify with existing dataflow-axis identities.
- Added deterministic tests covering alias/attribute/async detection (`test_execution_pattern_detection_supports_alias_attribute_and_async_callables`) and residue stability under source-order permutations (`test_execution_pattern_residue_is_stable_under_source_order_permutations`), and updated test-evidence output to reflect the new tests.

### Testing
- Ran targeted pytest: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_dataflow_audit_helpers.py -k "execution_pattern_detection_supports_alias_attribute_and_async_callables or execution_pattern_residue_is_stable_under_source_order_permutations or execution_pattern_matches_include_runner_motif_and_shared_schema_identity or pattern_schema_near_miss_residue_is_stable_across_domains"` and all selected tests passed (`4 passed`).
- Ran policy checks `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` which completed successfully.
- Updated the evidence carrier with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`, producing an intentional `out/test_evidence.json` update to include the new tests and mappings (evidence file changed as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e3fe67e88324a292be3744724859)