### PR TITLE
Integration: consolidate dataflow/fingerprint hub (#291/#290/#281/#283)

### DIFF
--- a/docs/sppf_checklist.md
+++ b/docs/sppf_checklist.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 162
+doc_revision: 163
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: sppf_checklist
 doc_role: checklist
@@ -39,7 +39,7 @@ doc_review_notes:
   glossary.md#deadness_witness: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
   glossary.md#exception_obligation: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_sections:
-  sppf_checklist: 8
+  sppf_checklist: 9
 doc_section_requires:
   sppf_checklist:
     - README.md#repo_contract
@@ -55,47 +55,47 @@ doc_section_reviews:
   sppf_checklist:
     README.md#repo_contract:
       dep_version: 2
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Repo contract rev2 reviewed; command and artifact guidance remains aligned."
     CONTRIBUTING.md#contributing_contract:
       dep_version: 2
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Contributor contract rev2 reviewed; dual-sensor cadence and correction gates remain aligned."
     glossary.md#decision_table:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_table rev1 (decision table tier definition)."
     glossary.md#decision_bundle:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_bundle rev1 (decision bundle tier definition)."
     glossary.md#decision_protocol:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_protocol rev1 (decision protocol tier definition)."
     glossary.md#decision_surface:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#decision_surface rev1 (decision surface tier boundary semantics)."
     glossary.md#value_encoded_decision:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#value_encoded_decision rev1 (value-encoded decision surface semantics)."
     glossary.md#deadness_witness:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#deadness_witness rev1 (deadness witness obligations for negative evidence)."
     glossary.md#exception_obligation:
       dep_version: 1
-      self_version_at_review: 8
+      self_version_at_review: 9
       outcome: no_change
       note: "Reviewed glossary.md#exception_obligation rev1 (exception obligation status + evidence linkage)."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
@@ -213,7 +213,7 @@ trailers or run `scripts/sppf_sync.py --comment` after adding references.
 - <a id="in-23-aspf-carrier-formalization"></a>[x] ASPF carrier obligations formalized (determinism, base conservation, ctor coherence, synth tail reversibility, provenance completeness, snapshot reproducibility). (in-23, GH-73; anchors: `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_provenance`, `src/gabion/analysis/dataflow_audit.py::_compute_fingerprint_synth`, `src/gabion/analysis/type_fingerprints.py::build_synth_registry_from_payload`, `tests/test_type_fingerprints.py::test_build_fingerprint_registry_deterministic_assignment`, `tests/test_type_fingerprints.py::test_synth_registry_payload_roundtrip`, `tests/test_fingerprint_warnings.py::test_fingerprint_provenance_emits_entries`, `scripts/audit_snapshot.sh`, `scripts/latest_snapshot.sh`). sppf{doc=done; impl=done; doc_ref=in-23@10}
 - [~] SuiteSite carriers + loop-scoped deadline obligations (recursive loop attribution now outer-vs-inner precise; SuiteSite-native enforcement still incomplete). Evidence anchors: `src/gabion/analysis/dataflow_obligations.py::collect_deadline_obligations`, `tests/test_deadline_coverage.py::test_deadline_loop_unchecked_status_is_root_gated`. (in-30, GH-85) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
 - [~] Deadline propagation as gas (ticks-based carriers across LSP/CLI/server; carrier budget semantics are stable but broader lane acceptance remains partial). Evidence anchors: `scripts/deadline_runtime.py::deadline_scope_from_lsp_env`, `tests/test_deadline_runtime.py::test_deadline_scope_from_lsp_env_uses_default_and_explicit_gas_limit`. (in-30, GH-87) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
-- [~] Structural ambiguity as CallCandidate alts (SuiteSite) with virtual AmbiguitySet (materialization landed; phase-3/4 decision-surface migration deferred). Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_materialize_call_candidates`, `tests/test_deadline_coverage.py::test_materialized_call_candidates_target_function_suites`. (in-30, GH-88) sppf{doc=partial; impl=partial; doc_ref=in-30@27}
+- [x] Structural ambiguity as CallCandidate alts (SuiteSite) with SuiteSite-native decision/never facets; function-level decision and never views are projection-only and parity-verified by regression tests. Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_analyze_decision_surface_indexed`, `src/gabion/analysis/dataflow_audit.py::_collect_never_invariants`, `src/gabion/analysis/test_evidence_suggestions.py::_facet_site_id`, `tests/test_suite_site_projection_parity.py::test_decision_surface_function_projection_parity_from_suite_sites`, `tests/test_suite_site_projection_parity.py::test_never_invariant_function_projection_parity_from_suite_sites`. (in-30, GH-88) sppf{doc=done; impl=done; doc_ref=in-30@27}
 - <a id="in-33-pattern-schema-unification"></a>[~] PatternSchema unification for dataflow bundles + execution patterns (shared cross-axis `schema:*` IDs, contract-versioned residue payloads, deterministic artifact ordering, Tier-2 residue ratchet/metafactory gate landed; execution rules still narrow). (in-33) sppf{doc=partial; impl=partial; doc_ref=in-33@3}
 - <a id="in-34-lambda-callable-sites"></a>[~] Lambda/closure callable indexing as first-class function sites (stable synthetic identities + direct/bound/closure lambda resolution; conservative dynamic fallback retained for unresolved alias/dynamic paths). Evidence anchors: `src/gabion/analysis/dataflow_audit.py::_resolve_callee_outcome`, `tests/test_dataflow_resolve_callee.py::test_resolve_callee_bound_lambda_call`, `tests/test_dataflow_resolve_callee.py::test_resolve_callee_outcome_keeps_dynamic_fallback_for_attribute_calls`. (in-34) sppf{doc=partial; impl=partial; doc_ref=in-34@2}
 - <a id="in-35-dict-key-carrier-tracking"></a>[~] Dict carrier tracking beyond literal subscript aliases (name-bound constant keys + unknown-key carrier evidence; key grammar remains conservative by design). Evidence anchors: `src/gabion/analysis/visitors.py::_normalize_key`, `tests/test_visitors_unit.py::test_subscript_forwarding_normalizes_const_keys`, `tests/test_visitors_unit.py::test_subscript_dynamic_key_marks_uncertainty`. (in-35) sppf{doc=partial; impl=partial; doc_ref=in-35@1}

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -2257,7 +2257,12 @@ def _analyze_decision_surface_indexed(
             else f"internal callers (transitive): {caller_count}"
         )
         descriptor = spec.descriptor(info, boundary)
-        site_id = forest.add_site(info.path.name, info.qual)
+        suite_id = forest.add_suite_site(
+            info.path.name,
+            info.qual,
+            "function_body",
+            span=info.function_span,
+        )
         paramset_id = forest.add_paramset(params)
         reason_summary = (
             _decision_reason_summary(info, params)
@@ -2266,7 +2271,7 @@ def _analyze_decision_surface_indexed(
         )
         forest.add_alt(
             spec.alt_kind,
-            (site_id, paramset_id),
+            (suite_id, paramset_id),
             evidence=_decision_surface_alt_evidence(
                 spec=spec,
                 boundary=boundary,
@@ -5512,7 +5517,12 @@ def _collect_never_invariants(
                     entry["environment_ref"] = environment_ref
                 entry["span"] = list(normalized_span)
                 invariants.append(entry)
-                site_id = forest.add_site(path.name, function)
+                site_id = forest.add_suite_site(
+                    path.name,
+                    function,
+                    "call",
+                    span=normalized_span,
+                )
                 paramset_id = forest.add_paramset(bundle)
                 evidence: dict[str, object] = {"path": path.name, "qual": function}
                 if reason:

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -3150,13 +3150,27 @@ _INDEXED_PASS_RUNNER_RULE = _ExecutionPatternRule(
         "the execution carrier into a shared runner Protocol."
     ),
 )
+_INDEXED_PASS_GRAPH_RULE = _ExecutionPatternRule(
+    pattern_id="indexed_pass_graph_builder",
+    kind="execution_pattern",
+    schema_family="indexed_pass_cluster",
+    required_params=_INDEXED_PASS_INGRESS_CORE_PARAMS,
+    callee_names=frozenset({"_build_call_graph"}),
+    min_members=2,
+    candidate="IndexedPassSpec[T] graph-builder Protocol",
+    description=(
+        "Functions repeatedly rebuilding call graph projections should "
+        "share one indexed-pass graph-builder execution contract."
+    ),
+)
 _EXECUTION_PATTERN_RULES: tuple[_ExecutionPatternRule, ...] = (
     _INDEXED_PASS_INGRESS_RULE,
     _INDEXED_PASS_RUNNER_RULE,
+    _INDEXED_PASS_GRAPH_RULE,
 )
 
 
-def _function_param_names(node: ast.FunctionDef) -> tuple[str, ...]:
+def _function_param_names(node: FunctionNode) -> tuple[str, ...]:
     params: list[str] = []
     params.extend(arg.arg for arg in node.args.posonlyargs)
     params.extend(arg.arg for arg in node.args.args)
@@ -3164,20 +3178,59 @@ def _function_param_names(node: ast.FunctionDef) -> tuple[str, ...]:
     return tuple(params)
 
 
+def _callable_name_variants(node: ast.AST) -> tuple[str, ...]:
+    if type(node) is ast.Name:
+        return (cast(ast.Name, node).id,)
+    if type(node) is not ast.Attribute:
+        return ()
+    attribute = cast(ast.Attribute, node)
+    parts: list[str] = [attribute.attr]
+    cursor: ast.AST = attribute.value
+    while type(cursor) is ast.Attribute:
+        nested = cast(ast.Attribute, cursor)
+        parts.append(nested.attr)
+        cursor = nested.value
+    if type(cursor) is ast.Name:
+        parts.append(cast(ast.Name, cursor).id)
+    dotted = ".".join(reversed(parts))
+    return (attribute.attr, dotted)
+
+
 def _iter_execution_function_facts(tree: ast.Module) -> Iterator[tuple[str, frozenset[str], frozenset[str]]]:
     for node in tree.body:
         check_deadline()
-        if type(node) is not ast.FunctionDef:
+        if type(node) not in {ast.FunctionDef, ast.AsyncFunctionDef}:
             continue
-        function_node = cast(ast.FunctionDef, node)
+        function_node = cast(FunctionNode, node)
         param_names = frozenset(_function_param_names(function_node))
+        alias_map: dict[str, tuple[str, ...]] = {}
+        for statement in function_node.body:
+            check_deadline()
+            if type(statement) is not ast.Assign or len(cast(ast.Assign, statement).targets) != 1:
+                continue
+            assign_node = cast(ast.Assign, statement)
+            target = assign_node.targets[0]
+            if type(target) is not ast.Name:
+                continue
+            variants = _callable_name_variants(assign_node.value)
+            if not variants:
+                continue
+            alias_map[cast(ast.Name, target).id] = variants
         called_names: set[str] = set()
         for index, child in enumerate(ast.walk(function_node), start=1):
             if index % 64 == 0:
                 check_deadline()
-            if type(child) is not ast.Call or type(cast(ast.Call, child).func) is not ast.Name:
+            if type(child) is not ast.Call:
                 continue
-            called_names.add(cast(ast.Name, cast(ast.Call, child).func).id)
+            call_node = cast(ast.Call, child)
+            variants = _callable_name_variants(call_node.func)
+            if not variants:
+                continue
+            for variant in variants:
+                check_deadline()
+                called_names.add(variant)
+                for alias_variant in alias_map.get(variant, ()):  # boundary alias normalization
+                    called_names.add(alias_variant)
         yield function_node.name, param_names, frozenset(called_names)
 
 

--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -14254,6 +14254,9 @@ def compute_structure_reuse(
         witness_obligations = list(
             sequence_or_none(suggestion.get("witness_obligations")) or []
         )
+        aspf_witness_requirements = mapping_or_empty(
+            suggestion.get("aspf_witness_requirements")
+        )
         return {
             "plan_id": f"reuse:{kind}:{hash_value}:{suggestion_name}",
             "status": "UNVERIFIED",
@@ -14276,6 +14279,7 @@ def compute_structure_reuse(
             "evidence": {
                 "provenance_id": f"reuse:{hash_value}",
                 "coherence_id": f"aspf:{hash_value}",
+                "aspf_witness_requirements": aspf_witness_requirements,
                 "witness_obligations": witness_obligations,
             },
             "post_expectation": {
@@ -14366,6 +14370,25 @@ def compute_structure_reuse(
                         ),
                     }
                 )
+                suggestion["witness_obligations"].append(
+                    {
+                        "kind": "aspf_structure_class_coherence",
+                        "required": True,
+                        "witness_ref": f"aspf:coherence:{hash_value}",
+                        "coherence_ref": f"aspf:{hash_value}",
+                    }
+                )
+                suggestion["aspf_witness_requirements"] = {
+                    "equivalence": {
+                        "kind": "aspf_structure_class_equivalence",
+                        "witness_ref": f"aspf:{hash_value}",
+                    },
+                    "coherence": {
+                        "kind": "aspf_structure_class_coherence",
+                        "witness_ref": f"aspf:coherence:{hash_value}",
+                        "coherence_ref": f"aspf:{hash_value}",
+                    },
+                }
                 suggestion["rewrite_plan_artifact"] = _build_suggested_plan_artifact(
                     suggestion=suggestion
                 )
@@ -14376,6 +14399,27 @@ def compute_structure_reuse(
         "min_count": min_count,
         "reused": reused,
         "suggested_lemmas": suggested,
+        "heuristic_structural_repetition_candidates": [
+            {
+                "hash": entry.get("hash"),
+                "kind": entry.get("kind"),
+                "count": entry.get("count"),
+                "source": "heuristic_structural_repetition",
+            }
+            for entry in reused
+            if entry.get("kind") in {"bundle", "function"}
+        ],
+        "witness_validated_isomorphy_candidates": [
+            {
+                "hash": suggestion.get("hash"),
+                "kind": suggestion.get("kind"),
+                "suggested_name": suggestion.get("suggested_name"),
+                "source": "aspf_witness_requirements",
+                "aspf_witness_requirements": suggestion.get("aspf_witness_requirements"),
+            }
+            for suggestion in suggested
+            if mapping_or_none(suggestion.get("aspf_witness_requirements")) is not None
+        ],
         "replacement_map": replacement_map,
         "warnings": warnings,
     }

--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -402,8 +402,13 @@ class FingerprintDimension:
     ) -> tuple[list[str], int]:
         """Decode this dimension, preferring the sparse exponent sidecar."""
         check_deadline()
+        reverse_index = build_reverse_prime_index(registry)
         if not self.exponents:
-            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+            return fingerprint_to_type_keys_with_remainder(
+                self.product,
+                registry,
+                reverse_index,
+            )
         keys: list[str] = []
         for key, exponent in self.exponents:
             check_deadline()
@@ -416,11 +421,19 @@ class FingerprintDimension:
             prime = registry.prime_for(key)
             if prime is None:
                 # Incomplete registry basis: preserve soundness by falling back.
-                return fingerprint_to_type_keys_with_remainder(self.product, registry)
+                return fingerprint_to_type_keys_with_remainder(
+                    self.product,
+                    registry,
+                    reverse_index,
+                )
             sidecar_product *= prime
         if sidecar_product != self.product:
             # Product remains source-of-truth; sidecar is an optimization.
-            return fingerprint_to_type_keys_with_remainder(self.product, registry)
+            return fingerprint_to_type_keys_with_remainder(
+                self.product,
+                registry,
+                reverse_index,
+            )
         return keys, 1
 
 
@@ -931,6 +944,7 @@ def synth_registry_payload(
 ) -> JSONObject:
     check_deadline()
     entries: list[JSONObject] = []
+    reverse_index = build_reverse_prime_index(registry)
     for prime, tail in sort_once(
         synth_registry.tails.items(),
         source="synth_registry_payload.tails",
@@ -938,10 +952,14 @@ def synth_registry_payload(
     ):
         check_deadline()
         base_keys, base_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.base.product, registry
+            tail.base.product,
+            registry,
+            reverse_index,
         )
         ctor_keys, ctor_remaining = fingerprint_to_type_keys_with_remainder(
-            tail.ctor.product, registry
+            tail.ctor.product,
+            registry,
+            reverse_index,
         )
         ctor_keys = [
             key[len("ctor:") :] if key.startswith("ctor:") else key
@@ -1290,22 +1308,43 @@ def build_fingerprint_registry(
     return registry, index
 
 
+@dataclass(frozen=True)
+class ReversePrimeIndex:
+    prime_to_key: dict[int, str]
+    ordered_primes: tuple[int, ...]
+
+
+def build_reverse_prime_index(registry: PrimeRegistry) -> ReversePrimeIndex:
+    check_deadline()
+    ordered = tuple(
+        prime
+        for _key, prime in sort_once(
+            registry.primes.items(),
+            source="build_reverse_prime_index.registry.primes",
+            key=lambda item: item[1],
+            policy=OrderPolicy.SORT,
+        )
+    )
+    prime_to_key: dict[int, str] = {}
+    for key, prime in registry.primes.items():
+        check_deadline()
+        prime_to_key[int(prime)] = key
+    return ReversePrimeIndex(prime_to_key=prime_to_key, ordered_primes=ordered)
+
+
 def fingerprint_to_type_keys_with_remainder(
     fingerprint: int,
     registry: PrimeRegistry,
+    reverse_index: ReversePrimeIndex,
 ) -> tuple[list[str], int]:
     check_deadline()
     remaining = fingerprint
     keys: list[str] = []
     if remaining <= 1:
         return keys, remaining
-    for key, prime in sort_once(
-        registry.primes.items(),
-        source="fingerprint_to_type_keys_with_remainder.registry.primes",
-        key=lambda item: item[1],
-        policy=OrderPolicy.SORT,
-    ):
+    for prime in reverse_index.ordered_primes:
         check_deadline()
+        key = reverse_index.prime_to_key[prime]
         while remaining % prime == 0:
             check_deadline()
             keys.append(key)
@@ -1322,7 +1361,9 @@ def fingerprint_to_type_keys(
     strict: bool = False,
 ) -> list[str]:
     keys, remaining = fingerprint_to_type_keys_with_remainder(
-        fingerprint, registry
+        fingerprint,
+        registry,
+        build_reverse_prime_index(registry),
     )
     if strict and remaining not in (0, 1):
         raise ValueError(

--- a/tests/test_dataflow_audit_edges.py
+++ b/tests/test_dataflow_audit_edges.py
@@ -1069,3 +1069,20 @@ def test_deadline_obligations_emit_suite_metadata_from_forest(tmp_path: Path) ->
         assert suite_id in by_identity
         suite_kind = str(site.get("suite_kind", ""))
         assert suite_kind == str(by_identity[suite_id].meta.get("suite_kind", ""))
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_edges.py::test_parse_stage_cache_key_uses_canonical_nodeid_identity::test_dataflow_audit_edges.py::tests.test_dataflow_audit_edges._load
+def test_parse_stage_cache_key_uses_canonical_nodeid_identity() -> None:
+    da = _load()
+    key = da._parse_stage_cache_key(
+        stage=da._ParseModuleStage.FUNCTION_INDEX,
+        cache_context=da._CacheSemanticContext(),
+        config_subset={"strictness": "high"},
+        detail="function_index",
+    )
+
+    assert isinstance(key, da.NodeId)
+    assert key.kind == "ParseStageCacheIdentity"
+    aliases = da._stage_cache_key_aliases(key)
+    assert key in aliases
+    assert any(type(alias) is tuple and alias[0] == "parse" for alias in aliases)

--- a/tests/test_dataflow_audit_helpers.py
+++ b/tests/test_dataflow_audit_helpers.py
@@ -789,9 +789,19 @@ def test_collect_config_and_dataclass_stage_caches_reuse_analysis_index(
     assert "AppConfig" in bundles[module]
     assert "module.AppConfig" in registry
     assert "module.Payload" in registry
-    cache_keys = {key[1] for key in analysis_index.stage_cache_by_key}
-    assert any(isinstance(key, tuple) and key[-1] == "config_fields" for key in cache_keys)
-    assert any(isinstance(key, tuple) and key[-1] == "dataclass_registry" for key in cache_keys)
+    cache_details = set()
+    for scoped_key in analysis_index.stage_cache_by_key:
+        if (
+            isinstance(scoped_key, tuple)
+            and len(scoped_key) == 2
+            and isinstance(scoped_key[1], da.NodeId)
+            and scoped_key[1].kind == "ParseStageCacheIdentity"
+            and len(scoped_key[1].key) == 3
+            and isinstance(scoped_key[1].key[2], str)
+        ):
+            cache_details.add(scoped_key[1].key[2])
+    assert "config_fields" in cache_details
+    assert "dataclass_registry" in cache_details
 
 # gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_run_indexed_pass_hydrates_index_and_sink::dataflow_audit.py::gabion.analysis.dataflow_audit._run_indexed_pass::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
 def test_run_indexed_pass_hydrates_index_and_sink() -> None:

--- a/tests/test_dataflow_audit_helpers.py
+++ b/tests/test_dataflow_audit_helpers.py
@@ -1085,6 +1085,84 @@ def test_pattern_schema_suggestions_include_execution_and_dataflow_axes() -> Non
         for line in suggestions
     )
 
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_execution_pattern_detection_supports_alias_attribute_and_async_callables::dataflow_audit.py::gabion.analysis.dataflow_audit._detect_execution_pattern_matches::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
+def test_execution_pattern_detection_supports_alias_attribute_and_async_callables() -> None:
+    da = _load()
+    source = (
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+
+    matches = da._detect_execution_pattern_matches(source=source)
+    ids = {entry.pattern_id for entry in matches}
+
+    assert "indexed_pass_runner" in ids
+    assert "indexed_pass_graph_builder" in ids
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_execution_pattern_residue_is_stable_under_source_order_permutations::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_matches::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_lines::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
+def test_execution_pattern_residue_is_stable_under_source_order_permutations() -> None:
+    da = _load()
+    source_a = (
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+    source_b = (
+        "def graph_sync(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return _build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "async def graph_async(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    return planner._build_call_graph(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_b(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = _run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+        "def runner_alias_a(paths, *, project_root, ignore_params, strictness, external_filter, "
+        "transparent_decorators=None, parse_failure_witnesses=None, analysis_index=None):\n"
+        "    runner = ops._run_indexed_pass\n"
+        "    return runner(paths, project_root=project_root, ignore_params=ignore_params, strictness=strictness, external_filter=external_filter, transparent_decorators=transparent_decorators, parse_failure_witnesses=parse_failure_witnesses, analysis_index=analysis_index)\n"
+    )
+
+    lines_a = da._pattern_schema_residue_lines(
+        da._pattern_schema_residue_entries(
+            da._pattern_schema_matches(groups_by_path={}, source=source_a)
+        )
+    )
+    lines_b = da._pattern_schema_residue_lines(
+        da._pattern_schema_residue_entries(
+            da._pattern_schema_matches(groups_by_path={}, source=source_b)
+        )
+    )
+
+    assert lines_a == lines_b
+    assert any("indexed_pass_graph_builder" in line for line in lines_a)
+
+
 # gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_pattern_schema_residue_entries_cover_both_axes::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_matches::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_entries::dataflow_audit.py::gabion.analysis.dataflow_audit._pattern_schema_residue_lines::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
 def test_pattern_schema_residue_entries_cover_both_axes() -> None:
     da = _load()

--- a/tests/test_structure_reuse.py
+++ b/tests/test_structure_reuse.py
@@ -52,9 +52,12 @@ def test_compute_structure_reuse_detects_repeated_subtrees() -> None:
         entry.get("kind") == "bundle"
         and entry.get("suggested_name")
         and entry.get("witness_obligations")
+        and entry.get("aspf_witness_requirements")
         and entry.get("rewrite_plan_artifact")
         for entry in suggestions
     )
+    assert reuse.get("heuristic_structural_repetition_candidates")
+    assert reuse.get("witness_validated_isomorphy_candidates")
     replacement_map = reuse.get("replacement_map", {})
     assert any(location.startswith("a.py::f") for location in replacement_map)
 
@@ -158,6 +161,13 @@ def test_render_reuse_lemma_stubs_emits_plan_artifacts_from_reuse_suggestions() 
     assert any(
         any(
             obligation.get("kind") == "aspf_structure_class_equivalence"
+            for obligation in plan.get("evidence", {}).get("witness_obligations", [])
+        )
+        for plan in plans
+    )
+    assert any(
+        any(
+            obligation.get("kind") == "aspf_structure_class_coherence"
             for obligation in plan.get("evidence", {}).get("witness_obligations", [])
         )
         for plan in plans

--- a/tests/test_suite_site_projection_parity.py
+++ b/tests/test_suite_site_projection_parity.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _load():
+    from gabion.analysis import dataflow_audit as da
+
+    return da
+
+
+# gabion:evidence E:decision_surface/direct::dataflow_audit.py::gabion.analysis.dataflow_audit._analyze_decision_surface_indexed
+def test_decision_surface_function_projection_parity_from_suite_sites(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "mod.py"
+    path.write_text(
+        "def choose(flag, mode):\n"
+        "    if flag:\n"
+        "        return mode\n"
+        "    return mode\n"
+    )
+
+    forest = da.Forest()
+    analysis = da.analyze_paths(
+        forest=forest,
+        paths=[path],
+        recursive=True,
+        type_audit=False,
+        type_audit_report=False,
+        type_audit_max=0,
+        include_constant_smells=False,
+        include_unused_arg_smells=False,
+        include_decision_surfaces=True,
+        config=da.AuditConfig(project_root=tmp_path),
+    )
+
+    decision_alts = [alt for alt in forest.alts if alt.kind == "DecisionSurface"]
+    assert decision_alts
+    projected: list[str] = []
+    for alt in decision_alts:
+        suite_node = forest.nodes[alt.inputs[0]]
+        assert suite_node.kind == "SuiteSite"
+        assert suite_node.meta.get("suite_kind") == "function_body"
+        params = list(forest.nodes[alt.inputs[1]].meta.get("params", []))
+        descriptor = str(alt.evidence.get("classification_descriptor", "") or "")
+        projected.append(
+            f"{suite_node.meta['path']}:{suite_node.meta['qual']} decision surface params: {', '.join(params)} ({descriptor})"
+        )
+
+    assert sorted(projected) == sorted(analysis.decision_surfaces)
+
+
+# gabion:evidence E:never/sink::dataflow_audit.py::gabion.analysis.dataflow_audit._collect_never_invariants
+def test_never_invariant_function_projection_parity_from_suite_sites(tmp_path: Path) -> None:
+    da = _load()
+    path = tmp_path / "never_case.py"
+    path.write_text(
+        "from gabion.invariants import never\n\n"
+        "def fail_fast(flag):\n"
+        "    if flag:\n"
+        "        never('stop')\n"
+    )
+
+    forest = da.Forest()
+    analysis = da.analyze_paths(
+        forest=forest,
+        paths=[path],
+        recursive=True,
+        type_audit=False,
+        type_audit_report=False,
+        type_audit_max=0,
+        include_constant_smells=False,
+        include_unused_arg_smells=False,
+        include_never_invariants=True,
+        config=da.AuditConfig(project_root=tmp_path),
+    )
+
+    sink_alts = [alt for alt in forest.alts if alt.kind == "NeverInvariantSink"]
+    assert sink_alts
+    projected = {
+        (
+            str(forest.nodes[alt.inputs[0]].meta.get("path", "")),
+            str(forest.nodes[alt.inputs[0]].meta.get("qual", "")),
+            tuple(str(item) for item in forest.nodes[alt.inputs[1]].meta.get("params", [])),
+        )
+        for alt in sink_alts
+    }
+    for alt in sink_alts:
+        suite_node = forest.nodes[alt.inputs[0]]
+        assert suite_node.kind == "SuiteSite"
+        assert suite_node.meta.get("suite_kind") == "call"
+
+    projected_entries = {
+        (
+            str(entry.get("site", {}).get("path", "")),
+            str(entry.get("site", {}).get("function", "")),
+            tuple(str(item) for item in entry.get("site", {}).get("bundle", [])),
+        )
+        for entry in analysis.never_invariants
+    }
+    assert projected == projected_entries

--- a/tests/test_type_fingerprints.py
+++ b/tests/test_type_fingerprints.py
@@ -899,3 +899,27 @@ def test_registry_assignment_policy_roundtrips_and_stays_deterministic() -> None
     assert registry_b.assignment_origin["int"] == "seeded"
     assert registry_b.assignment_origin["str"] == "seeded"
     assert registry_b.assignment_origin["bool"] == "learned"
+
+
+# gabion:evidence E:call_footprint::tests/test_type_fingerprints.py::test_reverse_prime_index_preserves_decode_identity_across_reruns::test_type_fingerprints.py::tests.test_type_fingerprints._load
+def test_reverse_prime_index_preserves_decode_identity_across_reruns() -> None:
+    tf = _load()
+    registry = tf.PrimeRegistry()
+    fingerprint = tf.bundle_fingerprint(["int", "str", "int"], registry)
+
+    reverse_index = tf.build_reverse_prime_index(registry)
+    keys_a, remainder_a = tf.fingerprint_to_type_keys_with_remainder(
+        fingerprint,
+        registry,
+        reverse_index=reverse_index,
+    )
+    keys_b, remainder_b = tf.fingerprint_to_type_keys_with_remainder(
+        fingerprint,
+        registry,
+        reverse_index=tf.build_reverse_prime_index(registry),
+    )
+
+    assert remainder_a == 1
+    assert remainder_b == 1
+    assert keys_a == ["int", "int", "str"]
+    assert keys_a == keys_b

--- a/tests/test_type_fingerprints.py
+++ b/tests/test_type_fingerprints.py
@@ -152,8 +152,11 @@ def test_fingerprint_to_type_keys_with_remainder_and_strict() -> None:
     registry = tf.PrimeRegistry()
     int_prime = registry.get_or_assign("int")
     fingerprint = int_prime * 97
+    reverse_index = tf.build_reverse_prime_index(registry)
     keys, remaining = tf.fingerprint_to_type_keys_with_remainder(
-        fingerprint, registry
+        fingerprint,
+        registry,
+        reverse_index,
     )
     assert keys == ["int"]
     assert remaining == 97


### PR DESCRIPTION
Consolidates the overlapping dataflow/fingerprint follow-on hub.

Included PRs:
- #291 Canonicalize ASPF evidence + stage-cache identities + fingerprint reverse-index
- #290 SuiteSite carrier migration for decision/value/never facets
- #281 ASPF witness obligations in structure reuse suggestions
- #283 Expanded execution pattern callable matching

Integration fixes:
- resolved docs/sppf_checklist.md doc_revision conflict with cumulative bump
- aligned tests with canonical stage-cache key shape and explicit reverse-index decode contract
- regenerated out/test_evidence.json

Validation run: policy checks (--workflows, --ambiguity-contract, --normative-map, --tier2-residue-contract) and targeted pytest bundle passed.

Supersedes: #291 #290 #281 #283
