### PR TITLE
Harden consolidation forest mode and make fallback explicit

### DIFF
--- a/tests/test_consolidation_forest_guardrail.py
+++ b/tests/test_consolidation_forest_guardrail.py
@@ -22,13 +22,36 @@ def _write_decision_snapshot(path: Path, *, include_forest: bool = False) -> Non
         "summary": {"decision_surfaces": 1, "value_decision_surfaces": 0},
     }
     if include_forest:
-        payload["forest"] = {"format_version": 1, "nodes": [], "alts": []}
+        payload["forest"] = {
+            "format_version": 1,
+            "nodes": [
+                {
+                    "kind": "FunctionSite",
+                    "key": ["mod.py", "mod.fn"],
+                    "meta": {"path": "mod.py", "qual": "mod.fn"},
+                },
+                {
+                    "kind": "ParamSet",
+                    "key": ["a"],
+                    "meta": {"params": ["a"]},
+                },
+            ],
+            "alts": [
+                {
+                    "kind": "DecisionSurface",
+                    "inputs": [
+                        {"kind": "FunctionSite", "key": ["mod.py", "mod.fn"]},
+                        {"kind": "ParamSet", "key": ["a"]},
+                    ],
+                    "evidence": {"meta": "boundary"},
+                }
+            ],
+        }
     path.write_text(json.dumps(payload))
 
 # gabion:evidence E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._write_decision_snapshot E:decision_surface/direct::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools::stale_df4a2ad0492a
 def test_consolidation_requires_forest_in_strict_mode(tmp_path: Path) -> None:
     audit_tools = _load_audit_tools()
-    (tmp_path / "gabion.toml").write_text("[consolidation]\nrequire_forest = true\n")
     decision_path = tmp_path / "decision_snapshot.json"
     lint_path = tmp_path / "lint.txt"
     output_path = tmp_path / "consolidation_report.md"
@@ -51,13 +74,12 @@ def test_consolidation_requires_forest_in_strict_mode(tmp_path: Path) -> None:
     assert "forest-only mode enabled" in str(exc.value)
 
 # gabion:evidence E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._write_decision_snapshot E:decision_surface/direct::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools::stale_649d8b273257_3f84b302
-def test_consolidation_allows_fallback_in_permissive_mode(tmp_path: Path) -> None:
+def test_consolidation_uses_forest_when_present(tmp_path: Path) -> None:
     audit_tools = _load_audit_tools()
-    (tmp_path / "gabion.toml").write_text("[consolidation]\nrequire_forest = false\n")
     decision_path = tmp_path / "decision_snapshot.json"
     lint_path = tmp_path / "lint.txt"
     output_path = tmp_path / "consolidation_report.md"
-    _write_decision_snapshot(decision_path, include_forest=False)
+    _write_decision_snapshot(decision_path, include_forest=True)
     lint_path.write_text("")
 
     result = audit_tools.run_consolidation_cli(
@@ -74,6 +96,40 @@ def test_consolidation_allows_fallback_in_permissive_mode(tmp_path: Path) -> Non
     )
     assert result == 0
     report_text = output_path.read_text()
+    assert "Consolidation source mode: forest-native" in report_text
+    assert "FOREST_FALLBACK_USED" not in report_text
+
+
+# gabion:evidence E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools E:function_site::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._write_decision_snapshot
+def test_consolidation_explicit_fallback_mode_emits_warning_payload(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    audit_tools = _load_audit_tools()
+    decision_path = tmp_path / "decision_snapshot.json"
+    lint_path = tmp_path / "lint.txt"
+    output_path = tmp_path / "consolidation_report.md"
+    _write_decision_snapshot(decision_path, include_forest=False)
+    lint_path.write_text("")
+
+    result = audit_tools.run_consolidation_cli(
+        [
+            "--root",
+            str(tmp_path),
+            "--decision",
+            str(decision_path),
+            "--lint",
+            str(lint_path),
+            "--output",
+            str(output_path),
+            "--allow-fallback",
+        ]
+    )
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert '"warning_class": "consolidation.forest_fallback"' in captured.out
+    report_text = output_path.read_text()
+    assert "Consolidation source mode: fallback-derived" in report_text
     assert "FOREST_FALLBACK_USED" in report_text
 
 # gabion:evidence E:call_footprint::tests/test_consolidation_forest_guardrail.py::test_audit_tools_gas_limit_env_override::governance_audit.py::gabion.tooling.governance_audit._audit_gas_limit::env_helpers.py::tests.env_helpers.env_scope::test_consolidation_forest_guardrail.py::tests.test_consolidation_forest_guardrail._load_audit_tools


### PR DESCRIPTION
### Motivation
- Make consolidation behave conservatively by default by requiring the decision-forest to be present so guardrails prefer forest-native consolidation.
- Provide an explicit, auditable escape hatch for fallback-derived consolidation and surface a distinct warning-class payload when it is used.
- Improve reporting so consumers can tell whether suggestions came from the forest or from fallback parsing.

### Description
- Flip the `require_forest` default to `True` in the `ConsolidationConfig` dataclass and in `_load_consolidation_config` coercion logic.
- Change `_consolidation_command` to fail in strict (default) mode when forest data is missing or incomplete unless `--allow-fallback` is passed, and add the `--allow-fallback` CLI flag.
- Add constants and metadata: `FOREST_FALLBACK_WARNING_CLASS`, `CONSOLIDATION_SOURCE_FOREST_NATIVE`, and `CONSOLIDATION_SOURCE_FALLBACK_DERIVED`, include `Consolidation source mode: ...` in the markdown report, and add `report_metadata` into the `--json-output` payload with `source_mode`, `forest_required`, and `fallback_used`.
- When fallback parsing is used, emit a structured JSON warning payload (containing `warning_class`, `source_mode`, and `notes`) to make fallback occurrences machine-detectable.
- Extend and adjust tests in `tests/test_consolidation_forest_guardrail.py` to cover forest-present, forest-missing (strict mode), and explicit fallback-with-warning modes, and make the fixture produce a minimal valid forest for the native path.
- Updated `out/test_evidence.json` to reflect the changed tests.

### Testing
- Ran `PYTHONPATH=src mise exec -- python scripts/policy_check.py --workflows` and it completed successfully (warnings from `mise` metadata resolution are environment-related and expected here).
- Ran `PYTHONPATH=src mise exec -- python scripts/policy_check.py --ambiguity-contract` and it completed successfully.
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_consolidation_forest_guardrail.py` and all tests in the file passed (`8 passed`).
- Ran `PYTHONPATH=src mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ecb258d4832481bafe6557bfbfe4)