### PR TITLE
Add adapter ingestion contract tests, golden fixtures, and CI guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 110
+doc_revision: 111
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -241,10 +241,16 @@ Correction-unit validation stack (recommended interoperability baseline):
 ```bash
 mise exec -- python scripts/policy_check.py --workflows
 mise exec -- python scripts/policy_check.py --ambiguity-contract
+mise exec -- python -m pytest -q tests/test_ingest_adapter_contract.py
 mise exec -- python -m pytest -q <targeted-tests>
 mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json
 git diff --exit-code out/test_evidence.json
 ```
+
+Adapter-ingestion corrections must include golden fixture evidence for each
+added adapter path under `tests/fixtures/ingest_adapter/`, plus parity
+assertions that equivalent adapter payloads preserve overlapping
+bundle/decision surfaces.
 
 When semantic-core modules or policy-check-critical files are touched, also run the strict coverage gate:
 

--- a/tests/fixtures/ingest_adapter/python_expected.json
+++ b/tests/fixtures/ingest_adapter/python_expected.json
@@ -1,0 +1,25 @@
+{
+  "exit_code": 0,
+  "timeout": false,
+  "analysis_state": "done",
+  "errors": ["2", "first error"],
+  "lint_entries": [
+    {
+      "path": "pkg/module.py",
+      "line": 9,
+      "col": 2,
+      "code": "DF001",
+      "message": "ambiguous bundle",
+      "severity": "warning"
+    }
+  ],
+  "decision_surfaces": [
+    {"surface": "bundle", "id": "B1"},
+    {"surface": "deadness", "id": "D1"}
+  ],
+  "bundle_sites_by_path": {
+    "pkg/module.py": [
+      {"function": "f", "bundle": ["a", "b"]}
+    ]
+  }
+}

--- a/tests/fixtures/ingest_adapter/python_raw.json
+++ b/tests/fixtures/ingest_adapter/python_raw.json
@@ -1,0 +1,42 @@
+{
+  "exit_code": "0",
+  "timeout": false,
+  "analysis_state": "done",
+  "errors": ["first error", 2],
+  "lint_lines": [
+    "pkg/module.py:9:2: DF001 ambiguous bundle",
+    "not-a-lint-line"
+  ],
+  "decision_surfaces": [
+    {"surface": "bundle", "id": "B1"},
+    {"surface": "deadness", "id": "D1"}
+  ],
+  "bundle_sites_by_path": {
+    "pkg/module.py": [
+      {"function": "f", "bundle": ["a", "b"]}
+    ]
+  },
+  "fingerprint_rewrite_plans": [
+    {
+      "plan_id": "rewrite:z.py:f:a:glossary-ambiguity:surface-canonicalize",
+      "site": {"path": "z.py", "function": "f", "bundle": ["a"]},
+      "rewrite": {"kind": "SURFACE_CANONICALIZE", "parameters": {"candidates": ["ctx"]}},
+      "verification": {"predicates": [{"kind": "base_conservation"}]},
+      "evidence": {"provenance_id": "p", "coherence_id": "c"}
+    },
+    {
+      "plan_id": "rewrite:a.py:f:a:glossary-ambiguity:bundle-align",
+      "site": {"path": "a.py", "function": "f", "bundle": ["a"]},
+      "rewrite": {"kind": "BUNDLE_ALIGN", "parameters": {"candidates": ["ctx"]}},
+      "verification": {
+        "predicates": [
+          {"kind": "base_conservation"},
+          {"kind": "ctor_coherence"},
+          {"kind": "match_strata"},
+          {"kind": "remainder_non_regression"}
+        ]
+      },
+      "evidence": {"provenance_id": "p", "coherence_id": "c"}
+    }
+  ]
+}

--- a/tests/fixtures/ingest_adapter/synthetic_expected.json
+++ b/tests/fixtures/ingest_adapter/synthetic_expected.json
@@ -1,0 +1,25 @@
+{
+  "exit_code": 0,
+  "timeout": false,
+  "analysis_state": "done",
+  "errors": [],
+  "lint_entries": [
+    {
+      "path": "web/app.ts",
+      "line": 9,
+      "col": 2,
+      "code": "DF001",
+      "message": "ambiguous bundle",
+      "severity": "warning"
+    }
+  ],
+  "decision_surfaces": [
+    {"surface": "bundle", "id": "B1"},
+    {"surface": "deadness", "id": "D1"}
+  ],
+  "bundle_sites_by_path": {
+    "web/app.ts": [
+      {"function": "f", "bundle": ["a", "b"]}
+    ]
+  }
+}

--- a/tests/fixtures/ingest_adapter/synthetic_raw.json
+++ b/tests/fixtures/ingest_adapter/synthetic_raw.json
@@ -1,0 +1,24 @@
+{
+  "exit_code": 0,
+  "timeout": false,
+  "analysis_state": "done",
+  "errors": [],
+  "lint_entries": [
+    {
+      "path": "web/app.ts",
+      "line": 9,
+      "col": 2,
+      "code": "DF001",
+      "message": "ambiguous bundle"
+    }
+  ],
+  "decision_surfaces": [
+    {"surface": "bundle", "id": "B1"},
+    {"surface": "deadness", "id": "D1"}
+  ],
+  "bundle_sites_by_path": {
+    "web/app.ts": [
+      {"function": "f", "bundle": ["a", "b"]}
+    ]
+  }
+}

