### PR TITLE
Add streaming JSONL import and unified visitor-driven merge for ASPF traces

### DIFF
--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -50,6 +50,12 @@ from .aspf_stream import (
     TwoCellWitnessRecorded,
 )
 from .aspf_visitors import (
+    AspfCofibrationEvent,
+    AspfEventReplayVisitor,
+    AspfOneCellEvent,
+    AspfRunBoundaryEvent,
+    AspfSurfaceUpdateEvent,
+    AspfTwoCellEvent,
     OpportunityPayloadEmitter,
     StatePayloadEmitter,
     TracePayloadEmitter,
@@ -301,12 +307,8 @@ def merge_imported_trace(
     state: AspfExecutionTraceState,
     trace_payload: Mapping[str, object],
 ) -> None:
-    payload = {str(key): trace_payload[key] for key in trace_payload}
-    state.imported_trace_payloads.append(payload)
-    _merge_surface_representatives(state=state, trace_payload=payload)
-    _merge_one_cells(state=state, trace_payload=payload)
-    _merge_two_cells(state=state, trace_payload=payload)
-    _merge_cofibrations(state=state, trace_payload=payload)
+    payload = normalize_imported_trace_payload(trace_payload)
+    _merge_imported_trace_with_visitor(state=state, trace_payload=payload)
 
 
 def merge_imported_trace_paths(
@@ -315,8 +317,8 @@ def merge_imported_trace_paths(
     paths: Sequence[Path],
 ) -> None:
     for path in paths:
-        payload = load_trace_payload(path)
-        merge_imported_trace(state=state, trace_payload=payload)
+        payload = _load_trace_payload_for_import(path)
+        _merge_imported_trace_with_visitor(state=state, trace_payload=payload)
 
 
 def register_semantic_surface(
@@ -644,10 +646,36 @@ def finalize_execution_trace(
 
 def load_trace_payload(path: Path) -> JSONObject:
     payload = cast(Mapping[str, object], json.loads(path.read_text(encoding="utf-8")))
+    return normalize_imported_trace_payload(payload)
+
+
+def load_trace_stream_payload(path: Path) -> JSONObject:
+    events: list[JSONObject] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle):
+            line = raw.strip()
+            if not line:
+                continue
+            payload = cast(Mapping[str, object], json.loads(line))
+            normalized_event = {str(key): _as_json_value(payload[key]) for key in payload}
+            normalized_event.setdefault("line", line_number)
+            events.append(normalized_event)
+    ordered_events = sort_once(
+        events,
+        key=_event_ordering_key,
+        source="aspf_execution_fibration.load_trace_stream_payload.events",
+    )
+    return normalize_imported_trace_payload({"events": ordered_events})
+
+
+def normalize_imported_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    if "events" in payload:
+        return _normalize_stream_trace_payload(payload)
+
     normalized_payload = {str(key): _as_json_value(payload[key]) for key in payload}
     trace_payload = normalized_payload.get("trace")
     if trace_payload is None:
-        return normalized_payload
+        return _normalize_legacy_trace_payload(normalized_payload)
     trace_payload = cast(Mapping[str, object], trace_payload)
     normalized_trace: JSONObject = {
         str(key): _as_json_value(trace_payload[key]) for key in trace_payload
@@ -664,7 +692,7 @@ def load_trace_payload(path: Path) -> JSONObject:
     normalized_trace["opportunities"] = {
         str(key): _as_json_value(opportunities_payload[key]) for key in opportunities_payload
     }
-    return normalized_trace
+    return _normalize_legacy_trace_payload(normalized_trace)
 
 
 def _command_profile_from_payload(payload: Mapping[str, object]) -> str:
@@ -672,6 +700,123 @@ def _command_profile_from_payload(payload: Mapping[str, object]) -> str:
         payload.get("synthesis_report")
     )
     return ("check.run", "synth")[int(synth_requested)]
+
+
+def _load_trace_payload_for_import(path: Path) -> JSONObject:
+    suffix = path.suffix.lower()
+    if suffix in {".jsonl", ".ndjson"}:
+        return load_trace_stream_payload(path)
+    return load_trace_payload(path)
+
+
+def _normalize_legacy_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    normalized_payload = {str(key): _as_json_value(payload[key]) for key in payload}
+    normalized_payload.setdefault("surface_representatives", {})
+    normalized_payload.setdefault("one_cells", [])
+    normalized_payload.setdefault("two_cell_witnesses", [])
+    normalized_payload.setdefault("cofibration_witnesses", [])
+    return normalized_payload
+
+
+def _normalize_stream_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    raw_events = cast(Sequence[Mapping[str, object]], payload.get("events", []))
+    ordered_events = sort_once(
+        [
+            {str(key): _as_json_value(event[key]) for key in event}
+            for event in raw_events
+            if isinstance(event, Mapping)
+        ],
+        key=_event_ordering_key,
+        source="aspf_execution_fibration._normalize_stream_trace_payload.events",
+    )
+    emitter = TracePayloadEmitter()
+    _adapt_streamed_trace_events_to_visitor(events=ordered_events, visitor=emitter)
+    return _normalize_legacy_trace_payload(
+        {
+            "surface_representatives": emitter.surface_representatives,
+            "one_cells": emitter.one_cells,
+            "two_cell_witnesses": emitter.two_cell_witnesses,
+            "cofibration_witnesses": emitter.cofibration_witnesses,
+        }
+    )
+
+
+def _event_ordering_key(event: Mapping[str, object]) -> tuple[int, int, int]:
+    sequence = int(event.get("sequence", event.get("index", event.get("line", 0))))
+    kind = str(event.get("kind", "")).strip().lower()
+    kind_rank = {
+        "one_cell": 0,
+        "two_cell": 1,
+        "cofibration": 2,
+        "surface_update": 3,
+    }.get(kind, 9)
+    line = int(event.get("line", 0))
+    return (sequence, kind_rank, line)
+
+
+def _adapt_streamed_trace_events_to_visitor(
+    *,
+    events: Sequence[Mapping[str, object]],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    for event in events:
+        kind = str(event.get("kind", "")).strip().lower()
+        sequence = int(event.get("sequence", event.get("index", event.get("line", 0))))
+        payload = cast(Mapping[str, object], event.get("payload", {}))
+        if kind == "one_cell":
+            visitor.one_cell(AspfOneCellEvent(index=sequence, payload=payload))
+        elif kind == "two_cell":
+            visitor.two_cell(AspfTwoCellEvent(index=sequence, payload=payload))
+        elif kind == "cofibration":
+            visitor.cofibration(AspfCofibrationEvent(index=sequence, payload=payload))
+        elif kind == "surface_update":
+            visitor.surface_update(
+                AspfSurfaceUpdateEvent(
+                    surface=str(event.get("surface", "")),
+                    representative=str(event.get("representative", "")),
+                )
+            )
+
+
+@dataclass
+class _ImportedTraceMergeVisitor:
+    state: AspfExecutionTraceState
+
+    def one_cell(self, event: AspfOneCellEvent) -> None:
+        _merge_one_cell_payload(state=self.state, one_cell_payload=event.payload)
+
+    def two_cell(self, event: AspfTwoCellEvent) -> None:
+        _merge_two_cell_payload(state=self.state, witness_payload=event.payload)
+
+    def cofibration(self, event: AspfCofibrationEvent) -> None:
+        _merge_cofibration_payload(state=self.state, cofibration_payload=event.payload)
+
+    def surface_update(self, event: AspfSurfaceUpdateEvent) -> None:
+        _merge_surface_representative(
+            state=self.state,
+            surface=event.surface,
+            representative=event.representative,
+        )
+
+    def run_boundary(self, event: AspfRunBoundaryEvent) -> None:
+        return None
+
+
+def _merge_imported_trace_with_visitor(
+    *,
+    state: AspfExecutionTraceState,
+    trace_payload: Mapping[str, object],
+) -> None:
+    payload = normalize_imported_trace_payload(trace_payload)
+    state.imported_trace_payloads.append(payload)
+    visitor = _ImportedTraceMergeVisitor(state=state)
+    adapt_live_event_stream_to_visitor(
+        one_cells=cast(list[Mapping[str, object]], payload["one_cells"]),
+        two_cell_witnesses=cast(list[Mapping[str, object]], payload["two_cell_witnesses"]),
+        cofibration_witnesses=cast(list[Mapping[str, object]], payload["cofibration_witnesses"]),
+        surface_representatives=cast(Mapping[str, str], payload["surface_representatives"]),
+        visitor=visitor,
+    )
 
 
 def _build_state_payload(
@@ -906,54 +1051,49 @@ def _write_json(path: Path, payload: Mapping[str, object]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def _merge_surface_representatives(
+def _merge_surface_representative(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    surface: str,
+    representative: str,
 ) -> None:
-    raw = trace_payload["surface_representatives"]
-    for key in raw:
-        state.surface_representatives.setdefault(str(key), str(raw[key]))
+    state.surface_representatives.setdefault(str(surface), str(representative))
 
 
-def _merge_one_cells(
+def _merge_one_cell_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    one_cell_payload: Mapping[str, object],
 ) -> None:
-    raw_cells = trace_payload["one_cells"]
-    for raw in raw_cells:
-        source = str(raw["source"])
-        target = str(raw["target"])
-        representative = str(raw["representative"])
-        basis_path = tuple(str(item) for item in raw["basis_path"])
-        record_1cell(
-            state,
-            kind=str(raw.get("kind", "imported_1cell")),
-            source_label=source,
-            target_label=target,
-            representative=representative,
-            basis_path=basis_path,
-            surface=str(raw.get("surface", "")) or None,
-            metadata=raw.get("metadata"),
-        )
+    source = str(one_cell_payload["source"])
+    target = str(one_cell_payload["target"])
+    representative = str(one_cell_payload["representative"])
+    basis_path = tuple(str(item) for item in one_cell_payload["basis_path"])
+    record_1cell(
+        state,
+        kind=str(one_cell_payload.get("kind", "imported_1cell")),
+        source_label=source,
+        target_label=target,
+        representative=representative,
+        basis_path=basis_path,
+        surface=str(one_cell_payload.get("surface", "")) or None,
+        metadata=one_cell_payload.get("metadata"),
+    )
 
 
-def _merge_two_cells(
+def _merge_two_cell_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    witness_payload: Mapping[str, object],
 ) -> None:
-    raw_witnesses = trace_payload["two_cell_witnesses"]
-    for raw in raw_witnesses:
-        parsed = cast(AspfTwoCellWitness, parse_2cell_witness(raw))
-        record_2cell_witness(
-            state,
-            left=parsed.left,
-            right=parsed.right,
-            witness_id=parsed.witness_id,
-            reason=parsed.reason,
-        )
+    parsed = cast(AspfTwoCellWitness, parse_2cell_witness(witness_payload))
+    record_2cell_witness(
+        state,
+        left=parsed.left,
+        right=parsed.right,
+        witness_id=parsed.witness_id,
+        reason=parsed.reason,
+    )
 
 
 def _publish_event(
@@ -979,19 +1119,17 @@ def _publish_event(
             visitor.visit_run_finalized(event)
 
 
-def _merge_cofibrations(
+def _merge_cofibration_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    cofibration_payload: Mapping[str, object],
 ) -> None:
-    raw_cofibrations = trace_payload["cofibration_witnesses"]
-    for raw in raw_cofibrations:
-        cofibration = _parse_cofibration(raw["cofibration"])
-        record_cofibration(
-            state=state,
-            canonical_identity_kind=str(raw["canonical_identity_kind"]),
-            cofibration=cofibration,
-        )
+    cofibration = _parse_cofibration(cast(Mapping[str, object], cofibration_payload["cofibration"]))
+    record_cofibration(
+        state=state,
+        canonical_identity_kind=str(cofibration_payload["canonical_identity_kind"]),
+        cofibration=cofibration,
+    )
 
 
 def _parse_cofibration(raw: Mapping[str, object]) -> DomainToAspfCofibration:
@@ -1108,4 +1246,4 @@ def _find_witness(
 
 def _iter_baseline_trace_payloads(paths: Iterable[Path]) -> Iterator[JSONObject]:
     for path in paths:
-        yield load_trace_payload(path)
+        yield _load_trace_payload_for_import(path)


### PR DESCRIPTION
### Motivation
- Provide a streaming trace ingestion path (JSONL/event log) alongside the existing legacy full-JSON payload loader to support large/streamed ASPF traces.
- Ensure deterministic ordering of streamed events so replay and merge behavior is stable and reproducible.
- Collapse duplicated merging logic by routing both legacy and streamed inputs into a single visitor-driven merge implementation to keep the semantic core unchanged and maintain backwards compatibility at the ingress boundary.

### Description
- Added a JSONL/event-log trace reader `load_trace_stream_payload` with deterministic ordering using `_event_ordering_key` and normalization into internal event records.
- Introduced `normalize_imported_trace_payload` and `_load_trace_payload_for_import` to accept both legacy full-trace payloads and stream payloads and to choose the streaming reader based on file extension (`.jsonl`/`.ndjson`) at ingress only.
- Implemented a single visitor-driven merge path via `_merge_imported_trace_with_visitor` and `_ImportedTraceMergeVisitor`, and factored per-payload handlers `_merge_one_cell_payload`, `_merge_two_cell_payload`, `_merge_cofibration_payload`, and `_merge_surface_representative` so semantic-core logic is not duplicated.
- Hooked streamed events into existing replay helpers via `_adapt_streamed_trace_events_to_visitor` and `TracePayloadEmitter` so both formats produce identical normalized trace payload structures.
- Updated `merge_imported_trace_paths` and baseline iterators to pick the streaming path when appropriate and added a regression test `test_merge_imported_trace_paths_streaming_matches_legacy_payload_merge` to assert equivalence between legacy JSON import and streaming JSONL import.
- Updated `out/test_evidence.json` to reflect relocated/added evidence mappings for the new functions and tests.

### Testing
- Ran policy checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`, both succeeded in the repo environment.
- Ran unit tests with `PYTHONPATH=src pytest -q -o addopts='' tests/test_aspf_execution_fibration.py` and observed `14 passed`.
- Ran `python -m py_compile src/gabion/analysis/aspf_execution_fibration.py tests/test_aspf_execution_fibration.py` to validate syntax and `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` to refresh evidence, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e43421f4832486e122e5a922ca8b)