### PR TITLE
Add adapter capability gating for analysis surfaces

### DIFF
--- a/src/gabion/analysis/dataflow_pipeline.py
+++ b/src/gabion/analysis/dataflow_pipeline.py
@@ -6,6 +6,42 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import cast
 
+_SURFACE_BUNDLE_INFERENCE = "bundle-inference"
+_SURFACE_DECISION_SURFACES = "decision-surfaces"
+_SURFACE_TYPE_FLOW = "type-flow"
+_SURFACE_EXCEPTION_OBLIGATIONS = "exception-obligations"
+_SURFACE_REWRITE_PLAN_SUPPORT = "rewrite-plan-support"
+
+
+def _capability_enabled(adapter_contract: object, capability_name: str) -> bool:
+    if type(adapter_contract) is not dict:
+        return True
+    capabilities = cast(dict[object, object], adapter_contract).get("capabilities")
+    if type(capabilities) is not dict:
+        return True
+    value = cast(dict[object, object], capabilities).get(capability_name)
+    return bool(value) if type(value) is bool else True
+
+
+def _unsupported_surface_diagnostic(
+    *,
+    surface: str,
+    capability_name: str,
+    runtime_config: AuditConfig,
+) -> JSONObject:
+    required = surface in runtime_config.required_analysis_surfaces
+    adapter_contract = runtime_config.adapter_contract
+    adapter_name = "native"
+    if type(adapter_contract) is dict:
+        adapter_name = str(cast(dict[object, object], adapter_contract).get("name", "native") or "native")
+    return {
+        "kind": "unsupported_by_adapter",
+        "surface": surface,
+        "capability": capability_name,
+        "adapter": adapter_name,
+        "required_by_policy": required,
+    }
+
 _BOUND = False
 
 
