### PR TITLE
Migrate decision/value/never facets to SuiteSite carriers and add projection-parity tests

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 160
+doc_revision: 161
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -39,7 +39,7 @@ doc_review_notes:
   glossary.md#deadness_witness: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
   glossary.md#exception_obligation: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_sections:
-  sppf_checklist: 8
+  sppf_checklist: 9
 doc_section_requires:
   sppf_checklist:
     - README.md#repo_contract
@@ -55,47 +55,47 @@ doc_section_reviews:
   sppf_checklist:
     README.md#repo_contract:
       dep_version: 2
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Repo contract rev2 reviewed; command and artifact guidance remains aligned."
     CONTRIBUTING.md#contributing_contract:
       dep_version: 2
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Contributor contract rev2 reviewed; dual-sensor cadence and correction gates remain aligned."
     glossary.md#decision_table:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_table rev1 (decision table tier definition)."
     glossary.md#decision_bundle:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_bundle rev1 (decision bundle tier definition)."
     glossary.md#decision_protocol:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_protocol rev1 (decision protocol tier definition)."
     glossary.md#decision_surface:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_surface rev1 (decision surface tier boundary semantics)."
     glossary.md#value_encoded_decision:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#value_encoded_decision rev1 (value-encoded decision surface semantics)."
     glossary.md#deadness_witness:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
     glossary.md#exception_obligation:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
@@ -213,7 +213,7 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - <a id="in-23-aspf-carrier-formalization"></a>[x] ASPF carrier obligations formalized (determinism, base conservation, ctor coherence, synth tail reversibility, provenance completeness, snapshot reproducibility). (in-23, GH-73; anchors: `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_provenance`, `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_synth`, `src/gabion/analysis/type_fingerprints.py::build_synth_registry_from_payload`, `tests/test_type_fingerprints.py::test_build_fingerprint_registry_deterministic_assignment`, `tests/test_type_fingerprints.py::test_synth_registry_payload_roundtrip`, `tests/test_fingerprint_warnings.py::test_fingerprint_provenance_emits_entries`, `scripts/audit_snapshot.sh`, `scripts/latest_snapshot.sh`). sppf{doc=done; impl=done; doc_ref=in-23@10}
 - [~] SuiteSite carriers + loop-scoped deadline obligations (recursive loop attribution now outer-vs-inner precise; SuiteSite-native enforcement still incomplete). Evidence anchors: `src/gabion/analysis/dataflow_obligations.py::collect_deadline_obligations`, `tests/test_deadline_coverage.py::test_deadline_loop_unchecked_status_is_root_gated`. (in-30, GH-85) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
 - [~] Deadline propagation as gas (ticks-based carriers across LSP/CLI/server; carrier budget semantics are stable but broader lane acceptance remains partial). Evidence anchors: `scripts/deadline_runtime.py::deadline_scope_from_lsp_env`, `tests/test_deadline_runtime.py::test_deadline_scope_from_lsp_env_uses_default_and_explicit_gas_limit`. (in-30, GH-87) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