--- a/tests/test_ingest_adapter_contract.py
+++ b/tests/test_ingest_adapter_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from gabion.server import _normalize_dataflow_response
+
+_FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "ingest_adapter"
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((_FIXTURE_ROOT / name).read_text(encoding="utf-8"))
+
+
+def _normalized_primitives(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_dataflow_response(payload)
+    return {
+        "exit_code": normalized["exit_code"],
+        "timeout": normalized["timeout"],
+        "analysis_state": normalized["analysis_state"],
+        "errors": normalized["errors"],
+        "lint_entries": normalized["lint_entries"],
+        "decision_surfaces": normalized.get("decision_surfaces", []),
+        "bundle_sites_by_path": normalized.get("bundle_sites_by_path", {}),
+    }
+
+
+# gabion:evidence E:function_site::tests/test_ingest_adapter_contract.py::test_python_ingest_contract_fixture
+
+def test_python_ingest_contract_fixture() -> None:
+    raw = _load_fixture("python_raw.json")
+    expected = _load_fixture("python_expected.json")
+
+    assert _normalized_primitives(raw) == expected
+
+
+# gabion:evidence E:function_site::tests/test_ingest_adapter_contract.py::test_synthetic_non_python_ingest_contract_fixture
+
+def test_synthetic_non_python_ingest_contract_fixture() -> None:
+    raw = _load_fixture("synthetic_raw.json")
+    expected = _load_fixture("synthetic_expected.json")
+
+    assert _normalized_primitives(raw) == expected
+
+
+# gabion:evidence E:function_site::tests/test_ingest_adapter_contract.py::test_ingest_normalization_deterministic_ordering
+
+def test_ingest_normalization_deterministic_ordering() -> None:
+    raw = _load_fixture("python_raw.json")
+    reversed_insertion_payload = {key: raw[key] for key in reversed(list(raw.keys()))}
+
+    first = _normalize_dataflow_response(raw)
+    second = _normalize_dataflow_response(reversed_insertion_payload)
+
+    assert list(first.keys()) == list(second.keys())
+    assert first["fingerprint_rewrite_plans"][0]["site"]["path"] == "a.py"
+    assert first["fingerprint_rewrite_plans"] == second["fingerprint_rewrite_plans"]
+
+
+# gabion:evidence E:function_site::tests/test_ingest_adapter_contract.py::test_adapter_parity_on_overlapping_decision_surfaces
+
+def test_adapter_parity_on_overlapping_decision_surfaces() -> None:
+    python_primitives = _normalized_primitives(_load_fixture("python_raw.json"))
+    synthetic_primitives = _normalized_primitives(_load_fixture("synthetic_raw.json"))
+
+    assert python_primitives["exit_code"] == synthetic_primitives["exit_code"]
+    assert python_primitives["timeout"] == synthetic_primitives["timeout"]
+    assert python_primitives["analysis_state"] == synthetic_primitives["analysis_state"]
+    assert python_primitives["decision_surfaces"] == synthetic_primitives["decision_surfaces"]
+    assert python_primitives["lint_entries"][0]["code"] == synthetic_primitives["lint_entries"][0]["code"]
+    assert python_primitives["lint_entries"][0]["message"] == synthetic_primitives["lint_entries"][0]["message"]


### PR DESCRIPTION
### Motivation
- Ensure adapter ingestion normalization invariants and deterministic ordering are validated as part of the test surface. 
- Provide golden fixtures for at least one non-Python adapter path (synthetic format) to exercise downstream parity. 
- Make CI/contributor guidance explicit about running adapter contract tests and producing evidence artifacts for gateable verification.

### Description
- Add `tests/test_ingest_adapter_contract.py` which exercises normalization invariants, deterministic ordering, and parity across adapter payloads. 
- Add golden fixture pairs under `tests/fixtures/ingest_adapter/` (`*_raw.json` and `*_expected.json`) for a Python-style payload and a synthetic non-Python payload. 
- Update `CONTRIBUTING.md` (`doc_revision` bump) to include adapter contract tests in the recommended correction-unit validation stack and require adapter fixture/evidence expectations. 
- Refresh `out/test_evidence.json` to include evidence mappings for the new adapter tests (evidence carrier updated to reflect the added tests).

### Testing
- Ran the workflow policy checks with `PYTHONPATH=src:. python scripts/policy_check.py --workflows` and the command succeeded. 
- Ran the ambiguity-contract check with `PYTHONPATH=src:. python scripts/policy_check.py --ambiguity-contract` and it succeeded. 
- Executed targeted pytest runs with `PYTHONPATH=src:. python -m pytest -q -o addopts='' tests/test_ingest_adapter_contract.py tests/test_server_rewrite_plan_projection.py tests/test_check_contract.py` and the tests passed (`11 passed`). 
- Ran evidence extraction with `PYTHONPATH=src:. python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` which produced an updated `out/test_evidence.json` reflecting the new tests and was recorded in the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ea51f614832481ffc3bc0a5be74c)