### PR TITLE
Refactor ASPF replay to iterator-native visitor dispatch

### DIFF
--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -223,6 +223,28 @@ def adapt_event_log_reader_iterator_to_visitor(
         )
 
 
+def replay_iterator_inputs_to_visitor(
+    *,
+    one_cells: Iterable[Mapping[str, object]],
+    two_cell_witnesses: Iterable[Mapping[str, object]],
+    cofibration_witnesses: Iterable[Mapping[str, object]],
+    surface_representatives: Mapping[str, str],
+    equivalence_surface_rows: Iterable[Mapping[str, object]],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    adapt_live_event_stream_to_visitor(
+        one_cells=one_cells,
+        two_cell_witnesses=two_cell_witnesses,
+        cofibration_witnesses=cofibration_witnesses,
+        surface_representatives=surface_representatives,
+        visitor=visitor,
+    )
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=equivalence_surface_rows,
+        visitor=visitor,
+    )
+
+
 @dataclass
 class TracePayloadEmitter(NullAspfTraversalVisitor):
     one_cells: list[JSONValue] = field(default_factory=list)


### PR DESCRIPTION
### Motivation
- Stop forcing list materialization for sink-backed replay consumers so visitors can operate on iterator inputs and avoid unnecessary memory allocation.
- Provide a clear dual-path: iterator-native replay for runtime visitors and an optional materialization path only when producing final JSON artifacts.
- Preserve deterministic ordering for surface representatives by keeping `sort_once` semantics at replay boundaries.

### Description
- Add `replay_iterator_inputs_to_visitor` in `src/gabion/analysis/aspf_visitors.py` that accepts iterator inputs (`Iterable[Mapping[str, object]]`) and replays both trace and equivalence rows to an `AspfEventReplayVisitor` without requiring list casting. 
- Introduce `AspfTraceReplayIterators` and `_build_trace_replay_iterators` in `src/gabion/analysis/aspf_execution_fibration.py` to expose iterator-native replay bundles backed by either sink indexes (file iterators) or in-memory generators. 
- Update `build_trace_payload` and `build_opportunities_payload` to dispatch visitor-based computations via the iterator-native path (`replay_iterator_inputs_to_visitor`) and keep the legacy materialization confined to emitter logic for JSON output. 
- Add `_iter_equivalence_surface_rows` to normalize equivalence rows as an iterator and ensure `sort_once` is preserved for `surface_representatives` in both sink and memory paths.

### Testing
- Ran policy workflow checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` and they completed successfully. 
- Ran ambiguity contract checks with `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` and they completed successfully. 
- Executed targeted unit tests with `PYTHONPATH=src pytest -q -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py` which passed (`17 passed`). 
- Generated evidence with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and verified `git diff --exit-code out/test_evidence.json` returned clean (no diff).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e4308a508324bcded3744744b4d3)