-- [~] Structural ambiguity as CallCandidate alts (SuiteSite) with virtual AmbiguitySet (materialization landed; phase-3/4 decision-surface migration deferred). Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_materialize_call_candidates`, `tests/test_deadline_coverage.py::test_materialized_call_candidates_target_function_suites`. (in-30, GH-88) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
+- [x] Structural ambiguity as CallCandidate alts (SuiteSite) with SuiteSite-native decision/never facets; function-level decision and never views are projection-only and parity-verified by regression tests. Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_analyze_decision_surface_indexed`, `src/gabion/analysis/dataflow_audit.py::_collect_never_invariants`, `src/gabion/analysis/test_evidence_suggestions.py::_facet_site_id`, `tests/test_suite_site_projection_parity.py::test_decision_surface_function_projection_parity_from_suite_sites`, `tests/test_suite_site_projection_parity.py::test_never_invariant_function_projection_parity_from_suite_sites`. (in-30, GH-88) sppf{doc=done; impl=done; doc_ref=in-30@27}
 - <a id="in-33-pattern-schema-unification"></a>[~] PatternSchema unification for dataflow bundles + execution patterns (shared cross-axis `schema:*` IDs, contract-versioned residue payloads, deterministic artifact ordering, Tier-2 residue ratchet/metafactory gate landed; execution rules still narrow). (in-33) sppf{doc=partial; impl=partial; doc_ref=in-33@3}
 - <a id="in-34-lambda-callable-sites"></a>[~] Lambda/closure callable indexing as first-class function sites (stable synthetic identities + direct/bound/closure lambda resolution; conservative dynamic fallback retained for unresolved alias/dynamic paths). Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_resolve_callee_outcome`, `tests/test_dataflow_resolve_callee.py::test_resolve_callee_bound_lambda_call`, `tests/test_dataflow_resolve_callee.py::test_resolve_callee_outcome_keeps_dynamic_fallback_for_attribute_calls`. (in-34) sppf{doc=partial; impl=partial; doc_ref=in-34@2}
 - <a id="in-35-dict-key-carrier-tracking"></a>[~] Dict carrier tracking beyond literal subscript aliases (name-bound constant keys + unknown-key carrier evidence; key grammar remains conservative by design). Evidence anchors: `src/gabion/analysis/visitors.py::_normalize_key`, `tests/test_visitors_unit.py::test_subscript_forwarding_normalizes_const_keys`, `tests/test_visitors_unit.py::test_subscript_dynamic_key_marks_uncertainty`. (in-35) sppf{doc=partial; impl=partial; doc_ref=in-35@1}

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -2257,7 +2257,12 @@ def _analyze_decision_surface_indexed(
             else f"internal callers (transitive): {caller_count}"
         )
         descriptor = spec.descriptor(info, boundary)
-        site_id = forest.add_site(info.path.name, info.qual)
+        suite_id = forest.add_suite_site(
+            info.path.name,
+            info.qual,
+            "function_body",
+            span=info.function_span,
+        )
         paramset_id = forest.add_paramset(params)
         reason_summary = (
             _decision_reason_summary(info, params)
@@ -2266,7 +2271,7 @@ def _analyze_decision_surface_indexed(
         )
         forest.add_alt(
             spec.alt_kind,
-            (site_id, paramset_id),
+            (suite_id, paramset_id),
             evidence=_decision_surface_alt_evidence(
                 spec=spec,
                 boundary=boundary,
@@ -5512,7 +5517,12 @@ def _collect_never_invariants(
                     entry["environment_ref"] = environment_ref
                 entry["span"] = list(normalized_span)
                 invariants.append(entry)
-                site_id = forest.add_site(path.name, function)
+                site_id = forest.add_suite_site(
+                    path.name,
+                    function,
+                    "call",
+                    span=normalized_span,
+                )
                 paramset_id = forest.add_paramset(bundle)
                 evidence: dict[str, object] = {"path": path.name, "qual": function}
                 if reason:

--- a/tests/test_suite_site_projection_parity.py
+++ b/tests/test_suite_site_projection_parity.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _load():
+    from gabion.analysis import dataflow_audit as da
+
+    return da
+
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._analyze_decision_surface_indexed
+def test_decision_surface_function_projection_parity_from_suite_sites(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "mod.py"
+    path.write_text(
+        "def choose(flag, mode):\n"
+        "    if flag:\n"
+        "        return mode\n"
+        "    return mode\n"
+    )
+
+    forest = da.Forest()
+    analysis = da.analyze_paths(
+        forest=forest,
+        paths=[path],
+        recursive=True,
+        type_audit=False,
+        type_audit_report=False,
+        type_audit_max=0,
+        include_constant_smells=False,
+        include_unused_arg_smells=False,
+        include_decision_surfaces=True,
+        config=da.AuditConfig(project_root=tmp_path),
+    )
+
+    decision_alts = [alt for alt in forest.alts if alt.kind == "DecisionSurface"]
+    assert decision_alts
+    projected: list[str] = []
+    for alt in decision_alts:
+        suite_node = forest.nodes[alt.inputs[0]]
+        assert suite_node.kind == "SuiteSite"
+        assert suite_node.meta.get("suite_kind") == "function_body"
+        params = list(forest.nodes[alt.inputs[1]].meta.get("params", []))
+        descriptor = str(alt.evidence.get("classification_descriptor", "") or "")
+        projected.append(
+            f"{suite_node.meta['path']}:{suite_node.meta['qual']} decision surface params: {', '.join(params)} ({descriptor})"
+        )
+
+    assert sorted(projected) == sorted(analysis.decision_surfaces)
+
+
+# gabion:evidence E:never/sink::dataflow_audit.py::gabion.analysis.dataflow_audit._collect_never_invariants
+def test_never_invariant_function_projection_parity_from_suite_sites(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "never_case.py"
+    path.write_text(
+        "from gabion.invariants import never\n\n"
+        "def fail_fast(flag):\n"
+        "    if flag:\n"
+        "        never('stop')\n"
+    )
+
+    forest = da.Forest()
+    analysis = da.analyze_paths(
+        forest=forest,
+        paths=[path],
+        recursive=True,
+        type_audit=False,
+        type_audit_report=False,
+        type_audit_max=0,
+        include_constant_smells=False,
+        include_unused_arg_smells=False,
+        include_never_invariants=True,
+        config=da.AuditConfig(project_root=tmp_path),
+    )
+
+    sink_alts = [alt for alt in forest.alts if alt.kind == "NeverInvariantSink"]
+    assert sink_alts
+    projected = {
+        (
+            str(forest.nodes[alt.inputs[0]].meta.get("path", "")),
+            str(forest.nodes[alt.inputs[0]].meta.get("qual", "")),
+            tuple(str(item) for item in forest.nodes[alt.inputs[1]].meta.get("params", [])),
+        )
+        for alt in sink_alts
+    }
+    for alt in sink_alts:
+        suite_node = forest.nodes[alt.inputs[0]]
+        assert suite_node.kind == "SuiteSite"
+        assert suite_node.meta.get("suite_kind") == "call"
+
+    projected_entries = {
+        (
+            str(entry.get("site", {}).get("path", "")),
+            str(entry.get("site", {}).get("function", "")),
+            tuple(str(item) for item in entry.get("site", {}).get("bundle", [])),
+        )
+        for entry in analysis.never_invariants
+    }
+    assert projected == projected_entries


### PR DESCRIPTION
### Motivation
- Move decision-surface and never-invariant facets from a function-centric carrier to the SuiteSite locality carrier so facets attach to the exact suite (function body / call) where they arise. 
- Preserve existing function-level reports as projections (no user-facing report shape change) while centralizing semantics on SuiteSite for higher precision and correctness. 
- Verify projection parity with regression tests to prevent behavioral drift during migration. 

### Description
- Emit decision-surface alts against SuiteSite `function_body` nodes instead of `FunctionSite` in `_analyze_decision_surface_indexed` (attach `DecisionSurface` alts with `(suite_id, paramset_id)`).
- Emit never-invariant sinks against SuiteSite `call` nodes instead of `FunctionSite` in `_collect_never_invariants` (attach `NeverInvariantSink` alts with `(suite_id, paramset_id)`).
- Update evidence suggestion indexing to prefer SuiteSite-backed facets and fall back to `FunctionSite` via a new helper `_facet_site_id` in `src/gabion/analysis/test_evidence_suggestions.py` so downstream evidence projection remains function-compatible.
- Add regression tests `tests/test_suite_site_projection_parity.py` asserting (a) `DecisionSurface` alts are SuiteSite-native and project to the same function-level decision strings, and (b) `NeverInvariantSink` alt emission at call suites projects identically to the previous function-level view.
- Update the SPPF checklist entry in `docs/sppf_checklist.md` to mark the in-30 Phase 3/4 SuiteSite-native step complete and bump `doc_revision`; refresh `out/test_evidence.json` to record the new test evidence anchors.

### Testing
- Ran the targeted pytest suite with `PYTHONPATH=src` and no extra addopts: `python -m pytest -o addopts='' tests/test_test_evidence_suggestions.py tests/test_test_evidence_suggestions_edges.py tests/test_decision_surfaces.py tests/test_suite_site_projection_parity.py -q`, and all tests passed (`56 passed`).
- Ran the focused projection-parity tests: `python -m pytest -o addopts='' tests/test_suite_site_projection_parity.py -q`, and they passed (`2 passed`).
- Ran policy checks: `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`, and both succeeded after addressing a deterministic-annotation helper; there were no ambiguity-contract violations remaining.
- Extracted test-evidence with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and refreshed `out/test_evidence.json` to include the new regression-test evidence entries.
- Note: an initial attempt using `mise exec` failed in this environment due to local toolchain trust/fetch constraints, so the above test runs were executed using `PYTHONPATH=src` as the validated alternative.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e4084acc832492b93ab3b05af422)