### PR TITLE
Canonicalize ASPF evidence & stage-cache identities; add deterministic fingerprint reverse-index

### DIFF
--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -402,8 +402,13 @@ class FingerprintDimension:
     ) -> tuple[list[str], int]:
         """Decode this dimension, preferring the sparse exponent sidecar."""
         check_deadline()
+        reverse_index = build_reverse_prime_index(registry)
         if not self.exponents:
-            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+            return fingerprint_to_type_keys_with_remainder(
+                self.product,
+                registry,
+                reverse_index,
+            )
         keys: list[str] = []
         for key, exponent in self.exponents:
             check_deadline()
@@ -416,11 +421,19 @@ class FingerprintDimension:
             prime = registry.prime_for(key)
             if prime is None:
                 # Incomplete registry basis: preserve soundness by falling back.
-                return fingerprint_to_type_keys_with_remainder(self.product, registry)
+                return fingerprint_to_type_keys_with_remainder(
+                    self.product,
+                    registry,
+                    reverse_index,
+                )
             sidecar_product *= prime
         if sidecar_product != self.product:
             # Product remains source-of-truth; sidecar is an optimization.
-            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+            return fingerprint_to_type_keys_with_remainder(
+                self.product,
+                registry,
+                reverse_index,
+            )
         return keys, 1
 
 
@@ -931,6 +944,7 @@ def synth_registry_payload(
 ) -> JSONObject:
     check_deadline()
     entries: list[JSONObject] = []
+    reverse_index = build_reverse_prime_index(registry)
     for prime, tail in sort_once(
         synth_registry.tails.items(),
         source="synth_registry_payload.tails",
@@ -938,10 +952,14 @@ def synth_registry_payload(
     ):
         check_deadline()
         base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.base.product, registry
+            tail.base.product,
+            registry,
+            reverse_index,
         )
         ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.ctor.product, registry
