### PR TITLE
Normalize ASPF node identity and canonicalize stage-cache identities; add equivalence tests

### DIFF
--- a/src/gabion/analysis/type_fingerprints.py
+++ b/src/gabion/analysis/type_fingerprints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Iterable, cast
+import hashlib
 import math
 
 from gabion.analysis.aspf_core import (
@@ -32,6 +33,7 @@ from gabion.analysis.resume_codec import mapping_or_none, sequence_or_none, str_
 from gabion.analysis.timeout_context import check_deadline
 from gabion.analysis.timeout_context import consume_deadline_ticks
 from gabion.order_contract import OrderPolicy, sort_once
+from gabion.runtime import stable_encode
 
 TYPE_BASE_NAMESPACE = "type_base"
 TYPE_CTOR_NAMESPACE = "type_ctor"
@@ -569,6 +571,17 @@ def fingerprint_identity_payload(
     if cofibration.entries:
         payload["cofibration_witness"] = cofibration.as_dict()
     return payload
+
+
+def fingerprint_stage_cache_identity(
+    fingerprint_seed_revision: object,
+) -> str:
+    text = str(fingerprint_seed_revision or "").strip()
+    if not text:
+        return ""
+    canonical_text = stable_encode.stable_compact_text({"fingerprint_seed_revision": text})
+    digest = hashlib.sha1(canonical_text.encode("utf-8")).hexdigest()
+    return f"aspf:sha1:{digest}"
 
 
 def _fingerprint_sort_key(fingerprint: Fingerprint) -> tuple[int, int, int, int, int, int, int, int]:

--- a/tests/test_type_fingerprints.py
+++ b/tests/test_type_fingerprints.py
@@ -926,3 +926,12 @@ def test_reverse_prime_index_preserves_decode_identity_across_reruns() -> None:
     assert remainder_b == 1
     assert keys_a == ["int", "int", "str"]
     assert keys_a == keys_b
+
+
+# gabion:evidence E:call_footprint::tests/test_type_fingerprints.py::test_fingerprint_stage_cache_identity_normalizes_equivalent_seed_text::type_fingerprints.py::gabion.analysis.type_fingerprints.fingerprint_stage_cache_identity
+def test_fingerprint_stage_cache_identity_normalizes_equivalent_seed_text() -> None:
+    tf = _load()
+    first = tf.fingerprint_stage_cache_identity(" seed@v1 ")
+    second = tf.fingerprint_stage_cache_identity("seed@v1")
+    assert first == second
+    assert first.startswith("aspf:sha1:")


### PR DESCRIPTION
### Motivation
- Remove ad-hoc non-`NodeId` identity paths in ASPF internals to ensure a single, canonical identity flow for node creation and lookups. 
- Centralize canonicalization of `Alt.evidence` at a single ingress so that structural identity used for interning is stable and reused. 
- Make stage-cache keys deterministic across semantically equivalent but differently serialized inputs (config ordering and fingerprint seed text). 
- Add tests that prove cache hits for equivalent inputs to prevent regressions in cache-key identity logic.

### Description
- Reworked ASPF intern identity plumbing to prefer a `NodeId`-first canonicalization API and updated `Forest._intern_node` / `Forest.has_node` to use `NodeId` directly. 
- Normalized `Alt.evidence` canonicalization by relying on `Alt.__post_init__` and creating the `Alt` before computing the interning structural key in `Forest.add_alt`. 
- Standardized stage-cache identity generation by adding `_canonical_stage_cache_detail` (structural canonicalization of the `detail` payload) in `dataflow_audit.py` and a `fingerprint_stage_cache_identity` helper in `type_fingerprints.py` to canonicalize fingerprint-seed values and use `aspf:sha1:` prefixed digests. 
- Added regression tests: `test_analysis_index_stage_cache_hits_for_equivalent_parse_key_config_serializations` and `test_fingerprint_stage_cache_identity_normalizes_equivalent_seed_text`, and updated assertions that examine canonicalized parse-detail values; refreshed `out/test_evidence.json` to reflect new call-footprint evidence mapping.

### Testing
- Ran the targeted pytest subset with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_aspf.py tests/test_dataflow_audit_edges.py tests/test_dataflow_audit_helpers.py tests/test_type_fingerprints.py` and all tests passed (`269 passed`).
- Executed policy checks with `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` which completed successfully. 
- Re-generated test evidence with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and committed the refreshed `out/test_evidence.json` mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ecce6a8083249164ad87e8d4d9bd)