### PR TITLE
Add registry-driven ASPF opportunity taxonomy and normalization

### DIFF
--- a/docs/aspf_execution_fibration.md
+++ b/docs/aspf_execution_fibration.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 5
+doc_revision: 6
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: aspf_execution_fibration
 doc_role: contract
@@ -87,13 +87,29 @@ Aggregate verdict is `non_drift` only when all surfaced classifications are
 
 ## Opportunity Semantics
 
-Phase-1 opportunities are advisory and include:
-- `materialize_load_fusion`
-- `reusable_boundary_artifact`
-- `fungible_execution_path_substitution`
+Phase-1 opportunities are emitted via a registry keyed by explicit algebraic
+predicates over one-cell / two-cell / cofibration structure. The default class
+set is:
+- `materialize_load_observed` (one-cell predicate: at least one `resume_load`)
+- `materialize_load_fusion` (one-cell predicate: `resume_load` + `resume_write`
+  over the same resume reference)
+- `reusable_boundary_artifact` (two-cell predicate: representative fan-out over
+  projected semantic surfaces)
+- `fungible_execution_path_substitution` (two-cell predicate: `non_drift`
+  classification with witness-carrying equivalence rows)
+- `cofibration_prime_embedding_reuse` (cofibration predicate: at least one
+  validated domain→ASPF basis embedding)
 
-Opportunities are emitted only when supported by observed morphism patterns
-and/or witness evidence.
+Evidence requirements match the class semantics:
+- `none` for ingress-only observations (`materialize_load_observed`,
+  `materialize_load_fusion`)
+- `representative_pair` for representative-confluence reuse
+- `two_cell_witness` for fungible substitution opportunities
+- `cofibration_witness` for cofibration-prime embedding opportunities
+
+Adding a new opportunity kind now requires adding a normalized observation shape
+plus a taxonomy registration; no ad-hoc branch expansion is required inside
+`OpportunityPayloadEmitter`.
 
 ## Cross-Script Handoff
 

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 import hashlib
-from typing import Iterable, Literal, Mapping, Protocol, cast
+from typing import Callable, Iterable, Literal, Mapping, Protocol, cast
 
 from gabion.analysis.aspf import Alt, Forest, Node
 from gabion.json_types import JSONObject, JSONValue
@@ -291,11 +291,59 @@ class OpportunityWitnessRequirement(StrEnum):
     NONE = "none"
     REPRESENTATIVE_PAIR = "representative_pair"
     TWO_CELL_WITNESS = "two_cell_witness"
+    COFIBRATION_WITNESS = "cofibration_witness"
 
 
 class OpportunityActionabilityState(StrEnum):
     ACTIONABLE = "actionable"
     OBSERVATIONAL = "observational"
+
+
+class OpportunityStructure(StrEnum):
+    ONE_CELL = "one_cell"
+    TWO_CELL = "two_cell"
+    COFIBRATION = "cofibration"
+
+
+@dataclass(frozen=True)
+class OpportunityAlgebraicPredicate:
+    structure: OpportunityStructure
+    min_one_cells: int = 0
+    min_two_cells: int = 0
+    min_cofibrations: int = 0
+    requires_resume_load: bool = False
+    requires_resume_write: bool = False
+    requires_non_drift: bool = False
+
+    def matches(self, *, observation: "OpportunityAlgebraicObservation") -> bool:
+        if observation.structure is not self.structure:
+            return False
+        if observation.one_cell_count < self.min_one_cells:
+            return False
+        if observation.two_cell_count < self.min_two_cells:
+            return False
+        if observation.cofibration_count < self.min_cofibrations:
+            return False
+        if self.requires_resume_load and "resume_load" not in observation.one_cell_kinds:
+            return False
+        if self.requires_resume_write and "resume_write" not in observation.one_cell_kinds:
+            return False
+        if self.requires_non_drift and observation.classification != "non_drift":
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class OpportunityAlgebraicObservation:
+    structure: OpportunityStructure
+    subject_id: str
+    one_cell_count: int = 0
+    two_cell_count: int = 0
+    cofibration_count: int = 0
+    one_cell_kinds: frozenset[str] = frozenset()
+    surfaces: tuple[str, ...] = ()
+    witness_ids: tuple[str, ...] = ()
+    classification: str = ""
 
 
 @dataclass(frozen=True)
