### PR TITLE
Add registry-based ingest adapter seam for boundary normalization

### DIFF
--- a/src/gabion/ingest/__init__.py
+++ b/src/gabion/ingest/__init__.py
@@ -1,0 +1,9 @@
+from gabion.ingest.adapter_contract import LanguageAdapter, NormalizedIngestBundle, ParsedFileUnit
+from gabion.ingest.registry import resolve_adapter
+
+__all__ = [
+    "LanguageAdapter",
+    "NormalizedIngestBundle",
+    "ParsedFileUnit",
+    "resolve_adapter",
+]

--- a/src/gabion/ingest/adapter_contract.py
+++ b/src/gabion/ingest/adapter_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from gabion.analysis.dataflow_audit import AuditConfig
+
+
+@dataclass(frozen=True)
+class ParsedFileUnit:
+    path: Path
+    tree: ast.AST
+    function_count: int
+
+
+@dataclass(frozen=True)
+class NormalizedIngestBundle:
+    language_id: str
+    file_paths: tuple[Path, ...]
+    parsed_units: tuple[ParsedFileUnit, ...]
+
+
+@runtime_checkable
+class LanguageAdapter(Protocol):
+    language_id: str
+    file_extensions: tuple[str, ...]
+
+    def discover_files(
+        self,
+        paths: list[Path],
+        *,
+        config: AuditConfig,
+    ) -> list[Path]: ...
+
+    def parse_files(self, paths: list[Path]) -> list[ParsedFileUnit]: ...
+
+    def normalize(
+        self,
+        paths: list[Path],
+        *,
+        config: AuditConfig,
+    ) -> NormalizedIngestBundle: ...

--- a/src/gabion/ingest/python_adapter.py
+++ b/src/gabion/ingest/python_adapter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from gabion.analysis.dataflow_audit import AuditConfig, _collect_functions, resolve_analysis_paths
+from gabion.ingest.adapter_contract import (
+    LanguageAdapter,
+    NormalizedIngestBundle,
+    ParsedFileUnit,
+)
+
+
+class PythonAdapter(LanguageAdapter):
+    language_id = "python"
+    file_extensions = (".py",)
+
+    def discover_files(self, paths: list[Path], *, config: AuditConfig) -> list[Path]:
+        return resolve_analysis_paths(paths, config=config)
+
+    def parse_files(self, paths: list[Path]) -> list[ParsedFileUnit]:
+        parsed_units: list[ParsedFileUnit] = []
+        for path in paths:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+            parsed_units.append(
+                ParsedFileUnit(
+                    path=path,
+                    tree=tree,
+                    function_count=len(_collect_functions(tree)),
+                )
+            )
+        return parsed_units
+
+    def normalize(self, paths: list[Path], *, config: AuditConfig) -> NormalizedIngestBundle:
+        discovered_paths = self.discover_files(paths, config=config)
+        parsed_units = self.parse_files(discovered_paths)
+        return NormalizedIngestBundle(
+            language_id=self.language_id,
+            file_paths=tuple(discovered_paths),
+            parsed_units=tuple(parsed_units),
+        )

--- a/src/gabion/ingest/registry.py
+++ b/src/gabion/ingest/registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion import never
+from gabion.ingest.adapter_contract import LanguageAdapter
+from gabion.ingest.python_adapter import PythonAdapter
+
+
+_ADAPTERS_BY_LANGUAGE: dict[str, LanguageAdapter] = {}
+_ADAPTERS_BY_EXTENSION: dict[str, LanguageAdapter] = {}
+
+
+def register_adapter(adapter: LanguageAdapter) -> None:
+    _ADAPTERS_BY_LANGUAGE[adapter.language_id] = adapter
+    for extension in adapter.file_extensions:
+        _ADAPTERS_BY_EXTENSION[extension.lower()] = adapter
+
+
+def adapter_for_language(language_id: str) -> LanguageAdapter | None:
+    return _ADAPTERS_BY_LANGUAGE.get(language_id.lower())
+
+
+def adapter_for_extension(extension: str) -> LanguageAdapter | None:
+    return _ADAPTERS_BY_EXTENSION.get(extension.lower())
+
+
+def resolve_adapter(
+    *,
+    paths: list[Path],
+    language_id: str | None = None,
+    default_language_id: str = "python",
+) -> LanguageAdapter:
+    if language_id is not None:
+        adapter = adapter_for_language(language_id)
+        if adapter is None:
+            never("unknown language adapter", language_id=language_id)
+        return adapter
+    for path in paths:
+        suffix = path.suffix.lower()
+        if not suffix:
+            continue
+        adapter = adapter_for_extension(suffix)
+        if adapter is not None:
+            return adapter
+    fallback = adapter_for_language(default_language_id)
+    if fallback is None:
+        never("missing fallback language adapter", language_id=default_language_id)
+    return fallback
+
+
+register_adapter(PythonAdapter())

