### PR TITLE
Refactor ASPF replay visitors around canonical event hook

### DIFF
--- a/tests/test_aspf_execution_fibration.py
+++ b/tests/test_aspf_execution_fibration.py
@@ -809,8 +809,8 @@ def test_imported_trace_merge_visitor_run_boundary_noop(tmp_path: Path) -> None:
         len(state.cofibrations),
         dict(state.surface_representatives),
     )
-    visitor.run_boundary(
-        aspf_execution_fibration.AspfRunBoundaryEvent(
+    visitor.on_replay_event(
+        event=aspf_execution_fibration.AspfRunBoundaryEvent(
             boundary="equivalence_surface_row",
             payload={"surface": "groups_by_path"},
         )
@@ -832,3 +832,38 @@ def test_controls_from_payload_defaults_empty_semantic_surface() -> None:
         }
     )
     assert controls.aspf_semantic_surface == aspf_execution_fibration.DEFAULT_PHASE1_SEMANTIC_SURFACES
+
+
+def test_normalize_imported_trace_payload_filters_invalid_two_cell_witnesses() -> None:
+    payload = aspf_execution_fibration.normalize_imported_trace_payload(
+        {
+            "one_cells": [],
+            "surface_representatives": {},
+            "cofibration_witnesses": [],
+            "two_cell_witnesses": [
+                {
+                    "witness_id": "w:valid",
+                    "left_representative": "rep:left",
+                    "right_representative": "rep:right",
+                },
+                {
+                    "witness_id": "",
+                    "left_representative": "rep:left",
+                    "right_representative": "rep:right",
+                },
+                {
+                    "witness_id": "w:missing-right",
+                    "left_representative": "rep:left",
+                    "right_representative": "",
+                },
+            ],
+        }
+    )
+
+    assert payload["two_cell_witnesses"] == [
+        {
+            "witness_id": "w:valid",
+            "left_representative": "rep:left",
+            "right_representative": "rep:right",
+        }
+    ]


### PR DESCRIPTION
### Motivation

- Reduce per-event boilerplate by exposing one canonical replay hook for ASPF event consumers. 
- Centralize replay dispatch so semantic-core visitors no longer need repetitive pass-through overrides. 
- Move two-cell witness validation to replay payload ingestion so visitor paths only see normalized, valid witness records. 
- Remove redundant adapter/bridge methods that existed only to forward events.

### Description

- Introduced a typed replay event union `AspfTraceReplayEvent` and replaced the per-event `one_cell/two_cell/cofibration/surface_update/run_boundary` overrides on the replay visitor with a single `on_replay_event(*, event: AspfTraceReplayEvent)` hook in `aspf_visitors.py`.
- Implemented a typed dispatch table (`_REPLAY_EVENT_DISPATCH_TABLE`) and small per-type dispatch functions that route canonical events to the concrete `on_trace_*` handlers on `NullAspfTraversalVisitor`.
- Added a deterministic two-cell normalization outcome type (`TwoCellReplayNormalizationOutcome`) and `_normalize_two_cell_witness_for_replay` to filter/normalize invalid two-cell witness records before dispatch, and updated live/streamed replay adapters to call `on_replay_event` and to only emit normalized two-cell events.
- Moved legacy two-cell payload sanitation into `_normalize_two_cell_witness_payloads` and wired it into `normalize_imported_trace_payload`/legacy normalization in `aspf_execution_fibration.py` so ingestion always returns validated two-cell witness records.
- Removed redundant pass-through replay adapter methods from `TracePayloadEmitter` and `OpportunityPayloadEmitter` so they rely on the canonical `on_replay_event` dispatch, and updated the imported-trace merge visitor to implement `on_replay_event` using pattern matching.
- Added/updated tests to exercise the canonical replay hook and two-cell witness normalization, and refreshed `out/test_evidence.json`.

### Testing

- Ran unit tests with `PYTHONPATH=src:. python -m pytest -o addopts='' tests/test_aspf_visitors.py tests/test_aspf_execution_fibration.py -q` and all tests passed (`30 passed`).
- Ran repo policy checks using the repo-local runner: `PYTHONPATH=src:. python scripts/policy_check.py --workflows` and `PYTHONPATH=src:. python scripts/policy_check.py --ambiguity-contract` and both completed successfully after adjusting normalization placement.
- Generated evidence carrier with `PYTHONPATH=src:. python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and committed the refreshed `out/test_evidence.json`.
- Note: an initial attempt to use `mise exec -- python ...` failed due to local `mise` trust/toolchain resolution in this environment, but equivalent repo-local checks were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21e255df883248e3a51f6bc93330e)