@@ -353,12 +401,138 @@ class OpportunityDecisionProtocol:
         }
 
 
+@dataclass(frozen=True)
+class OpportunityTaxonomyRegistration:
+    predicate: OpportunityAlgebraicPredicate
+    build: Callable[[OpportunityAlgebraicObservation], OpportunityDecisionProtocol]
+
+
+@dataclass(frozen=True)
+class OpportunityTaxonomyRegistry:
+    registrations: tuple[OpportunityTaxonomyRegistration, ...]
+
+    def decisions_for(
+        self,
+        *,
+        observations: Iterable[OpportunityAlgebraicObservation],
+    ) -> list[OpportunityDecisionProtocol]:
+        decisions: list[OpportunityDecisionProtocol] = []
+        for observation in observations:
+            for registration in self.registrations:
+                if registration.predicate.matches(observation=observation):
+                    decisions.append(registration.build(observation))
+        return decisions
+
+
+def _build_default_opportunity_taxonomy_registry() -> OpportunityTaxonomyRegistry:
+    return OpportunityTaxonomyRegistry(
+        registrations=(
+            OpportunityTaxonomyRegistration(
+                predicate=OpportunityAlgebraicPredicate(
+                    structure=OpportunityStructure.ONE_CELL,
+                    min_one_cells=1,
+                    requires_resume_load=True,
+                ),
+                build=lambda observation: OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:materialize-load-observed:{observation.subject_id}",
+                    kind="materialize_load_observed",
+                    affected_surfaces=(),
+                    witness_ids=(),
+                    reason="resume boundary observed state reference",
+                    confidence_provenance=OpportunityConfidenceProvenance.INGRESS_OBSERVATION,
+                    witness_requirement=OpportunityWitnessRequirement.NONE,
+                    actionability=OpportunityActionabilityState.OBSERVATIONAL,
+                ),
+            ),
+            OpportunityTaxonomyRegistration(
+                predicate=OpportunityAlgebraicPredicate(
+                    structure=OpportunityStructure.ONE_CELL,
+                    min_one_cells=2,
+                    requires_resume_load=True,
+                    requires_resume_write=True,
+                ),
+                build=lambda observation: OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:materialize-load-fusion:{observation.subject_id}",
+                    kind="materialize_load_fusion",
+                    affected_surfaces=(),
+                    witness_ids=(),
+                    reason="resume load and write boundaries share state reference",
+                    confidence_provenance=OpportunityConfidenceProvenance.INGRESS_OBSERVATION,
+                    witness_requirement=OpportunityWitnessRequirement.NONE,
+                    actionability=OpportunityActionabilityState.ACTIONABLE,
+                ),
+            ),
+            OpportunityTaxonomyRegistration(
+                predicate=OpportunityAlgebraicPredicate(
+                    structure=OpportunityStructure.TWO_CELL,
+                    min_one_cells=1,
+                ),
+                build=lambda observation: OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:reusable-boundary:{observation.subject_id}",
+                    kind="reusable_boundary_artifact",
+                    affected_surfaces=observation.surfaces,
+                    witness_ids=observation.witness_ids,
+                    reason="multiple semantic surfaces share deterministic representative",
+                    confidence_provenance=(
+                        OpportunityConfidenceProvenance.REPRESENTATIVE_CONFLUENCE
+                        if not observation.witness_ids
+                        else OpportunityConfidenceProvenance.MORPHISM_WITNESS
+                    ),
+                    witness_requirement=OpportunityWitnessRequirement.REPRESENTATIVE_PAIR,
+                    actionability=(
+                        OpportunityActionabilityState.OBSERVATIONAL
+                        if len(observation.surfaces) < 2
+                        else OpportunityActionabilityState.ACTIONABLE
+                    ),
+                ),
+            ),
+            OpportunityTaxonomyRegistration(
+                predicate=OpportunityAlgebraicPredicate(
+                    structure=OpportunityStructure.TWO_CELL,
+                    min_two_cells=1,
+                    requires_non_drift=True,
+                ),
+                build=lambda observation: OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:fungible-substitution:{observation.subject_id}",
+                    kind="fungible_execution_path_substitution",
+                    affected_surfaces=observation.surfaces,
+                    witness_ids=observation.witness_ids,
+                    reason="2-cell witness links baseline/current representatives",
+                    confidence_provenance=OpportunityConfidenceProvenance.MORPHISM_WITNESS,
+                    witness_requirement=OpportunityWitnessRequirement.TWO_CELL_WITNESS,
+                    actionability=OpportunityActionabilityState.ACTIONABLE,
+                ),
+            ),
+            OpportunityTaxonomyRegistration(
+                predicate=OpportunityAlgebraicPredicate(
+                    structure=OpportunityStructure.COFIBRATION,
+                    min_cofibrations=1,
+                ),
+                build=lambda observation: OpportunityDecisionProtocol(
+                    opportunity_id=f"opp:cofibration-prime-embedding:{observation.subject_id}",
+                    kind="cofibration_prime_embedding_reuse",
+                    affected_surfaces=(),
+                    witness_ids=observation.witness_ids,
+                    reason="domain-to-ASPF cofibration witness preserves prime embedding",
+                    confidence_provenance=OpportunityConfidenceProvenance.MORPHISM_WITNESS,
+                    witness_requirement=OpportunityWitnessRequirement.COFIBRATION_WITNESS,
+                    actionability=OpportunityActionabilityState.OBSERVATIONAL,
+                ),
+            ),
+        )
+    )
+
+
 @dataclass
 class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