+            tail.ctor.product,
+            registry,
+            reverse_index,
         )
         ctor_keys = [
             key[len("ctor:") :] if key.startswith("ctor:") else key
@@ -1290,22 +1308,43 @@ def build_fingerprint_registry(
     return registry, index
 
 
+@dataclass(frozen=True)
+class ReversePrimeIndex:
+    prime_to_key: dict[int, str]
+    ordered_primes: tuple[int, ...]
+
+
+def build_reverse_prime_index(registry: PrimeRegistry) -> ReversePrimeIndex:
+    check_deadline()
+    ordered = tuple(
+        prime
+        for _key, prime in sort_once(
+            registry.primes.items(),
+            source="build_reverse_prime_index.registry.primes",
+            key=lambda item: item[1],
+            policy=OrderPolicy.SORT,
+        )
+    )
+    prime_to_key: dict[int, str] = {}
+    for key, prime in registry.primes.items():
+        check_deadline()
+        prime_to_key[int(prime)] = key
+    return ReversePrimeIndex(prime_to_key=prime_to_key, ordered_primes=ordered)
+
+
 def fingerprint_to_type_keys_with_remainder(
     fingerprint: int,
     registry: PrimeRegistry,
+    reverse_index: ReversePrimeIndex,
 ) -> tuple[list[str], int]:
     check_deadline()
     remaining = fingerprint
     keys: list[str] = []
     if remaining <= 1:
         return keys, remaining
-    for key, prime in sort_once(
-        registry.primes.items(),
-        source="fingerprint_to_type_keys_with_remainder.registry.primes",
-        key=lambda item: item[1],
-        policy=OrderPolicy.SORT,
-    ):
+    for prime in reverse_index.ordered_primes:
         check_deadline()
+        key = reverse_index.prime_to_key[prime]
         while remaining % prime == 0:
             check_deadline()
             keys.append(key)
@@ -1322,7 +1361,9 @@ def fingerprint_to_type_keys(
     strict: bool = False,
 ) -> list[str]:
     keys, remaining = fingerprint_to_type_keys_with_remainder(
-        fingerprint, registry
+        fingerprint,
+        registry,
+        build_reverse_prime_index(registry),
     )
     if strict and remaining not in (0, 1):
         raise ValueError(

--- a/tests/test_dataflow_audit_edges.py
+++ b/tests/test_dataflow_audit_edges.py
@@ -1069,3 +1069,20 @@ def test_deadline_obligations_emit_suite_metadata_from_forest(tmp_path: Path) ->
         assert suite_id in by_identity
         suite_kind = str(site.get("suite_kind", ""))
         assert suite_kind == str(by_identity[suite_id].meta.get("suite_kind", ""))
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_edges.py::test_parse_stage_cache_key_uses_canonical_nodeid_identity::test_dataflow_audit_edges.py::tests.test_dataflow_audit_edges._load
+def test_parse_stage_cache_key_uses_canonical_nodeid_identity() -> None:
+    da = _load()
+    key = da._parse_stage_cache_key(
+        stage=da._ParseModuleStage.FUNCTION_INDEX,
+        cache_context=da._CacheSemanticContext(),
+        config_subset={"strictness": "high"},
+        detail="function_index",
+    )
+
+    assert isinstance(key, da.NodeId)
+    assert key.kind == "ParseStageCacheIdentity"
+    aliases = da._stage_cache_key_aliases(key)
+    assert key in aliases
+    assert any(type(alias) is tuple and alias[0] == "parse" for alias in aliases)

--- a/tests/test_type_fingerprints.py
+++ b/tests/test_type_fingerprints.py
@@ -899,3 +899,27 @@ def test_registry_assignment_policy_roundtrips_and_stays_deterministic() -> None
     assert registry_b.assignment_origin["int"] == "seeded"
     assert registry_b.assignment_origin["str"] == "seeded"
     assert registry_b.assignment_origin["bool"] == "learned"
+
+
+# gabion:evidence E:call_footprint::tests/test_type_fingerprints.py::test_reverse_prime_index_preserves_decode_identity_across_reruns::test_type_fingerprints.py::tests.test_type_fingerprints._load
+def test_reverse_prime_index_preserves_decode_identity_across_reruns() -> None:
+    tf = _load()
+    registry = tf.PrimeRegistry()
+    fingerprint = tf.bundle_fingerprint(["int", "str", "int"], registry)
+
+    reverse_index = tf.build_reverse_prime_index(registry)
+    keys_a, remainder_a = tf.fingerprint_to_type_keys_with_remainder(
+        fingerprint,
+        registry,
+        reverse_index=reverse_index,
+    )
+    keys_b, remainder_b = tf.fingerprint_to_type_keys_with_remainder(
+        fingerprint,
+        registry,
+        reverse_index=tf.build_reverse_prime_index(registry),
+    )
+
+    assert remainder_a == 1
+    assert remainder_b == 1
+    assert keys_a == ["int", "int", "str"]
+    assert keys_a == keys_b


### PR DESCRIPTION
### Motivation

- Remove non-deterministic identity drift caused by sequence/map presentation differences so equivalent ASPF alternatives and fingerprint decodes produce identical canonical identities across reruns.
- Complete parts of the in/in-22 migration by moving mixed tuple cache identities to canonical ASPF carriers and by stabilizing fingerprint decode sidecars for cross-stage cache reuse.

### Description

- Canonicalize Alt evidence end-to-end by normalizing and deterministically canonicalizing sequence/map evidence via `_canonicalize_evidence` / `_canonicalize_evidence_value`, and wire this into `Alt.__post_init__` so evidence interning is stable (`src/gabion/analysis/aspf.py`).
- Migrate parse-stage stage-cache keys from ad-hoc 4-tuple identity keys to a canonical `NodeId` carrier `ParseStageCacheIdentity` while preserving legacy tuple aliases via `_stage_cache_key_aliases` to maintain backward compatibility (`src/gabion/analysis/dataflow_audit.py`).
- Add a deterministic reverse-prime sidecar (`ReversePrimeIndex` + `build_reverse_prime_index`) and route fingerprint-to-keys decoding through it so identical registries decode in the same order across runs, and apply it in synth payloads and callers (`src/gabion/analysis/type_fingerprints.py`).
- Add targeted regression tests covering evidence canonicalization, parse-stage cache NodeId identity + alias behavior, and reverse-prime decode stability, and refresh the extracted test-evidence artifact (`tests/test_aspf.py`, `tests/test_dataflow_audit_edges.py`, `tests/test_type_fingerprints.py`, `out/test_evidence.json`).

### Testing

- Ran the workflow policy check with `PYTHONPATH=src python scripts/policy_check.py --workflows` and the ambiguity-contract check with `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`, both of which completed without violations.
- Executed focused regression tests with `PYTHONPATH=src pytest -q -o addopts=''` for the new/affected tests and the selected edge tests and all targeted tests passed (e.g. `test_add_alt_canonicalizes_sequence_evidence_for_rerun_identity`, `test_reverse_prime_index_preserves_decode_identity_across_reruns`, `test_parse_stage_cache_key_uses_canonical_nodeid_identity`).
- Re-extracted test evidence with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to include the new test evidence mappings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e3f2769c832494754d2650f3a6a6)