--- a/tests/test_ingest_registry.py
+++ b/tests/test_ingest_registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion.analysis.dataflow_audit import AuditConfig
+from gabion.ingest.python_adapter import PythonAdapter
+from gabion.ingest.registry import resolve_adapter
+
+
+# gabion:evidence E:function_site::registry.py::gabion.ingest.registry.resolve_adapter
+def test_resolve_adapter_uses_explicit_language_id(tmp_path: Path) -> None:
+    source_path = tmp_path / "module.py"
+    source_path.write_text("def f() -> int:\n    return 1\n", encoding="utf-8")
+
+    adapter = resolve_adapter(paths=[source_path], language_id="python")
+
+    assert isinstance(adapter, PythonAdapter)
+
+
+# gabion:evidence E:function_site::python_adapter.py::gabion.ingest.python_adapter.PythonAdapter.normalize
+def test_python_adapter_normalize_discovers_and_parses_python_sources(tmp_path: Path) -> None:
+    source_path = tmp_path / "module.py"
+    source_path.write_text("def f() -> int:\n    return 1\n", encoding="utf-8")
+
+    adapter = PythonAdapter()
+    normalized = adapter.normalize([tmp_path], config=AuditConfig(project_root=tmp_path))
+
+    assert normalized.language_id == "python"
+    assert normalized.file_paths == (source_path,)
+    assert len(normalized.parsed_units) == 1
+    assert normalized.parsed_units[0].path == source_path
+    assert normalized.parsed_units[0].function_count == 1

--- a/tests/test_server_core_orchestrator_edges.py
+++ b/tests/test_server_core_orchestrator_edges.py
@@ -405,7 +405,11 @@ def test_prepare_analysis_resume_state_skips_intro_timeline_when_disabled(
         execute_deps=deps,
         aspf_trace_state=None,
         needs_analysis=True,
-        paths=[source_path],
+        normalized_ingest=orchestrator.NormalizedIngestBundle(
+            language_id="python",
+            file_paths=(source_path,),
+            parsed_units=(),
+        ),
         root=str(tmp_path),
         payload={},
         no_recursive=False,


### PR DESCRIPTION
### Motivation
- Centralize language/format ingress so each front-end normalizes once at the boundary and the semantic core receives a single deterministic ingest shape.
- Provide an extensible adapter seam to allow future languages/formats to plug in discovery, parsing, and normalization without scattering language-specific guards across core orchestration.

### Description
- Introduce an adapter contract and DTOs in `src/gabion/ingest/adapter_contract.py` with `LanguageAdapter`, `ParsedFileUnit`, and `NormalizedIngestBundle` to represent normalized ingest output.
- Add a baseline `PythonAdapter` in `src/gabion/ingest/python_adapter.py` that reuses existing Python discovery and visitor logic (`resolve_analysis_paths`, `_collect_functions`) and returns a `NormalizedIngestBundle`.
- Implement adapter registry/discovery in `src/gabion/ingest/registry.py` keyed by `language_id` and file extension, with Python pre-registered and fallback behavior; expose the seam via `src/gabion/ingest/__init__.py`.
- Wire orchestration in `src/gabion/server_core/command_orchestrator.py` to resolve an adapter once from the payload (`language_id` / `language`), call `normalize(...)`, and pass the `NormalizedIngestBundle` into the analysis resume preparation path so analysis uses the normalized file list rather than re-resolving discovery at multiple callsites.
- Add `tests/test_ingest_registry.py` to validate registry resolution and Python adapter normalization and update an orchestrator edge test to use the new `NormalizedIngestBundle` input shape.

### Testing
- Ran policy/ambiguity checks: `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` (executed as part of validation stack; environment `mise` trust steps were not used here due to local toolchain constraints). Both invocations were exercised during validation.
- Ran targeted pytest: `PYTHONPATH=src pytest -q -o addopts='' tests/test_ingest_registry.py tests/test_server_core_orchestrator_edges.py::test_prepare_analysis_resume_state_skips_intro_timeline_when_disabled` which reported: `3 passed`.
- Rebuilt test evidence carrier: `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to include new evidence markers for the adapter seam.
- Byte-compiled the new modules: `PYTHONPATH=src python -m compileall -q src/gabion/ingest src/gabion/server_core/command_orchestrator.py` succeeded.
- All automated checks run in this environment succeeded for the modified surfaces; note that `mise`-driven bootstrap in this container raised trust/toolchain resolution warnings and was not used for final validation. Commit recorded: "Add ingest adapter registry seam for boundary normalization."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ea2896448324a8a33fe384539e10)