+    taxonomy: OpportunityTaxonomyRegistry = field(
+        default_factory=_build_default_opportunity_taxonomy_registry
+    )
     _materialize_kinds_by_resume_ref: dict[str, set[str]] = field(default_factory=dict)
     _representative_to_surfaces: dict[str, list[str]] = field(default_factory=dict)
     _representative_witness_ids: dict[str, set[str]] = field(default_factory=dict)
-    _fungible_opportunities: list[OpportunityDecisionProtocol] = field(default_factory=list)
+    _non_drift_witness_ids_by_surface: dict[str, set[str]] = field(default_factory=dict)
+    _cofibration_entry_count_by_kind: dict[str, int] = field(default_factory=dict)
 
     def one_cell(self, event: AspfOneCellEvent) -> None:
         self.on_trace_one_cell(index=event.index, one_cell=event.payload)
@@ -414,6 +588,20 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
             if representative:
                 self._representative_witness_ids.setdefault(representative, set()).add(witness_id)
 
+    def on_trace_cofibration(
+        self,
+        *,
+        index: int,
+        cofibration: Mapping[str, object],
+    ) -> None:
+        canonical_identity_kind = str(cofibration.get("canonical_identity_kind", "")).strip()
+        normalized_cofibration = cast(Mapping[str, object], cofibration.get("cofibration", {}))
+        normalized_entries = cast(list[object], normalized_cofibration.get("entries", []))
+        if canonical_identity_kind:
+            self._cofibration_entry_count_by_kind[canonical_identity_kind] = len(
+                normalized_entries
+            )
+
     def on_equivalence_surface_row(
         self,
         *,
@@ -427,43 +615,22 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
             and bool(surface)
             and witness_id not in (None, "")
         ):
-            self._fungible_opportunities.append(
-                OpportunityDecisionProtocol(
-                    opportunity_id=f"opp:fungible-substitution:{surface}",
-                    kind="fungible_execution_path_substitution",
-                    affected_surfaces=(surface,),
-                    witness_ids=(str(witness_id),),
-                    reason="2-cell witness links baseline/current representatives",
-                    confidence_provenance=OpportunityConfidenceProvenance.MORPHISM_WITNESS,
-                    witness_requirement=OpportunityWitnessRequirement.TWO_CELL_WITNESS,
-                    actionability=OpportunityActionabilityState.ACTIONABLE,
-                )
-            )
+            self._non_drift_witness_ids_by_surface.setdefault(surface, set()).add(str(witness_id))
 
