### PR TITLE
Normalize impact DTO ingest and typed parity probe errors

### DIFF
--- a/tests/test_lsp_parity_gate.py
+++ b/tests/test_lsp_parity_gate.py
@@ -275,3 +275,21 @@ def test_cli_lsp_parity_gate_command_allows_zero_exit() -> None:
         },
     )
     assert result.exit_code == 0
+
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_execute_lsp_parity_gate_uses_typed_probe_error_channel::server.py::gabion.server._execute_lsp_parity_gate_total
+def test_execute_lsp_parity_gate_uses_typed_probe_error_channel() -> None:
+    rules = _rules_for_check_command(probe_payload={"k": "v"})
+    ls = SimpleNamespace(workspace=SimpleNamespace(root_path="."))
+
+    def _raise_runtime(_ls, _payload):
+        raise RuntimeError("executor failed")
+
+    result = server._execute_lsp_parity_gate_total(
+        ls,
+        {"commands": ["gabion.check"]},
+        load_rules=lambda: rules,
+        lsp_executor_for_command=lambda _command: _raise_runtime,
+        direct_executor_for_command=lambda _command: (lambda _ls, _payload: {}),
+    )
+    assert result["exit_code"] == 1
+    assert result["errors"] == ["executor failed"]


### PR DESCRIPTION
### Motivation

- Centralize and enforce validation for impact spans, call-depth, and confidence thresholds so command handlers consume deterministic data instead of ad-hoc branch guards. 
- Replace broad catch-all error handling in parity probing with explicit, typed probe error channels so executor failures are classified and surfaced predictably. 
- Ensure impact traversal only follows resolvable reverse edges and preserves unresolved references as normalized evidence rather than silently falling back. 

### Description

- Added `ImpactPayloadDTO` and `_normalize_impact_payload` to parse/validate/normalize `root`, `max_call_depth`, `confidence_threshold`, and `changes` before traversal, and wired the impact command to use the DTO (`src/gabion/server.py`).
- Introduced `ImpactEdgeBuckets` and `_normalize_impact_edge_buckets` so `_impact_collect_edges` output is split into resolvable reverse-edge buckets and a separate `unresolved_edges` bucket; unresolved entries are included in the response metadata (`meta.unresolved_reverse_edges`).
- Reworked parity probe execution by adding `ParityProbeError` and two concrete subclasses `LspProbeExecutionError` and `DirectProbeExecutionError`, plus executor wrappers `_probe_lsp_executor` and `_probe_direct_executor` that raise typed errors; the parity gate loop now catches `ParityProbeError` explicitly instead of `except Exception` (`src/gabion/server.py`).
- Removed branch-local fallback behavior in impact BFS (`caller_fn is None`) by treating missing callers after normalization as an invariant violation via `never(...)`, since normalization ensures only resolvable edges are followed.
- Added focused unit tests covering typed probe error handling and impact payload/edge normalization (`tests/test_lsp_parity_gate.py` and `tests/test_server_execute_command_edges.py`).

### Testing

- Ran the targeted pytest subset with `PYTHONPATH=src python -m pytest -q -o addopts='' tests/test_lsp_parity_gate.py tests/test_server_execute_command_edges.py -k 'impact or parity'`, and the tests passed (`25 passed, 189 deselected`).
- Ran governance checks `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`; both completed successfully.
- Extracted test-evidence with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and confirmed no changes (`git diff --exit-code out/test_evidence.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21e4e92b8832496f75ae370744280)