### PR TITLE
Refactor ASPF handoff to journal-first event projection

### DIFF
--- a/scripts/aspf_handoff.py
+++ b/scripts/aspf_handoff.py
@@ -18,6 +18,7 @@ def _prepare(args: argparse.Namespace) -> int:
         command_profile=args.command_profile,
         manifest_path=Path(args.manifest) if args.manifest else None,
         state_root=Path(args.state_root) if args.state_root else None,
+        write_manifest_projection=not args.no_manifest_projection,
     )
     payload = {
         "sequence": prepared.sequence,
@@ -43,6 +44,7 @@ def _record(args: argparse.Namespace) -> int:
         status=args.status,
         exit_code=args.exit_code,
         analysis_state=args.analysis_state,
+        write_manifest_projection=not args.no_manifest_projection,
     )
     print(json.dumps({"ok": bool(ok)}, indent=2, sort_keys=False))
     return 0 if ok else 1
@@ -69,6 +71,7 @@ def _run(args: argparse.Namespace) -> int:
         command_profile=args.command_profile,
         manifest_path=Path(args.manifest) if args.manifest else None,
         state_root=Path(args.state_root) if args.state_root else None,
+        write_manifest_projection=not args.no_manifest_projection,
     )
     command_with_aspf = tuple([*raw_command, *aspf_handoff.aspf_cli_args(prepared)])
     completed = subprocess.run(list(command_with_aspf), check=False)
@@ -82,6 +85,7 @@ def _run(args: argparse.Namespace) -> int:
         status=status,
         exit_code=exit_code,
         analysis_state=analysis_state,
+        write_manifest_projection=not args.no_manifest_projection,
     )
     payload = {
         "ok": bool(ok),
@@ -125,6 +129,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--state-root",
         default="artifacts/out/aspf_state",
     )
+    prepare.add_argument(
+        "--no-manifest-projection",
+        action="store_true",
+        help="Skip writing manifest projection cache (journal remains canonical).",
+    )
 
     record = subparsers.add_parser(
         "record",
@@ -139,6 +148,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     record.add_argument("--status", required=True)
     record.add_argument("--exit-code", type=int, default=None)
     record.add_argument("--analysis-state", default=None)
+    record.add_argument(
+        "--no-manifest-projection",
+        action="store_true",
+        help="Skip writing manifest projection cache (journal remains canonical).",
+    )
 
     run = subparsers.add_parser(
         "run",
@@ -157,6 +171,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     run.add_argument(
         "--state-root",
         default="artifacts/out/aspf_state",
+    )
+    run.add_argument(
+        "--no-manifest-projection",
+        action="store_true",
+        help="Skip writing manifest projection cache (journal remains canonical).",
     )
     run.add_argument("command", nargs=argparse.REMAINDER)
 

--- a/tests/test_aspf_handoff.py
+++ b/tests/test_aspf_handoff.py
@@ -236,3 +236,69 @@ def test_load_manifest_folds_journal_when_index_missing(tmp_path: Path) -> None:
     assert isinstance(entries, list)
     assert len(entries) == 1
     assert entries[0].get("status") == "success"
+
+
+# gabion:evidence E:function_site::tests/test_aspf_handoff.py::test_handoff_fold_journal_is_idempotent
+def test_handoff_fold_journal_is_idempotent(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    state_root = tmp_path / "state"
+    session_id = "session-idempotent"
+
+    step = aspf_handoff.prepare_step(
+        root=tmp_path,
+        session_id=session_id,
+        step_id="check.run",
+        command_profile="check.run",
+        manifest_path=manifest_path,
+        state_root=state_root,
+    )
+    assert aspf_handoff.record_step(
+        manifest_path=manifest_path,
+        session_id=session_id,
+        sequence=step.sequence,
+        status="success",
+        exit_code=0,
+        analysis_state="succeeded",
+    )
+
+    journal_path = manifest_path.with_name("manifest.journal.jsonl")
+    first = aspf_handoff._fold_journal(journal_path)
+    second = aspf_handoff._fold_journal(journal_path)
+    assert first == second
+    entries = first.get("entries")
+    assert isinstance(entries, list)
+    assert entries[0].get("status") == "success"
+
+
+# gabion:evidence E:function_site::tests/test_aspf_handoff.py::test_prepare_record_can_skip_manifest_projection_write
+def test_prepare_record_can_skip_manifest_projection_write(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    state_root = tmp_path / "state"
+    session_id = "session-no-manifest"
+
+    step = aspf_handoff.prepare_step(
+        root=tmp_path,
+        session_id=session_id,
+        step_id="check.run",
+        command_profile="check.run",
+        manifest_path=manifest_path,
+        state_root=state_root,
+        write_manifest_projection=False,
+    )
+    assert not manifest_path.exists()
+    assert aspf_handoff.record_step(
+        manifest_path=manifest_path,
+        session_id=session_id,
+        sequence=step.sequence,
+        status="success",
+        exit_code=0,
+        analysis_state="succeeded",
+        write_manifest_projection=False,
+    )
+    assert not manifest_path.exists()
+
+    projected = aspf_handoff.load_manifest(manifest_path)
+    entries = projected.get("entries")
+    assert isinstance(entries, list)
+    assert len(entries) == 1
+    assert entries[0].get("status") == "success"


### PR DESCRIPTION
### Motivation
- Make the journal (`.journal.jsonl`) the canonical durability source and treat the manifest as a materialized projection to simplify reasoning and avoid repeated full-manifest mutation loops. 
- Ensure `prepare_step`/`record_step` append durable events first and then derive manifest state deterministically via a single reducer so replay is idempotent and the projection logic is centralized.

### Description
- Introduced typed events `PrepareStepEvent` and `RecordStepEvent` plus a projection state and reducer `HandoffEventReducer` to fold journal events into a materialized manifest (`src/gabion/tooling/aspf_handoff.py`).
- Updated `prepare_step` and `record_step` to append event records to the journal first and then compute an optional manifest projection; added `write_manifest_projection` flags to control whether the projection is written.
- Made `load_manifest` route through the same reducer path so manifest-compatible payloads and journal folds share the same projection logic, with an option `cache_projection` to control writeback.
- Added script wrapper option `--no-manifest-projection` and wired it through the wrapper (`scripts/aspf_handoff.py`) so callers can use journal-only durability.
- Extended tests in `tests/test_aspf_handoff.py` with an idempotent replay/fold test and a `write_manifest_projection=False` behavior test, and refreshed `out/test_evidence.json` to include the new tests.

### Testing
- Ran the updated unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf_handoff.py` and all tests passed (`7 passed`).
- Executed policy checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`, both completed successfully.
- Verified syntax/byte-compile with `python -m py_compile src/gabion/tooling/aspf_handoff.py scripts/aspf_handoff.py tests/test_aspf_handoff.py` which succeeded.
- Ran test evidence extraction with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and refreshed `out/test_evidence.json` to include the new tests (diff expected and included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e4380dd483248ea4b6b7eb43e318)