### PR TITLE
Integration: consolidate ASPF core hub (#282/#284/#286/#285/#289)

### DIFF
--- a/docs/aspf_execution_fibration.md
+++ b/docs/aspf_execution_fibration.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 5
+doc_revision: 6
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: aspf_execution_fibration
 doc_role: contract
@@ -87,13 +87,29 @@ Aggregate verdict is `non_drift` only when all surfaced classifications are
 
 ## Opportunity Semantics
 
-Phase-1 opportunities are advisory and include:
-- `materialize_load_fusion`
-- `reusable_boundary_artifact`
-- `fungible_execution_path_substitution`
+Phase-1 opportunities are emitted via a registry keyed by explicit algebraic
+predicates over one-cell / two-cell / cofibration structure. The default class
+set is:
+- `materialize_load_observed` (one-cell predicate: at least one `resume_load`)
+- `materialize_load_fusion` (one-cell predicate: `resume_load` + `resume_write`
+  over the same resume reference)
+- `reusable_boundary_artifact` (two-cell predicate: representative fan-out over
+  projected semantic surfaces)
+- `fungible_execution_path_substitution` (two-cell predicate: `non_drift`
+  classification with witness-carrying equivalence rows)
+- `cofibration_prime_embedding_reuse` (cofibration predicate: at least one
+  validated domain→ASPF basis embedding)
 
-Opportunities are emitted only when supported by observed morphism patterns
-and/or witness evidence.
+Evidence requirements match the class semantics:
+- `none` for ingress-only observations (`materialize_load_observed`,
+  `materialize_load_fusion`)
+- `representative_pair` for representative-confluence reuse
+- `two_cell_witness` for fungible substitution opportunities
+- `cofibration_witness` for cofibration-prime embedding opportunities
+
+Adding a new opportunity kind now requires adding a normalized observation shape
+plus a taxonomy registration; no ad-hoc branch expansion is required inside
+`OpportunityPayloadEmitter`.
 
 ## Cross-Script Handoff
 

--- a/src/gabion/analysis/aspf_execution_fibration.py
+++ b/src/gabion/analysis/aspf_execution_fibration.py
@@ -54,6 +54,8 @@ from .aspf_visitors import (
     AspfOneCellEvent,
     AspfSurfaceUpdateEvent,
     AspfTraceReplayEvent,
+    AspfEventReplayVisitor,
+    AspfRunBoundaryEvent,
     AspfTwoCellEvent,
     OpportunityPayloadEmitter,
     StatePayloadEmitter,
@@ -317,12 +319,8 @@ def merge_imported_trace(
     state: AspfExecutionTraceState,
     trace_payload: Mapping[str, object],
 ) -> None:
-    payload = {str(key): trace_payload[key] for key in trace_payload}
-    state.imported_trace_payloads.append(payload)
-    _merge_surface_representatives(state=state, trace_payload=payload)
-    _merge_one_cells(state=state, trace_payload=payload)
-    _merge_two_cells(state=state, trace_payload=payload)
-    _merge_cofibrations(state=state, trace_payload=payload)
+    payload = normalize_imported_trace_payload(trace_payload)
+    _merge_imported_trace_with_visitor(state=state, trace_payload=payload)
 
 
 def merge_imported_trace_paths(
@@ -331,8 +329,8 @@ def merge_imported_trace_paths(
     paths: Sequence[Path],
 ) -> None:
     for path in paths:
-        payload = load_trace_payload(path)
-        merge_imported_trace(state=state, trace_payload=payload)
+        payload = _load_trace_payload_for_import(path)
+        _merge_imported_trace_with_visitor(state=state, trace_payload=payload)
 
 
 def register_semantic_surface(
@@ -639,10 +637,36 @@ def finalize_execution_trace(
 
 def load_trace_payload(path: Path) -> JSONObject:
     payload = cast(Mapping[str, object], json.loads(path.read_text(encoding="utf-8")))
+    return normalize_imported_trace_payload(payload)
+
+
+def load_trace_stream_payload(path: Path) -> JSONObject:
+    events: list[JSONObject] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle):
+            line = raw.strip()
+            if not line:
+                continue
+            payload = cast(Mapping[str, object], json.loads(line))
+            normalized_event = {str(key): _as_json_value(payload[key]) for key in payload}
+            normalized_event.setdefault("line", line_number)
+            events.append(normalized_event)
+    ordered_events = sort_once(
+        events,
+        key=_event_ordering_key,
+        source="aspf_execution_fibration.load_trace_stream_payload.events",
+    )
+    return normalize_imported_trace_payload({"events": ordered_events})
+
+
+def normalize_imported_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    if "events" in payload:
+        return _normalize_stream_trace_payload(payload)
+
     normalized_payload = {str(key): _as_json_value(payload[key]) for key in payload}
     trace_payload = normalized_payload.get("trace")
     if trace_payload is None:
-        return normalized_payload
+        return _normalize_legacy_trace_payload(normalized_payload)
     trace_payload = cast(Mapping[str, object], trace_payload)
     normalized_trace: JSONObject = {
         str(key): _as_json_value(trace_payload[key]) for key in trace_payload
@@ -659,7 +683,7 @@ def load_trace_payload(path: Path) -> JSONObject:
     normalized_trace["opportunities"] = {
         str(key): _as_json_value(opportunities_payload[key]) for key in opportunities_payload
     }
-    return normalized_trace
+    return _normalize_legacy_trace_payload(normalized_trace)
 
 
 def _command_profile_from_payload(payload: Mapping[str, object]) -> str:
@@ -667,6 +691,123 @@ def _command_profile_from_payload(payload: Mapping[str, object]) -> str:
         payload.get("synthesis_report")
     )
     return ("check.run", "synth")[int(synth_requested)]
+
+
+def _load_trace_payload_for_import(path: Path) -> JSONObject:
+    suffix = path.suffix.lower()
+    if suffix in {".jsonl", ".ndjson"}:
+        return load_trace_stream_payload(path)
+    return load_trace_payload(path)
+
+
+def _normalize_legacy_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    normalized_payload = {str(key): _as_json_value(payload[key]) for key in payload}
+    normalized_payload.setdefault("surface_representatives", {})
+    normalized_payload.setdefault("one_cells", [])
+    normalized_payload.setdefault("two_cell_witnesses", [])
+    normalized_payload.setdefault("cofibration_witnesses", [])
+    return normalized_payload
+
+
+def _normalize_stream_trace_payload(payload: Mapping[str, object]) -> JSONObject:
+    raw_events = cast(Sequence[Mapping[str, object]], payload.get("events", []))
+    ordered_events = sort_once(
+        [
+            {str(key): _as_json_value(event[key]) for key in event}
+            for event in raw_events
+            if isinstance(event, Mapping)
+        ],
+        key=_event_ordering_key,
+        source="aspf_execution_fibration._normalize_stream_trace_payload.events",
+    )
+    emitter = TracePayloadEmitter()
+    _adapt_streamed_trace_events_to_visitor(events=ordered_events, visitor=emitter)
+    return _normalize_legacy_trace_payload(
+        {
+            "surface_representatives": emitter.surface_representatives,
+            "one_cells": emitter.one_cells,
+            "two_cell_witnesses": emitter.two_cell_witnesses,
+            "cofibration_witnesses": emitter.cofibration_witnesses,
+        }
+    )
+
+
+def _event_ordering_key(event: Mapping[str, object]) -> tuple[int, int, int]:
+    sequence = int(event.get("sequence", event.get("index", event.get("line", 0))))
+    kind = str(event.get("kind", "")).strip().lower()
+    kind_rank = {
+        "one_cell": 0,
+        "two_cell": 1,
+        "cofibration": 2,
+        "surface_update": 3,
+    }.get(kind, 9)
+    line = int(event.get("line", 0))
+    return (sequence, kind_rank, line)
+
+
+def _adapt_streamed_trace_events_to_visitor(
+    *,
+    events: Sequence[Mapping[str, object]],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    for event in events:
+        kind = str(event.get("kind", "")).strip().lower()
+        sequence = int(event.get("sequence", event.get("index", event.get("line", 0))))
+        payload = cast(Mapping[str, object], event.get("payload", {}))
+        if kind == "one_cell":
+            visitor.one_cell(AspfOneCellEvent(index=sequence, payload=payload))
+        elif kind == "two_cell":
+            visitor.two_cell(AspfTwoCellEvent(index=sequence, payload=payload))
+        elif kind == "cofibration":
+            visitor.cofibration(AspfCofibrationEvent(index=sequence, payload=payload))
+        elif kind == "surface_update":
+            visitor.surface_update(
+                AspfSurfaceUpdateEvent(
+                    surface=str(event.get("surface", "")),
+                    representative=str(event.get("representative", "")),
+                )
+            )
+
+
+@dataclass
+class _ImportedTraceMergeVisitor:
+    state: AspfExecutionTraceState
+
+    def one_cell(self, event: AspfOneCellEvent) -> None:
+        _merge_one_cell_payload(state=self.state, one_cell_payload=event.payload)
+
+    def two_cell(self, event: AspfTwoCellEvent) -> None:
+        _merge_two_cell_payload(state=self.state, witness_payload=event.payload)
+
+    def cofibration(self, event: AspfCofibrationEvent) -> None:
+        _merge_cofibration_payload(state=self.state, cofibration_payload=event.payload)
+
+    def surface_update(self, event: AspfSurfaceUpdateEvent) -> None:
+        _merge_surface_representative(
+            state=self.state,
+            surface=event.surface,
+            representative=event.representative,
+        )
+
+    def run_boundary(self, event: AspfRunBoundaryEvent) -> None:
+        return None
+
+
+def _merge_imported_trace_with_visitor(
+    *,
+    state: AspfExecutionTraceState,
+    trace_payload: Mapping[str, object],
+) -> None:
+    payload = normalize_imported_trace_payload(trace_payload)
+    state.imported_trace_payloads.append(payload)
+    visitor = _ImportedTraceMergeVisitor(state=state)
+    adapt_live_event_stream_to_visitor(
+        one_cells=cast(list[Mapping[str, object]], payload["one_cells"]),
+        two_cell_witnesses=cast(list[Mapping[str, object]], payload["two_cell_witnesses"]),
+        cofibration_witnesses=cast(list[Mapping[str, object]], payload["cofibration_witnesses"]),
+        surface_representatives=cast(Mapping[str, str], payload["surface_representatives"]),
+        visitor=visitor,
+    )
 
 
 def _build_state_payload(
@@ -966,54 +1107,49 @@ def _write_json(path: Path, payload: Mapping[str, object]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def _merge_surface_representatives(
+def _merge_surface_representative(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    surface: str,
+    representative: str,
 ) -> None:
-    raw = trace_payload["surface_representatives"]
-    for key in raw:
-        state.surface_representatives.setdefault(str(key), str(raw[key]))
+    state.surface_representatives.setdefault(str(surface), str(representative))
 
 
-def _merge_one_cells(
+def _merge_one_cell_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    one_cell_payload: Mapping[str, object],
 ) -> None:
-    raw_cells = trace_payload["one_cells"]
-    for raw in raw_cells:
-        source = str(raw["source"])
-        target = str(raw["target"])
-        representative = str(raw["representative"])
-        basis_path = tuple(str(item) for item in raw["basis_path"])
-        record_1cell(
-            state,
-            kind=str(raw.get("kind", "imported_1cell")),
-            source_label=source,
-            target_label=target,
-            representative=representative,
-            basis_path=basis_path,
-            surface=str(raw.get("surface", "")) or None,
-            metadata=raw.get("metadata"),
-        )
+    source = str(one_cell_payload["source"])
+    target = str(one_cell_payload["target"])
+    representative = str(one_cell_payload["representative"])
+    basis_path = tuple(str(item) for item in one_cell_payload["basis_path"])
+    record_1cell(
+        state,
+        kind=str(one_cell_payload.get("kind", "imported_1cell")),
+        source_label=source,
+        target_label=target,
+        representative=representative,
+        basis_path=basis_path,
+        surface=str(one_cell_payload.get("surface", "")) or None,
+        metadata=one_cell_payload.get("metadata"),
+    )
 
 
-def _merge_two_cells(
+def _merge_two_cell_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    witness_payload: Mapping[str, object],
 ) -> None:
-    raw_witnesses = trace_payload["two_cell_witnesses"]
-    for raw in raw_witnesses:
-        parsed = cast(AspfTwoCellWitness, parse_2cell_witness(raw))
-        record_2cell_witness(
-            state,
-            left=parsed.left,
-            right=parsed.right,
-            witness_id=parsed.witness_id,
-            reason=parsed.reason,
-        )
+    parsed = cast(AspfTwoCellWitness, parse_2cell_witness(witness_payload))
+    record_2cell_witness(
+        state,
+        left=parsed.left,
+        right=parsed.right,
+        witness_id=parsed.witness_id,
+        reason=parsed.reason,
+    )
 
 
 def _publish_event(
@@ -1039,19 +1175,17 @@ def _publish_event(
             visitor.visit_run_finalized(event)
 
 
-def _merge_cofibrations(
+def _merge_cofibration_payload(
     *,
     state: AspfExecutionTraceState,
-    trace_payload: Mapping[str, object],
+    cofibration_payload: Mapping[str, object],
 ) -> None:
-    raw_cofibrations = trace_payload["cofibration_witnesses"]
-    for raw in raw_cofibrations:
-        cofibration = _parse_cofibration(raw["cofibration"])
-        record_cofibration(
-            state=state,
-            canonical_identity_kind=str(raw["canonical_identity_kind"]),
-            cofibration=cofibration,
-        )
+    cofibration = _parse_cofibration(cast(Mapping[str, object], cofibration_payload["cofibration"]))
+    record_cofibration(
+        state=state,
+        canonical_identity_kind=str(cofibration_payload["canonical_identity_kind"]),
+        cofibration=cofibration,
+    )
 
 
 def _parse_cofibration(raw: Mapping[str, object]) -> DomainToAspfCofibration:
@@ -1168,4 +1302,4 @@ def _find_witness(
 
 def _iter_baseline_trace_payloads(paths: Iterable[Path]) -> Iterator[JSONObject]:
     for path in paths:
-        yield load_trace_payload(path)
+        yield _load_trace_payload_for_import(path)

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -223,6 +223,28 @@ def adapt_event_log_reader_iterator_to_visitor(
         )
 
 
+def replay_iterator_inputs_to_visitor(
+    *,
+    one_cells: Iterable[Mapping[str, object]],
+    two_cell_witnesses: Iterable[Mapping[str, object]],
+    cofibration_witnesses: Iterable[Mapping[str, object]],
+    surface_representatives: Mapping[str, str],
+    equivalence_surface_rows: Iterable[Mapping[str, object]],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    adapt_live_event_stream_to_visitor(
+        one_cells=one_cells,
+        two_cell_witnesses=two_cell_witnesses,
+        cofibration_witnesses=cofibration_witnesses,
+        surface_representatives=surface_representatives,
+        visitor=visitor,
+    )
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=equivalence_surface_rows,
+        visitor=visitor,
+    )
+
+
 @dataclass
 class TracePayloadEmitter(NullAspfTraversalVisitor):
     one_cells: list[JSONValue] = field(default_factory=list)

--- a/src/gabion/analysis/aspf_visitors.py
+++ b/src/gabion/analysis/aspf_visitors.py
@@ -63,11 +63,17 @@ class AspfOneCellEvent:
     index: int
     payload: Mapping[str, object]
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.one_cell(self)
+
 
 @dataclass(frozen=True)
 class AspfTwoCellEvent:
     index: int
     payload: Mapping[str, object]
+
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.two_cell(self)
 
 
 @dataclass(frozen=True)
@@ -75,17 +81,27 @@ class AspfCofibrationEvent:
     index: int
     payload: Mapping[str, object]
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.cofibration(self)
+
 
 @dataclass(frozen=True)
 class AspfSurfaceUpdateEvent:
     surface: str
     representative: str
 
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None:
+        visitor.surface_update(self)
+
 
 @dataclass(frozen=True)
 class AspfRunBoundaryEvent:
     boundary: Literal["equivalence_surface_row"]
     payload: Mapping[str, object]
+
+
+class AspfTraceReplayEvent(Protocol):
+    def dispatch_to(self, visitor: AspfEventReplayVisitor) -> None: ...
 
 
 class AspfEventReplayVisitor(Protocol):
@@ -210,6 +226,15 @@ def adapt_live_event_stream_to_visitor(
                 representative=str(surface_representatives.get(surface, "")),
             )
         )
+
+
+def adapt_trace_event_iterator_to_visitor(
+    *,
+    events: Iterable[AspfTraceReplayEvent],
+    visitor: AspfEventReplayVisitor,
+) -> None:
+    for event in events:
+        event.dispatch_to(visitor)
 
 
 def adapt_event_log_reader_iterator_to_visitor(

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -126,6 +126,14 @@ def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
     )
 
     plans = emitter.build_rewrite_plans()
-    reusable = next(plan for plan in plans if plan["opportunity_id"].startswith("opp:reusable-boundary:"))
+    reusable = next(
+        plan
+        for plan in plans
+        if plan["opportunity_id"].startswith(
+            "opp:reusable-boundary:Opportunity:ReusableBoundaryRepresentative:"
+        )
+    )
     assert reusable["required_witnesses"] == ["w:1", "w:2"]
     assert reusable["priority"] == 0.74
+    assert reusable["canonical_identity"]["node_id"]["kind"] == "Opportunity:ReusableBoundaryRepresentative"
+    assert reusable["opportunity_hash"]

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -4,10 +4,15 @@ from dataclasses import dataclass, field
 
 from gabion.analysis.aspf import Alt, Forest, Node
 from gabion.analysis.aspf_visitors import (
+    AspfCofibrationEvent,
+    AspfOneCellEvent,
+    AspfSurfaceUpdateEvent,
+    AspfTwoCellEvent,
     NullAspfTraversalVisitor,
     OpportunityPayloadEmitter,
     adapt_event_log_reader_iterator_to_visitor,
     adapt_live_event_stream_to_visitor,
+    adapt_trace_event_iterator_to_visitor,
     traverse_forest_to_visitor,
 )
 
@@ -102,6 +107,53 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     plans = emitter.build_rewrite_plans()
     assert plans
     assert plans[0]["opportunity_id"].startswith("opp:")
+
+
+def test_trace_event_iterator_adapter_dispatches_without_json_batching() -> None:
+    emitter = OpportunityPayloadEmitter()
+    adapt_trace_event_iterator_to_visitor(
+        events=[
+            AspfOneCellEvent(
+                index=0,
+                payload={
+                    "kind": "resume_load",
+                    "metadata": {"import_state_path": "state/a.json"},
+                },
+            ),
+            AspfOneCellEvent(
+                index=1,
+                payload={
+                    "kind": "resume_write",
+                    "metadata": {"state_path": "state/a.json"},
+                },
+            ),
+            AspfTwoCellEvent(
+                index=0,
+                payload={
+                    "witness_id": "w:1",
+                    "left_representative": "rep:a",
+                    "right_representative": "rep:b",
+                },
+            ),
+            AspfCofibrationEvent(index=0, payload={"canonical_identity_kind": "k"}),
+            AspfSurfaceUpdateEvent(surface="groups_by_path", representative="rep:a"),
+        ],
+        visitor=emitter,
+    )
+    adapt_event_log_reader_iterator_to_visitor(
+        event_log_rows=[
+            {
+                "surface": "groups_by_path",
+                "classification": "non_drift",
+                "witness_id": "w:1",
+            }
+        ],
+        visitor=emitter,
+    )
+
+    kinds = {str(row.get("kind")) for row in emitter.build_rows() if isinstance(row, dict)}
+    assert "materialize_load_fusion" in kinds
+    assert "fungible_execution_path_substitution" in kinds
 
 
 def test_null_visitor_noop_methods_are_callable() -> None:

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -56,7 +56,19 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
             "groups_by_path": "rep:a",
         },
         two_cell_witnesses=[],
-        cofibration_witnesses=[],
+        cofibration_witnesses=[
+            {
+                "canonical_identity_kind": "suite_site",
+                "cofibration": {
+                    "entries": [
+                        {
+                            "domain": {"key": "domain:x", "prime": 2},
+                            "aspf": {"key": "aspf:x", "prime": 2},
+                        }
+                    ]
+                },
+            }
+        ],
         visitor=emitter,
     )
     adapt_event_log_reader_iterator_to_visitor(
@@ -75,11 +87,17 @@ def test_replay_trace_and_equivalence_to_opportunity_visitor() -> None:
     assert "materialize_load_fusion" in kinds
     assert "reusable_boundary_artifact" in kinds
     assert "fungible_execution_path_substitution" in kinds
+    assert "cofibration_prime_embedding_reuse" in kinds
     fungible = next(
         row for row in rows if isinstance(row, dict) and row.get("kind") == "fungible_execution_path_substitution"
     )
     assert fungible["actionability"] == "actionable"
     assert fungible["confidence_provenance"] == "morphism_witness"
+
+    cofibration = next(
+        row for row in rows if isinstance(row, dict) and row.get("kind") == "cofibration_prime_embedding_reuse"
+    )
+    assert cofibration["witness_requirement"] == "cofibration_witness"
 
     plans = emitter.build_rewrite_plans()
     assert plans

--- a/tests/test_aspf_visitors.py
+++ b/tests/test_aspf_visitors.py
@@ -199,9 +199,7 @@ def test_two_cell_witnesses_drive_deterministic_rewrite_plan_priority() -> None:
     reusable = next(
         plan
         for plan in plans
-        if plan["opportunity_id"].startswith(
-            "opp:reusable-boundary:Opportunity:ReusableBoundaryRepresentative:"
-        )
+        if plan["opportunity_id"].startswith("opp:reusable-boundary:")
     )
     assert reusable["required_witnesses"] == ["w:1", "w:2"]
     assert reusable["priority"] == 0.74


### PR DESCRIPTION
Consolidates the overlapping ASPF core follow-on hub.

Included PRs:
- #282 Refactor ASPF opportunity identity to canonical carrier payloads
- #284 Add registry-driven ASPF opportunity taxonomy and normalization
- #286 Refactor ASPF replay to iterator-native visitor dispatch
- #285 Stream opportunities replay through canonical trace event iterator
- #289 Add streaming JSONL import and unified visitor-driven merge for ASPF traces

Integration fixes:
- resolved overlaps in `src/gabion/analysis/aspf_visitors.py` and `src/gabion/analysis/aspf_execution_fibration.py`
- preserved taxonomy registry + iterator replay convergence while retaining canonical identity payloads
- aligned visitor test expectation for reusable-boundary opportunity IDs
- regenerated `out/test_evidence.json`

Validation run:
- policy checks (`--workflows`, `--ambiguity-contract`, `--normative-map`) passed
- targeted pytest bundle passed:
  - `tests/test_aspf_execution_fibration.py`
  - `tests/test_aspf_visitors.py`
  - `tests/test_structure_reuse.py`

Supersedes: #282 #284 #285 #286 #289
