### PR TITLE
integration: resolve #306 proof-obligation conflicts on stage

### DIFF
--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -171,8 +171,15 @@ class AspfOpportunityDTO(BaseModel):
     opportunity_id: str
     kind: str
     confidence: float
+    confidence_provenance: Optional[str] = None
+    witness_requirement: Optional[str] = None
+    actionability: Optional[str] = None
     affected_surfaces: List[str] = []
     witness_ids: List[str] = []
+    carrier_subgraph: Dict[str, Any] = {}
+    witness_chain: List[str] = []
+    proof_obligations: List[Dict[str, Any]] = []
+    failed_obligations: List[str] = []
     reason: str
 
 


### PR DESCRIPTION
## Summary
- resolves `#306` conflict against current `stage`
- preserves existing ASPF opportunity taxonomy/canonical-identity model
- integrates explicit proof-obligation semantics into opportunity rows and rewrite plans

## Integration decisions
- Keep stage’s taxonomy-based architecture (`OpportunityTaxonomyRegistry`) instead of reverting to legacy branch-local structure.
- Add explicit obligation carriers on `OpportunityDecisionProtocol`:
  - `proof_obligations`
  - `failed_obligations`
  - `carrier_subgraph`
  - `witness_chain`
- Derive reusable-boundary actionability from satisfied obligation set.
- Preserve existing canonical identity + `opportunity_hash` surfaces for compatibility with current stage consumers.

## Validation
- `mise exec -- python scripts/policy_check.py --workflows`
- `mise exec -- python scripts/policy_check.py --ambiguity-contract`
- `mise exec -- python scripts/policy_check.py --normative-map`
- `mise exec -- python -m pytest -q tests/test_aspf_visitors.py`
- `mise exec -- python -m pytest -q tests/test_aspf_execution_fibration.py tests/test_aspf_visitors.py`
- `mise exec -- python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`

Supersedes: #306
