### PR TITLE
Stream opportunities replay through canonical trace event iterator

### DIFF
--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -63,11 +63,17 @@ class AspfOneCellEvent:
     index: int
     payload: Mapping[str, object]
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.one_cell(self)
+
 
 @dataclass(frozen=True)
 class AspfTwoCellEvent:
     index: int
     payload: Mapping[str, object]
+
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.two_cell(self)
 
 
 @dataclass(frozen=True)
@@ -75,17 +81,27 @@ class AspfCofibrationEvent:
     index: int
     payload: Mapping[str, object]
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.cofibration(self)
+
 
 @dataclass(frozen=True)
 class AspfSurfaceUpdateEvent:
     surface: str
     representative: str
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.surface_update(self)
+
 
 @dataclass(frozen=True)
 class AspfRunBoundaryEvent:
     boundary: Literal["equivalence_surface_row"]
     payload: Mapping[str, object]
+
+
+class AspfTraceReplayEvent(Protocol):
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None: ...
 
 
 class AspfEventReplayVisitor(Protocol):
@@ -210,6 +226,15 @@ def adapt_live_event_stream_to_visitor(
                 representative=str(surface_representatives.get(surface, "")),
             )
         )
+
+
+def adapt_trace_event_iterator_to_visitor(
+    *,
+    events: Iterable[AspfTraceReplayEvent],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    for event in events:
+        event.dispatch_to(visitor)
 
 
 def adapt_event_log_reader_iterator_to_visitor(

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -4,10 +4,15 @@ from dataclasses import dataclass, field
 
 from gabion.analysis.aspf import Alt, Forest, Node
 from gabion.analysis.aspf_visitors import (
+    AspfCofibrationEvent,
+    AspfOneCellEvent,
+    AspfSurfaceUpdateEvent,
+    AspfTwoCellEvent,
     NullAspfTraversalVisitor,
     OpportunityPayloadEmitter,
     adapt_event_log_reader_iterator_to_visitor,
     adapt_live_event_stream_to_visitor,
+    adapt_trace_event_iterator_to_visitor,
     traverse_forest_to_visitor,
 )
 
@@ -84,6 +89,53 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     plans = emitter.build_rewrite_plans()
     assert plans
     assert plans[0]["opportunity_id"].startswith("opp:")
+
+
+def test_trace_event_iterator_adapter_dispatches_without_json_batching() -> None:
+    emitter = OpportunityPayloadEmitter()
+    adapt_trace_event_iterator_to_visitor(
+        events=[
+            AspfOneCellEvent(
+                index=0,
+                payload={
+                    "kind": "resume_load",
+                    "metadata": {"import_state_path": "state/a.json"},
+                },
+            ),
+            AspfOneCellEvent(
+                index=1,
+                payload={
+                    "kind": "resume_write",
+                    "metadata": {"state_path": "state/a.json"},
+                },
+            ),
+            AspfTwoCellEvent(
+                index=0,
+                payload={
+                    "witness_id": "w:1",
+                    "left_representative": "rep:a",
+                    "right_representative": "rep:b",
+                },
+            ),
+            AspfCofibrationEvent(index=0, payload={"canonical_identity_kind": "k"}),
+            AspfSurfaceUpdateEvent(surface="groups_by_path", representative="rep:a"),
+        ],
+        visitor=emitter,
+    )
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=[
+            {
+                "surface": "groups_by_path",
+                "classification": "non_drift",
+                "witness_id": "w:1",
+            }
+        ],
+        visitor=emitter,
+    )
+
+    kinds = {str(row.get("kind")) for row in emitter.build_rows() if isinstance(row, dict)}
+    assert "materialize_load_fusion" in kinds
+    assert "fungible_execution_path_substitution" in kinds
 
 
 def test_null_visitor_noop_methods_are_callable() -> None:


### PR DESCRIPTION
### Motivation
- Remove the batch dependency in `build_opportunities_payload` by streaming trace events to the opportunity visitor to avoid constructing large transient JSON containers while preserving the existing output contract.
- Provide a single canonical, deterministic trace event iteration entrypoint so sinks and in-memory state are replayed in a consistent order.
- Keep equivalence-row handling unchanged and preserve the opportunities payload schema for CLI/consumer compatibility.

### Description
- Added a canonical iterator `def _iter_trace_events(*, state: AspfExecutionTraceState) -> Iterator[...]` in `src/gabion/analysis/aspf_execution_fibration.py` that yields typed events in deterministic order for both sink-backed and in-memory trace sources and introduced helper `_iter_memory_one_cell_payloads` for memory one-cell normalization.
- Replaced the internal `build_opportunities_payload` dependence on `build_trace_payload(state)` with a streaming path that calls `adapt_trace_event_iterator_to_visitor(events=_iter_trace_events(state=state), visitor=emitter)` while keeping `adapt_event_log_reader_iterator_to_visitor` for equivalence rows and preserving the output fields (`format_version`, `trace_id`, `opportunities`, `rewrite_plans`).
- Added a typed iterator adapter `adapt_trace_event_iterator_to_visitor` and a small event-dispatch API in `src/gabion/analysis/aspf_visitors.py` by adding `dispatch_to` methods on the event dataclasses and a `AspfTraceReplayEvent` protocol so events are dispatched directly to `AspfEventReplayVisitor` methods (`one_cell`, `two_cell`, `cofibration`, `surface_update`) without intermediate JSON batching.
- Added a unit test `test_trace_event_iterator_adapter_dispatches_without_json_batching` to `tests/test_aspf_visitors.py` to validate iterator-based dispatch and updated `out/test_evidence.json` to reflect test changes.

### Testing
- Ran policy checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` and the check completed successfully.
- Ran ambiguity contract checks with `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` and the check completed successfully.
- Ran unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py` and all tests passed (`18 passed`).
- Ran `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` to refresh evidence; the evidence file was updated to reflect the new test positions and included in the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e42c83088324b5446e6319172f12)