### PR TITLE
integration: consolidate command-tooling lane (#299/#293)

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -136,6 +136,7 @@ if $run_dataflow; then
     "checks.check.run" \
     mise exec -- python -m gabion check run \
     "${baseline_arg[@]}"
+  mise exec -- python -m gabion delta-advisory-telemetry
 fi
 if $run_docflow; then
   docflow_args=(--fail-on-violations --sppf-gh-ref-mode "$docflow_mode")

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -1233,6 +1233,8 @@ def build_dataflow_payload(opts: argparse.Namespace) -> JSONObject:
             allow_external=opts.allow_external,
             strictness=opts.strictness,
             lint=bool(opts.lint or opts.lint_jsonl or opts.lint_sarif),
+            language=opts.language,
+            ingest_profile=opts.ingest_profile,
             aspf_trace_json=Path(aspf_trace_json_target)
             if aspf_trace_json_target
             else None,
@@ -3248,6 +3250,16 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
         default=None,
     )
     parser.add_argument("--strictness", choices=["high", "low"], default=None)
+    parser.add_argument(
+        "--language",
+        default=None,
+        help="Explicit analysis language adapter (for example: python).",
+    )
+    parser.add_argument(
+        "--ingest-profile",
+        default=None,
+        help="Optional ingest profile used by the selected language adapter.",
+    )
     parser.add_argument(
         "--aspf-trace-json",
         default=None,

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -59,6 +59,7 @@ from gabion.plan import (
     ExecutionPlanPolicyMetadata,
 )
 from gabion.tooling import (
+    delta_advisory as tooling_delta_advisory,
     docflow_delta_emit as tooling_docflow_delta_emit,
     governance_audit as tooling_governance_audit,
     impact_select_tests as tooling_impact_select_tests,
@@ -2171,6 +2172,7 @@ def _run_check_delta_gates(
         else tuple(gate_specs)
     )
     with _cli_deadline_scope():
+        tooling_delta_advisory.telemetry_main()
         return next(
             (
                 gate_exit
@@ -4379,6 +4381,7 @@ def _invoke_argparse_command(
 
 
 _TOOLING_NO_ARG_RUNNERS: dict[str, Callable[[], int]] = {
+    "delta-advisory-telemetry": tooling_delta_advisory.telemetry_main,
     "docflow-delta-emit": tooling_docflow_delta_emit.main,
 }
 _TOOLING_ARGV_RUNNERS: dict[str, Callable[[list[str] | None], int]] = {
@@ -4438,6 +4441,12 @@ def removed_delta_triplets() -> None:
     raise typer.BadParameter(
         "Removed command: delta-triplets. Use `gabion check delta-gates`."
     )
+
+
+@app.command("delta-advisory-telemetry")
+def delta_advisory_telemetry() -> None:
+    """Emit non-blocking advisory telemetry artifacts."""
+    raise typer.Exit(code=_run_tooling_no_arg("delta-advisory-telemetry"))
 
 
 @app.command("docflow-delta-emit")

--- a/src/gabion/commands/check_contract.py
+++ b/src/gabion/commands/check_contract.py
@@ -249,6 +249,8 @@ class DataflowPayloadCommonOptions:
     allow_external: bool | None
     strictness: str | None
     lint: bool
+    language: str | None = None
+    ingest_profile: str | None = None
     deadline_profile: bool = True
     aspf_trace_json: Path | None = None
     aspf_import_trace: list[Path] | None = None
@@ -320,6 +322,8 @@ def build_dataflow_payload_common(
         "allow_external": options.allow_external,
         "strictness": options.strictness,
         "lint": options.lint,
+        "language": options.language,
+        "ingest_profile": options.ingest_profile,
         "deadline_profile": bool(options.deadline_profile),
         "aspf_trace_json": str(options.aspf_trace_json)
         if options.aspf_trace_json is not None

--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -234,6 +234,9 @@ class DataflowAuditResponseDTO(BaseModel):
     errors: List[str] = []
     lint_lines: List[str] = []
     lint_entries: List[LintEntryDTO] = []
+    selected_adapter: Optional[str] = None
+    supported_analysis_surfaces: List[str] = []
+    disabled_surface_reasons: Dict[str, str] = {}
     aspf_trace: Optional[AspfTraceDTO] = None
     aspf_equivalence: Optional[AspfEquivalenceDTO] = None
     aspf_opportunities: Optional[AspfOpportunitiesDTO] = None

--- a/src/gabion/tooling/advisory_evidence.py
+++ b/src/gabion/tooling/advisory_evidence.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, Mapping
+
+from gabion.order_contract import sort_once
+from gabion.runtime import json_io
+
+AdvisoryDomain = Literal["obsolescence", "annotation_drift", "ambiguity", "docflow"]
+
+DEFAULT_ADVISORY_AGGREGATE_PATH = Path("artifacts/out/advisory_aggregate.json")
+
+
+@dataclass(frozen=True)
+class AdvisoryEvidenceEntry:
+    domain: AdvisoryDomain
+    key: str
+    baseline: int
+    current: int
+    delta: int
+    threshold_class: str
+    message: str
+    timestamp: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "baseline": int(self.baseline),
+            "current": int(self.current),
+            "delta": int(self.delta),
+            "domain": str(self.domain),
+            "key": str(self.key),
+            "message": str(self.message),
+            "threshold_class": str(self.threshold_class),
+            "timestamp": str(self.timestamp),
+        }
+
+
+@dataclass(frozen=True)
+class AdvisoryEvidencePayload:
+    domain: AdvisoryDomain
+    source_delta_path: str
+    generated_at: str
+    entries: tuple[AdvisoryEvidenceEntry, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        ordered_entries = sort_once(
+            self.entries,
+            source="advisory_evidence.AdvisoryEvidencePayload.to_dict.entries",
+            key=lambda entry: entry.key,
+        )
+        return {
+            "domain": str(self.domain),
+            "entries": [entry.to_dict() for entry in ordered_entries],
+            "generated_at": str(self.generated_at),
+            "schema_version": 1,
+            "source_delta_path": str(self.source_delta_path),
+        }
+
+
+@dataclass(frozen=True)
+class AdvisoryAggregatePayload:
+    generated_at: str
+    advisories: Mapping[str, AdvisoryEvidencePayload]
+
+    def to_dict(self) -> dict[str, object]:
+        ordered_domains = sort_once(
+            self.advisories.keys(),
+            source="advisory_evidence.AdvisoryAggregatePayload.to_dict.domains",
+        )
+        return {
+            "advisories": {
+                domain: self.advisories[domain].to_dict()
+                for domain in ordered_domains
+            },
+            "generated_at": str(self.generated_at),
+            "schema_version": 1,
+        }
+
+
+def advisory_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def write_payload(path: Path, payload: AdvisoryEvidencePayload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json_io.dump_json_pretty(payload.to_dict()) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_aggregate(path: Path = DEFAULT_ADVISORY_AGGREGATE_PATH) -> dict[str, object]:
+    return json_io.load_json_object_path(path)
+
+
+def write_aggregate(
+    payloads: Mapping[str, AdvisoryEvidencePayload],
+    *,
+    aggregate_path: Path = DEFAULT_ADVISORY_AGGREGATE_PATH,
+    generated_at: str | None = None,
+) -> None:
+    aggregate = AdvisoryAggregatePayload(
+        generated_at=generated_at or advisory_timestamp(),
+        advisories=payloads,
+    )
+    aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+    aggregate_path.write_text(
+        json_io.dump_json_pretty(aggregate.to_dict()) + "\n",
+        encoding="utf-8",
+    )

--- a/src/gabion/tooling/delta_advisory.py
+++ b/src/gabion/tooling/delta_advisory.py
@@ -1,14 +1,16 @@
 # gabion:decision_protocol_module
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Literal, Mapping
 
 from gabion.analysis.timeout_context import check_deadline
 from gabion.order_contract import sort_once
-from gabion.runtime import env_policy
+import json
+
+from gabion.runtime import env_policy, json_io
+from gabion.tooling import advisory_evidence
 from gabion.tooling.deadline_runtime import DeadlineBudget, deadline_scope_from_lsp_env
 
 AdvisoryId = Literal["obsolescence", "annotation_drift", "ambiguity", "docflow"]
@@ -26,12 +28,27 @@ _DEFAULT_ADVISORY_TIMEOUT_BUDGET = DeadlineBudget(
 
 
 @dataclass(frozen=True)
+class AdvisoryMetric:
+    key: str
+    baseline: int
+    current: int
+    delta: int
+
+
+@dataclass(frozen=True)
+class AdvisoryNormalizedSummary:
+    heading: str
+    metrics: tuple[AdvisoryMetric, ...]
+
+
+@dataclass(frozen=True)
 class AdvisoryConfig:
     id: AdvisoryId
     delta_path: Path
+    artifact_path: Path
     missing_message: str
     error_prefix: str
-    summary_renderer: Callable[[Mapping[str, object], Callable[[str], None]], None]
+    summary_builder: Callable[[Mapping[str, object]], AdvisoryNormalizedSummary]
     env_flag: str | None = None
     skip_message: str | None = None
 
@@ -50,10 +67,32 @@ def _mapping(value: object) -> Mapping[str, object]:
     return value if isinstance(value, Mapping) else {}
 
 
-def _obsolescence_summary(
-    payload: Mapping[str, object],
-    print_fn: Callable[[str], None],
-) -> None:
+def _count(value: object) -> int:
+    return int(value) if isinstance(value, int) else 0
+
+
+def _metric_entry(
+    key: str,
+    baseline: Mapping[str, object],
+    current: Mapping[str, object],
+    delta: Mapping[str, object],
+) -> AdvisoryMetric:
+    return AdvisoryMetric(
+        key=key,
+        baseline=_count(baseline.get(key)),
+        current=_count(current.get(key)),
+        delta=_count(delta.get(key)),
+    )
+
+
+def _render_summary(summary: AdvisoryNormalizedSummary, print_fn: Callable[[str], None]) -> None:
+    print_fn(summary.heading)
+    for entry in summary.metrics:
+        check_deadline()
+        print_fn(f"- {entry.key}: {entry.baseline} -> {entry.current} ({entry.delta})")
+
+
+def _obsolescence_summary(payload: Mapping[str, object]) -> AdvisoryNormalizedSummary:
     summary = _mapping(payload.get("summary"))
     counts = _mapping(summary.get("counts"))
     baseline = _mapping(counts.get("baseline"))
@@ -66,22 +105,25 @@ def _obsolescence_summary(
         "obsolete_candidate",
         "unmapped",
     ]
-    print_fn("Test obsolescence delta summary (advisory):")
-    for key in keys:
-        check_deadline()
-        print_fn(
-            f"- {key}: {baseline.get(key, 0)} -> {current.get(key, 0)} ({delta.get(key, 0)})"
+    metrics = [
+        _metric_entry(key, baseline, current, delta)
+        for key in keys
+    ]
+    metrics.append(
+        AdvisoryMetric(
+            key="opaque_evidence_count",
+            baseline=_count(opaque.get("baseline")),
+            current=_count(opaque.get("current")),
+            delta=_count(opaque.get("delta")),
         )
-    print_fn(
-        "- opaque_evidence_count: "
-        f"{opaque.get('baseline', 0)} -> {opaque.get('current', 0)} ({opaque.get('delta', 0)})"
+    )
+    return AdvisoryNormalizedSummary(
+        heading="Test obsolescence delta summary (advisory):",
+        metrics=tuple(metrics),
     )
 
 
-def _annotation_drift_summary(
-    payload: Mapping[str, object],
-    print_fn: Callable[[str], None],
-) -> None:
+def _annotation_drift_summary(payload: Mapping[str, object]) -> AdvisoryNormalizedSummary:
     summary = _mapping(payload.get("summary"))
     baseline = _mapping(summary.get("baseline"))
     current = _mapping(summary.get("current"))
@@ -90,64 +132,124 @@ def _annotation_drift_summary(
         {*baseline.keys(), *current.keys(), *delta.keys()},
         source="gabion.tooling.delta_advisory.annotation_summary_keys",
     )
-    print_fn("Annotation drift delta summary (advisory):")
-    for key in keys:
-        check_deadline()
-        print_fn(
-            f"- {key}: {baseline.get(key, 0)} -> {current.get(key, 0)} ({delta.get(key, 0)})"
-        )
+    return AdvisoryNormalizedSummary(
+        heading="Annotation drift delta summary (advisory):",
+        metrics=tuple(_metric_entry(str(key), baseline, current, delta) for key in keys),
+    )
 
 
-def _ambiguity_summary(
-    payload: Mapping[str, object],
-    print_fn: Callable[[str], None],
-) -> None:
+def _ambiguity_summary(payload: Mapping[str, object]) -> AdvisoryNormalizedSummary:
     summary = _mapping(payload.get("summary"))
     total = _mapping(summary.get("total"))
     by_kind = _mapping(summary.get("by_kind"))
     baseline = _mapping(by_kind.get("baseline"))
     current = _mapping(by_kind.get("current"))
     delta = _mapping(by_kind.get("delta"))
-    print_fn("Ambiguity delta summary (advisory):")
-    print_fn(
-        "- total: "
-        f"{total.get('baseline', 0)} -> {total.get('current', 0)} ({total.get('delta', 0)})"
-    )
     keys = sort_once(
         {*baseline.keys(), *current.keys(), *delta.keys()},
         source="gabion.tooling.delta_advisory.ambiguity_by_kind_keys",
     )
-    for key in keys:
-        check_deadline()
-        print_fn(
-            f"- {key}: {baseline.get(key, 0)} -> {current.get(key, 0)} ({delta.get(key, 0)})"
-        )
+    by_kind_metrics = [_metric_entry(str(key), baseline, current, delta) for key in keys]
+    return AdvisoryNormalizedSummary(
+        heading="Ambiguity delta summary (advisory):",
+        metrics=(
+            AdvisoryMetric(
+                key="total",
+                baseline=_count(total.get("baseline")),
+                current=_count(total.get("current")),
+                delta=_count(total.get("delta")),
+            ),
+            *by_kind_metrics,
+        ),
+    )
 
 
-def _docflow_summary(
-    payload: Mapping[str, object],
-    print_fn: Callable[[str], None],
-) -> None:
+def _docflow_summary(payload: Mapping[str, object]) -> AdvisoryNormalizedSummary:
     summary = _mapping(payload.get("summary"))
     baseline = _mapping(summary.get("baseline"))
     current = _mapping(summary.get("current"))
     delta = _mapping(summary.get("delta"))
     keys = ["compliant", "contradicts", "excess", "proposed"]
-    print_fn("Docflow compliance delta summary (advisory):")
-    for key in keys:
-        check_deadline()
-        print_fn(
-            f"- {key}: {baseline.get(key, 0)} -> {current.get(key, 0)} ({delta.get(key, 0)})"
+    return AdvisoryNormalizedSummary(
+        heading="Docflow compliance delta summary (advisory):",
+        metrics=tuple(_metric_entry(key, baseline, current, delta) for key in keys),
+    )
+
+
+def _evidence_payload(
+    *,
+    config: AdvisoryConfig,
+    normalized: AdvisoryNormalizedSummary,
+    timestamp: str,
+    threshold_class: str = "telemetry_non_blocking",
+) -> advisory_evidence.AdvisoryEvidencePayload:
+    entries = tuple(
+        advisory_evidence.AdvisoryEvidenceEntry(
+            domain=config.id,
+            key=entry.key,
+            baseline=entry.baseline,
+            current=entry.current,
+            delta=entry.delta,
+            threshold_class=threshold_class,
+            message=f"{config.id}:{entry.key} delta={entry.delta}",
+            timestamp=timestamp,
         )
+        for entry in normalized.metrics
+    )
+    return advisory_evidence.AdvisoryEvidencePayload(
+        domain=config.id,
+        source_delta_path=str(config.delta_path),
+        generated_at=timestamp,
+        entries=entries,
+    )
+
+
+def _write_aggregate_with_domain(payload: advisory_evidence.AdvisoryEvidencePayload) -> None:
+    existing = json_io.load_json_object_path(advisory_evidence.DEFAULT_ADVISORY_AGGREGATE_PATH)
+    advisories_raw = _mapping(existing.get("advisories"))
+    domain_payloads: dict[str, advisory_evidence.AdvisoryEvidencePayload] = {}
+    for raw_domain, raw_payload in advisories_raw.items():
+        if raw_domain == payload.domain:
+            continue
+        item = _mapping(raw_payload)
+        entries_raw = item.get("entries")
+        if not isinstance(entries_raw, list):
+            continue
+        entries = tuple(
+            advisory_evidence.AdvisoryEvidenceEntry(
+                domain=str(raw_domain),
+                key=str(_mapping(raw_entry).get("key", "")),
+                baseline=_count(_mapping(raw_entry).get("baseline")),
+                current=_count(_mapping(raw_entry).get("current")),
+                delta=_count(_mapping(raw_entry).get("delta")),
+                threshold_class=str(_mapping(raw_entry).get("threshold_class", "telemetry_non_blocking")),
+                message=str(_mapping(raw_entry).get("message", "")),
+                timestamp=str(_mapping(raw_entry).get("timestamp", payload.generated_at)),
+            )
+            for raw_entry in entries_raw
+            if isinstance(raw_entry, Mapping)
+        )
+        domain_payloads[str(raw_domain)] = advisory_evidence.AdvisoryEvidencePayload(
+            domain=str(raw_domain),
+            source_delta_path=str(item.get("source_delta_path", "")),
+            generated_at=str(item.get("generated_at", payload.generated_at)),
+            entries=entries,
+        )
+    domain_payloads[payload.domain] = payload
+    advisory_evidence.write_aggregate(
+        domain_payloads,
+        generated_at=payload.generated_at,
+    )
 
 
 _ADVISORY_CONFIGS: dict[AdvisoryId, AdvisoryConfig] = {
     "obsolescence": AdvisoryConfig(
         id="obsolescence",
         delta_path=Path("artifacts/out/test_obsolescence_delta.json"),
+        artifact_path=Path("artifacts/out/obsolescence_advisory.json"),
         missing_message="Test obsolescence delta missing (advisory).",
         error_prefix="Test obsolescence delta advisory error",
-        summary_renderer=_obsolescence_summary,
+        summary_builder=_obsolescence_summary,
         env_flag=OBSOLESCENCE_ENV_FLAG,
         skip_message=(
             "Test obsolescence delta advisory skipped; "
@@ -157,9 +259,10 @@ _ADVISORY_CONFIGS: dict[AdvisoryId, AdvisoryConfig] = {
     "annotation_drift": AdvisoryConfig(
         id="annotation_drift",
         delta_path=Path("artifacts/out/test_annotation_drift_delta.json"),
+        artifact_path=Path("artifacts/out/annotation_drift_advisory.json"),
         missing_message="Annotation drift delta missing (advisory).",
         error_prefix="Annotation drift delta advisory error",
-        summary_renderer=_annotation_drift_summary,
+        summary_builder=_annotation_drift_summary,
         env_flag=ANNOTATION_DRIFT_ENV_FLAG,
         skip_message=(
             "Annotation drift delta advisory skipped; "
@@ -169,9 +272,10 @@ _ADVISORY_CONFIGS: dict[AdvisoryId, AdvisoryConfig] = {
     "ambiguity": AdvisoryConfig(
         id="ambiguity",
         delta_path=Path("artifacts/out/ambiguity_delta.json"),
+        artifact_path=Path("artifacts/out/ambiguity_advisory.json"),
         missing_message="Ambiguity delta missing (advisory).",
         error_prefix="Ambiguity delta advisory error",
-        summary_renderer=_ambiguity_summary,
+        summary_builder=_ambiguity_summary,
         env_flag=AMBIGUITY_ENV_FLAG,
         skip_message=(
             "Ambiguity delta advisory skipped; "
@@ -181,9 +285,10 @@ _ADVISORY_CONFIGS: dict[AdvisoryId, AdvisoryConfig] = {
     "docflow": AdvisoryConfig(
         id="docflow",
         delta_path=Path("artifacts/out/docflow_compliance_delta.json"),
+        artifact_path=Path("artifacts/out/docflow_advisory.json"),
         missing_message="Docflow compliance delta missing (advisory).",
         error_prefix="Docflow compliance delta advisory error",
-        summary_renderer=_docflow_summary,
+        summary_builder=_docflow_summary,
     ),
 }
 
@@ -193,6 +298,7 @@ def main_for_advisory(
     *,
     delta_path: Path | None = None,
     print_fn: Callable[[str], None] = print,
+    timestamp_fn: Callable[[], str] = advisory_evidence.advisory_timestamp,
 ) -> int:
     config = _ADVISORY_CONFIGS[advisory_id]
     with _deadline_scope():
@@ -207,9 +313,28 @@ def main_for_advisory(
                 print_fn(config.missing_message)
                 return 0
             payload = json.loads(target_path.read_text(encoding="utf-8"))
-            config.summary_renderer(_mapping(payload), print_fn)
+            normalized = config.summary_builder(_mapping(payload))
+            _render_summary(normalized, print_fn)
+            timestamp = timestamp_fn()
+            evidence_payload = _evidence_payload(
+                config=config,
+                normalized=normalized,
+                timestamp=timestamp,
+            )
+            advisory_evidence.write_payload(config.artifact_path, evidence_payload)
+            _write_aggregate_with_domain(evidence_payload)
         except Exception as exc:  # advisory only; keep CI green
             print_fn(f"{config.error_prefix}: {exc}")
+    return 0
+
+
+def telemetry_main(*, print_fn: Callable[[str], None] = print) -> int:
+    for advisory_id in sort_once(
+        _ADVISORY_CONFIGS.keys(),
+        source="gabion.tooling.delta_advisory.telemetry_main",
+    ):
+        check_deadline()
+        main_for_advisory(advisory_id, print_fn=print_fn)
     return 0
 
 

--- a/tests/test_cli_payloads.py
+++ b/tests/test_cli_payloads.py
@@ -16,6 +16,22 @@ _DEFAULT_CHECK_ARTIFACT_FLAGS = cli.CheckArtifactFlags(
 )
 
 
+def test_dataflow_payload_includes_language_and_ingest_profile() -> None:
+    opts = cli.parse_dataflow_args_or_exit(
+        [
+            ".",
+            "--language",
+            "Python",
+            "--ingest-profile",
+            "syntax-only",
+        ]
+    )
+    payload = cli.build_dataflow_payload(opts)
+    assert payload["language"] == "Python"
+    assert payload["ingest_profile"] == "syntax-only"
+
+
+
 # gabion:evidence E:decision_surface/direct::cli.py::gabion.cli.build_check_payload::ambiguity_state,baseline,config,decision_snapshot,emit_ambiguity_delta,emit_ambiguity_state,emit_test_annotation_drift_delta,emit_test_obsolescence_delta,emit_test_obsolescence_state,fail_on_type_ambiguities,paths,report,strictness,test_annotation_drift_state,test_obsolescence_state,write_ambiguity_baseline,write_test_annotation_drift_baseline,write_test_obsolescence_baseline E:decision_surface/direct::cli.py::gabion.cli._split_csv_entries::entries E:decision_surface/direct::cli.py::gabion.cli._split_csv::value E:decision_surface/direct::cli.py::gabion.cli._split_csv::stale_2a09d8d5ce19_af4348d7
 def test_check_builds_payload() -> None:
     payload = cli.build_check_payload(
@@ -377,6 +393,8 @@ def test_check_and_raw_payloads_match_common_fields() -> None:
         "allow_external",
         "strictness",
         "lint",
+        "language",
+        "ingest_profile",
         "deadline_profile",
     ]
     assert {key: check_payload[key] for key in common_keys} == {

--- a/tests/test_server_execute_command_edges.py
+++ b/tests/test_server_execute_command_edges.py
@@ -4055,11 +4055,24 @@ def test_server_normalize_dataflow_response_preserves_aspf_payloads() -> None:
                 "trace_id": "aspf-trace:abc123",
                 "opportunities": [],
             },
+            "selected_adapter": "python:default",
+            "supported_analysis_surfaces": ["rewrite_plans", "decision_surfaces"],
+            "disabled_surface_reasons": {
+                "type_ambiguities": "disabled by ingest profile syntax-only"
+            },
         }
     )
     assert normalized["aspf_trace"]["trace_id"] == "aspf-trace:abc123"
     assert normalized["aspf_equivalence"]["verdict"] == "non_drift"
     assert normalized["aspf_opportunities"]["opportunities"] == []
+    assert normalized["selected_adapter"] == "python:default"
+    assert normalized["supported_analysis_surfaces"] == [
+        "decision_surfaces",
+        "rewrite_plans",
+    ]
+    assert normalized["disabled_surface_reasons"] == {
+        "type_ambiguities": "disabled by ingest profile syntax-only"
+    }
 
 
 # gabion:evidence E:call_footprint::tests/test_server_execute_command_edges.py::test_execute_command_rejects_invalid_strictness::server.py::gabion.server.execute_command::test_server_execute_command_edges.py::tests.test_server_execute_command_edges._with_timeout::test_server_execute_command_edges.py::tests.test_server_execute_command_edges._write_bundle_module
@@ -4073,6 +4086,23 @@ def test_execute_command_rejects_invalid_strictness(tmp_path: Path) -> None:
                 "root": str(tmp_path),
                 "paths": [str(module)],
                 "strictness": "invalid",
+            }
+        ),
+    )
+    _assert_invariant_failure(result)
+
+
+def test_execute_command_rejects_unsupported_dataflow_ingest_profile(tmp_path: Path) -> None:
+    module = tmp_path / "sample.py"
+    _write_bundle_module(module)
+    result = server.execute_command(
+        _DummyServer(str(tmp_path)),
+        _with_timeout(
+            {
+                "root": str(tmp_path),
+                "paths": [str(module)],
+                "language": "python",
+                "ingest_profile": "not-supported",
             }
         ),
     )


### PR DESCRIPTION
## Summary
- consolidate #299 and #293 on top of current `stage`
- resolve command-tooling lane timeout regressions introduced by combined surfaces
- preserve streamlined semantics while removing redundant execution-pattern rescans

## Integration corrections in this PR
- `src/gabion/analysis/dataflow_audit.py`
  - compute execution-pattern facts once and reuse for match + near-miss lanes
  - keep pattern match semantics stable while reducing deadline-clock churn
- `src/gabion/server_core/command_orchestrator.py`
  - add duration-timeout clock normalization for ms/seconds payloads
  - provide `_TimeoutCleanupContext.dataflow_capabilities` default factory for direct test construction parity

## Validation
- `mise exec -- python scripts/policy_check.py --workflows`
- `mise exec -- python scripts/policy_check.py --ambiguity-contract`
- `mise exec -- python scripts/policy_check.py --normative-map`
- `mise exec -- python scripts/policy_check.py --adapter-surfaces`
- `mise exec -- python -m pytest -q tests/test_cli_payloads.py tests/test_server_execute_command_edges.py tests/test_server_core_orchestrator_edges.py tests/test_tooling_emit_advisory_and_gates.py tests/test_check_contract.py`
- `mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`

Supersedes: #299, #293