-    def _build_decisions(self) -> list[OpportunityDecisionProtocol]:
-        decisions: list[OpportunityDecisionProtocol] = []
+    def _normalize_observations(self) -> list[OpportunityAlgebraicObservation]:
+        observations: list[OpportunityAlgebraicObservation] = []
+
         for resume_ref in sort_once(
             self._materialize_kinds_by_resume_ref,
             source="aspf_visitors.OpportunityPayloadEmitter.materialize.resume_ref",
         ):
-            kinds = self._materialize_kinds_by_resume_ref[resume_ref]
-            fused = int("resume_load" in kinds and "resume_write" in kinds)
-            decisions.append(
-                OpportunityDecisionProtocol(
-                    opportunity_id=f"opp:materialize-load-fusion:{resume_ref}",
-                    kind=("materialize_load_observed", "materialize_load_fusion")[fused],
-                    affected_surfaces=(),
-                    witness_ids=(),
-                    reason=(
-                        "resume boundary observed state reference",
-                        "resume load and write boundaries share state reference",
-                    )[fused],
-                    confidence_provenance=OpportunityConfidenceProvenance.INGRESS_OBSERVATION,
-                    witness_requirement=OpportunityWitnessRequirement.NONE,
-                    actionability=(
-                        OpportunityActionabilityState.OBSERVATIONAL,
-                        OpportunityActionabilityState.ACTIONABLE,
-                    )[fused],
+            kinds = frozenset(self._materialize_kinds_by_resume_ref[resume_ref])
+            observations.append(
+                OpportunityAlgebraicObservation(
+                    structure=OpportunityStructure.ONE_CELL,
+                    subject_id=resume_ref,
+                    one_cell_count=len(kinds),
+                    one_cell_kinds=kinds,
                 )
             )
 
@@ -484,28 +651,55 @@ class OpportunityPayloadEmitter(NullAspfTraversalVisitor):
                     source="aspf_visitors.OpportunityPayloadEmitter.representative_witnesses",
                 )
             )