@@ -909,6 +945,70 @@ def analyze_paths(
         if config is None:
             config = AuditConfig()
         runtime_config = cast(AuditConfig, config)
+        unsupported_by_adapter: list[JSONObject] = []
+        if include_bundle_forest and not _capability_enabled(
+            runtime_config.adapter_contract,
+            "bundle_inference",
+        ):
+            include_bundle_forest = False
+            unsupported_by_adapter.append(
+                _unsupported_surface_diagnostic(
+                    surface=_SURFACE_BUNDLE_INFERENCE,
+                    capability_name="bundle_inference",
+                    runtime_config=runtime_config,
+                )
+            )
+        if (include_decision_surfaces or include_value_decision_surfaces) and not _capability_enabled(
+            runtime_config.adapter_contract,
+            "decision_surfaces",
+        ):
+            include_decision_surfaces = False
+            include_value_decision_surfaces = False
+            unsupported_by_adapter.append(
+                _unsupported_surface_diagnostic(
+                    surface=_SURFACE_DECISION_SURFACES,
+                    capability_name="decision_surfaces",
+                    runtime_config=runtime_config,
+                )
+            )
+        if (type_audit or type_audit_report) and not _capability_enabled(
+            runtime_config.adapter_contract,
+            "type_flow",
+        ):
+            type_audit = False
+            type_audit_report = False
+            unsupported_by_adapter.append(
+                _unsupported_surface_diagnostic(
+                    surface=_SURFACE_TYPE_FLOW,
+                    capability_name="type_flow",
+                    runtime_config=runtime_config,
+                )
+            )
+        if (include_exception_obligations or include_handledness_witnesses) and not _capability_enabled(
+            runtime_config.adapter_contract,
+            "exception_obligations",
+        ):
+            include_exception_obligations = False
+            include_handledness_witnesses = False
+            unsupported_by_adapter.append(
+                _unsupported_surface_diagnostic(
+                    surface=_SURFACE_EXCEPTION_OBLIGATIONS,
+                    capability_name="exception_obligations",
+                    runtime_config=runtime_config,
+                )
+            )
+        if include_rewrite_plans and not _capability_enabled(
+            runtime_config.adapter_contract,
+            "rewrite_plan_support",
+        ):
+            include_rewrite_plans = False
+            unsupported_by_adapter.append(
+                _unsupported_surface_diagnostic(
+                    surface=_SURFACE_REWRITE_PLAN_SUPPORT,
+                    capability_name="rewrite_plan_support",
+                    runtime_config=runtime_config,
+                )
+            )
         if file_paths_override is None:
             file_paths = resolve_analysis_paths(paths, config=runtime_config)
         else:
@@ -1334,6 +1434,7 @@ def analyze_paths(
             parse_failure_witnesses=parse_failure_witnesses,
             forest_spec=forest_spec,
             profiling_v1=profiling_v1,
+            unsupported_by_adapter=unsupported_by_adapter,
         )
     except TimeoutExceeded:
         _best_effort_timeout_flush(lambda: _emit_collection_progress(force=True))

--- a/src/gabion/analysis/dataflow_report_rendering.py
+++ b/src/gabion/analysis/dataflow_report_rendering.py
@@ -64,3 +64,23 @@ def render_synthesis_section(
         lines.extend(str(e) for e in errors)
         lines.append("```")
     return "\n".join(lines)
+
+
+def render_unsupported_by_adapter_section(
+    diagnostics: list[JSONObject],
+    *,
+    check_deadline: Callable[[], None],
+) -> list[str]:
+    lines: list[str] = []
+    for diagnostic in diagnostics:
+        check_deadline()
+        if type(diagnostic) is not dict:
+            continue
+        surface = str(diagnostic.get("surface", ""))
+        adapter = str(diagnostic.get("adapter", "native"))
+        required = bool(diagnostic.get("required_by_policy", False))
+        line = f"{surface}: unsupported_by_adapter ({adapter})"
+        if required:
+            line = f"{line} [required]"
+        lines.append(line)
+    return lines

--- a/src/gabion/config.py
+++ b/src/gabion/config.py
@@ -148,6 +148,22 @@ def dataflow_deadline_roots(section: TomlTable | None) -> list[str]:
     return _normalize_name_list(section.get("deadline_roots"))
 
 
+def dataflow_adapter_payload(section: TomlTable | None) -> TomlTable:
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        return {}
+    adapter = section.get("adapter")
+    if not isinstance(adapter, dict):
+        return {}
+    return adapter
+
+
+def dataflow_required_surfaces(section: TomlTable | None) -> list[str]:
+    adapter = dataflow_adapter_payload(section)
+    return _normalize_name_list(adapter.get("required_surfaces"))
+
+
 def merge_payload(payload: TomlTable, defaults: TomlTable) -> TomlTable:
     check_deadline()
     merged = dict(defaults)

--- a/tests/test_dataflow_report_rendering_module.py
+++ b/tests/test_dataflow_report_rendering_module.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import random
 
-from gabion.analysis.dataflow_report_rendering import render_synthesis_section
+from gabion.analysis.dataflow_report_rendering import (
+    render_synthesis_section,
+    render_unsupported_by_adapter_section,
+)
 
 
 def _check_deadline() -> None:
@@ -94,3 +97,17 @@ def test_render_synthesis_section_renders_error_block() -> None:
     assert "Errors:" in text
     assert "first" in text
     assert "second" in text
+
+
+
+# gabion:evidence E:call_footprint::tests/test_dataflow_report_rendering_module.py::test_render_unsupported_by_adapter_section_marks_required::dataflow_report_rendering.py::gabion.analysis.dataflow_report_rendering.render_unsupported_by_adapter_section
+def test_render_unsupported_by_adapter_section_marks_required() -> None:
+    lines = render_unsupported_by_adapter_section(
+        [
+            {"surface": "type-flow", "adapter": "limited", "required_by_policy": False},
+            {"surface": "decision-surfaces", "adapter": "limited", "required_by_policy": True},
+        ],
+        check_deadline=_check_deadline,
+    )
+    assert "type-flow: unsupported_by_adapter (limited)" in lines
+    assert "decision-surfaces: unsupported_by_adapter (limited) [required]" in lines


### PR DESCRIPTION
### Motivation

- Allow adapters to declare supported analysis capabilities and avoid running unsupported passes at runtime. 
- Surface skipped analysis as structured diagnostics instead of silently omitting them so reports and policy can react.
- Provide a policy hook so repository config can require certain analysis surfaces and fail CI when a required surface is disabled.

### Description

- Add adapter payload helpers in `src/gabion/config.py` (`dataflow_adapter_payload`, `dataflow_required_surfaces`) and normalize adapter metadata into `AuditConfig.adapter_contract` and `AuditConfig.required_analysis_surfaces` in `dataflow_audit`.
- Introduce `AdapterCapabilities` parsing and `normalize_adapter_contract` in `src/gabion/analysis/dataflow_audit.py` and carry `unsupported_by_adapter` diagnostics on `AnalysisResult`/`ReportCarrier`.
- Gate orchestration passes in `analyze_paths` (`src/gabion/analysis/dataflow_pipeline.py`) based on adapter capabilities for `bundle-inference`, `decision-surfaces`, `type-flow`, `exception-obligations`, and `rewrite-plan-support`, and emit structured `unsupported_by_adapter` diagnostics for any skipped surfaces.
- Extend reporting rendering to include a dedicated "Skipped by adapter capabilities" section via `render_unsupported_by_adapter_section` in `src/gabion/analysis/dataflow_report_rendering.py`, and escalate skipped surfaces to violations only when `required_by_policy` is true in `src/gabion/analysis/dataflow_reporting.py`.
- Add a policy-check hook in `scripts/policy_check.py` (`--adapter-surfaces`) to validate configured `required_surfaces` against known surfaces and ensure required surfaces are not disabled by adapter capabilities.
- Add tests exercising rendering and runtime behavior (`tests/test_dataflow_report_rendering_module.py` and `tests/test_dataflow_audit_run.py`) and refresh `out/test_evidence.json` to include new evidence entries.

### Testing

- Ran the policy checks with `PYTHONPATH=src mise exec -- python -m scripts.policy_check --workflows --ambiguity-contract --adapter-surfaces` and it completed successfully.
- Ran the targeted test suite with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_dataflow_report_rendering_module.py tests/test_dataflow_audit_run.py -q` and all tests passed (`13 passed`).
- Re-generated test evidence with `PYTHONPATH=src mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to include the new evidence mappings for the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ea43e04c8324aba5b027b347bb4f)