### PR TITLE
Require explicit morphism proof obligations for ASPF opportunities

### DIFF
--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -171,8 +171,15 @@ class AspfOpportunityDTO(BaseModel):
     opportunity_id: str
     kind: str
     confidence: float
+    confidence_provenance: Optional[str] = None
+    witness_requirement: Optional[str] = None
+    actionability: Optional[str] = None
     affected_surfaces: List[str] = []
     witness_ids: List[str] = []
+    carrier_subgraph: Dict[str, Any] = {}
+    witness_chain: List[str] = []
+    proof_obligations: List[Dict[str, Any]] = []
+    failed_obligations: List[str] = []
     reason: str
 
 


### PR DESCRIPTION
### Motivation
- Strengthen opportunity derivation to require explicit morphism-pattern proof obligations over 1-cell/2-cell/cofibration structure instead of relying on a fixed additive score.  
- Make actionability and confidence depend on explicit proof obligations so opportunities reflect witnessed isomorphy rather than mere representative collisions.  
- Surface structural rationale in emitted payloads so downstream automation and human reviewers can inspect the carrier subgraph, witness chain, and any failed obligations.  

### Description
- Add a `OpportunityProofObligation` dataclass and extend `OpportunityDecisionProtocol` to carry `proof_obligations`, `carrier_subgraph`, `witness_chain` and a `failed_obligations` accessor in `src/gabion/analysis/aspf_visitors.py`.  
- Replace the previous additive `confidence()` scoring with obligation-coverage confidence computed as `satisfied / total`, and gate `actionability` on obligation satisfaction.  
- Collect additional morphism-pattern evidence from trace events: record representatives observed in 1-cells, parse nested or flattened 2-cell witness payloads, and count/inspect cofibration entries to evaluate cofibration support.  
- Emit richer opportunity rows and rewrite-plan artifacts with the structural rationale fields `carrier_subgraph`, `witness_chain`, `proof_obligations`, and `failed_obligations`.  
- Extend the ASPF opportunity DTO in `src/gabion/schema.py` to include the new fields for schema normalization and payload validation.  
- Add and update tests in `tests/test_aspf_visitors.py` to cover deterministic priority when obligations are satisfied and a golden-style test that distinguishes collision-only opportunities from true witnessed isomorphy.  
- Add evidence mapping entry and refresh `out/test_evidence.json` for the new golden test.  

### Testing
- Ran policy/workflow checks: `PYTHONPATH=src mise exec -- python scripts/policy_check.py --workflows` succeeded (environment warning about fetching tool list noted but non-blocking).  
- Ran ambiguity contract check: `PYTHONPATH=src mise exec -- python scripts/policy_check.py --ambiguity-contract` succeeded.  
- Ran targeted unit tests: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py -q` — all tests passed (`18 passed`).  
- Re-extracted test evidence: `PYTHONPATH=src mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json`.  
- Performed byte-compile sanity: `python -m py_compile` on modified modules and tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ecd9f6188324b081bec0367b44a2)