-            decisions.append(
-                OpportunityDecisionProtocol(
-                    opportunity_id=f"opp:reusable-boundary:{digest}",
-                    kind="reusable_boundary_artifact",
-                    affected_surfaces=surfaces,
+            observations.append(
+                OpportunityAlgebraicObservation(
+                    structure=OpportunityStructure.TWO_CELL,
+                    subject_id=digest,
+                    one_cell_count=len(surfaces),
+                    two_cell_count=len(witness_ids),
+                    surfaces=surfaces,
                     witness_ids=witness_ids,
-                    reason="multiple semantic surfaces share deterministic representative",
-                    confidence_provenance=(
-                        OpportunityConfidenceProvenance.REPRESENTATIVE_CONFLUENCE
-                        if not witness_ids
-                        else OpportunityConfidenceProvenance.MORPHISM_WITNESS
-                    ),
-                    witness_requirement=OpportunityWitnessRequirement.REPRESENTATIVE_PAIR,
-                    actionability=(
-                        OpportunityActionabilityState.OBSERVATIONAL
-                        if len(surfaces) < 2
-                        else OpportunityActionabilityState.ACTIONABLE
-                    ),
                 )
             )
 
-        decisions.extend(self._fungible_opportunities)
+        for surface in sort_once(
+            self._non_drift_witness_ids_by_surface,
+            source="aspf_visitors.OpportunityPayloadEmitter.non_drift_surfaces",
+        ):
+            witness_ids = tuple(
+                sort_once(
+                    self._non_drift_witness_ids_by_surface[surface],
+                    source="aspf_visitors.OpportunityPayloadEmitter.non_drift_witnesses",
+                )
+            )
+            observations.append(
+                OpportunityAlgebraicObservation(
+                    structure=OpportunityStructure.TWO_CELL,
+                    subject_id=surface,
+                    two_cell_count=len(witness_ids),
+                    surfaces=(surface,),
+                    witness_ids=witness_ids,
+                    classification="non_drift",
+                )
+            )
+
+        for identity_kind in sort_once(
+            self._cofibration_entry_count_by_kind,
+            source="aspf_visitors.OpportunityPayloadEmitter.cofibration_kind",
+        ):
+            observations.append(
+                OpportunityAlgebraicObservation(
+                    structure=OpportunityStructure.COFIBRATION,
+                    subject_id=identity_kind,
+                    cofibration_count=self._cofibration_entry_count_by_kind[identity_kind],
+                    witness_ids=(identity_kind,),
+                )
+            )
+
+        return observations
+
+    def _build_decisions(self) -> list[OpportunityDecisionProtocol]:
+        decisions = self.taxonomy.decisions_for(observations=self._normalize_observations())
         return sorted(decisions, key=lambda item: item.opportunity_id)
 
     def build_rows(self) -> list[JSONObject]:

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -56,7 +56,19 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
             "groups_by_path": "rep:a",
         },
         two_cell_witnesses=[],
-        cofibration_witnesses=[],
+        cofibration_witnesses=[
+            {
+                "canonical_identity_kind": "suite_site",
+                "cofibration": {
+                    "entries": [
+                        {
+                            "domain": {"key": "domain:x", "prime": 2},
+                            "aspf": {"key": "aspf:x", "prime": 2},
+                        }
+                    ]
+                },
+            }
+        ],
         visitor=emitter,
     )
     adapt_event_log_reader_iterator_to_visitor(
@@ -75,11 +87,17 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     assert "materialize_load_fusion" in kinds
     assert "reusable_boundary_artifact" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    assert "cofibration_prime_embedding_reuse" in kinds
     fungible = next(
         row for row in rows if isinstance(row, dict) and row.get("kind") == "fungible_execution_path_substitution"
     )
     assert fungible["actionability"] == "actionable"
     assert fungible["confidence_provenance"] == "morphism_witness"
+
+    cofibration = next(
+        row for row in rows if isinstance(row, dict) and row.get("kind") == "cofibration_prime_embedding_reuse"
+    )
+    assert cofibration["witness_requirement"] == "cofibration_witness"
 
     plans = emitter.build_rewrite_plans()
     assert plans


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc branching in opportunity emission by introducing a normalized, extensible decision surface for ASPF opportunity detection. 
- Expand the opportunity class set to cover cofibration-based evidence and make evidence requirements explicit and declarative.

### Description
- Introduce a registry/taxonomy for opportunity kinds keyed by algebraic predicates over ASPF structure via `OpportunityAlgebraicPredicate`, `OpportunityAlgebraicObservation`, `OpportunityTaxonomyRegistration`, and `OpportunityTaxonomyRegistry` in `src/gabion/analysis/aspf_visitors.py`.
- Add `OpportunityStructure` and extend witness requirements with `COFIBRATION_WITNESS`, and add the new opportunity kind `cofibration_prime_embedding_reuse` implemented in the default taxonomy builder.
- Add a normalization layer `_normalize_observations` in `OpportunityPayloadEmitter` that converts one-cell/two-cell/cofibration inputs into canonical observations consumed by the registry, removing ad-hoc `if` trees from `_build_decisions`.
- Update `docs/aspf_execution_fibration.md` to document the registry-based opportunity semantics, the expanded class set, and matching evidence requirements, and bump `doc_revision`.
- Update tests in `tests/test_aspf_visitors.py` to cover cofibration-driven opportunity emission and assert the new `cofibration_witness` requirement; refresh test evidence (`out/test_evidence.json`) accordingly.

### Testing
- Ran policy checks with `scripts/policy_check.py --workflows` and `scripts/policy_check.py --ambiguity-contract`, both completed (no blocking violations after adjustments).
- Executed unit tests with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py -q`, resulting in all tests passing (`17 passed`).
- Rebuilt the test evidence index with `scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`; differences in test line numbers were produced and recorded as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e3e398708324837ccf6715dd27d0)