### PR TITLE
Use never() for representative mode exhaustiveness

### DIFF
--- a/src/gabion/analysis/aspf_decision_surface.py
+++ b/src/gabion/analysis/aspf_decision_surface.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from .aspf_core import AspfTwoCellWitness
+from ..invariants import never
 
 
 class RepresentativeSelectionMode(StrEnum):
@@ -48,7 +49,7 @@ def select_representative(options: RepresentativeSelectionOptions) -> Representa
     elif options.mode is RepresentativeSelectionMode.SHORTEST_PATH_THEN_LEXICOGRAPHIC:
         selected = min(options.candidates, key=lambda value: (len(value), value))
     else:  # pragma: no cover - enum exhaustiveness
-        raise ValueError(f"Unsupported representative selection mode: {options.mode}")
+        never("unsupported representative selection mode", mode=options.mode)
     return RepresentativeSelectionWitness(
         mode=options.mode,
         selected=selected,

--- a/tests/test_aspf_cofibration_laws.py
+++ b/tests/test_aspf_cofibration_laws.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from typing import cast
 
 from gabion.analysis.aspf_core import (
     AspfCanonicalIdentityContract,
@@ -27,6 +28,7 @@ from gabion.analysis.aspf_morphisms import (
     DomainToAspfCofibrationEntry,
 )
 from gabion.analysis.evidence_keys import fingerprint_identity_layers
+from gabion.exceptions import NeverThrown
 
 
 # gabion:evidence E:function_site::tests/test_aspf_cofibration_laws.py::tests.test_aspf_cofibration_laws.test_aspf_identity_and_associativity
@@ -185,6 +187,14 @@ def test_selection_and_cofibration_failure_edges() -> None:
             mode=RepresentativeSelectionMode.LEXICOGRAPHIC_MIN,
             candidates=("dup", "dup"),
         ).validate()
+
+    with pytest.raises(NeverThrown, match="unsupported representative selection mode"):
+        select_representative(
+            RepresentativeSelectionOptions(
+                mode=cast(RepresentativeSelectionMode, "unsupported_mode"),
+                candidates=("candidate",),
+            )
+        )
     assert (
         classify_drift_by_homotopy(
             baseline_representative="left",


### PR DESCRIPTION
### Motivation
- Make the enum-exhaustive fallback in `select_representative` follow the repository invariant pattern by using the `never()` sink instead of raising `ValueError` so unreachable control flow is encoded as an invariant violation. 
- Keep the fallback correction-local and include the offending mode value for fast triage in the invariant payload. 
- Align tests to the repository’s invariant exception path so assertions reflect `never()` behaviour rather than `ValueError`.

### Description
- Replaced the fallback `raise ValueError(...)` in `select_representative` with `never("unsupported representative selection mode", mode=options.mode)` and preserved the `# pragma: no cover - enum exhaustiveness` marker in `src/gabion/analysis/aspf_decision_surface.py`.
- Added the `never` import from `..invariants` to the decision-surface module.
- Updated `tests/test_aspf_cofibration_laws.py` to assert that forcing an unsupported/cast mode raises the invariant exception `NeverThrown` (imported from `gabion.exceptions`) instead of `ValueError`.
- Refreshed the test-evidence carrier `out/test_evidence.json` to reflect the line changes after editing the test file.

### Testing
- Ran `PYTHONPATH=src:. mise exec -- python scripts/policy_check.py --workflows` which completed successfully (local `mise` emitted a tool-resolution warning but the check ran).
- Ran `PYTHONPATH=src:. mise exec -- python scripts/policy_check.py --ambiguity-contract` which completed successfully.
- Ran `PYTHONPATH=src:. mise exec -- python -m pytest -c /dev/null tests/test_aspf_cofibration_laws.py` which passed (7 tests passed).
- An initial `python -m pytest tests/test_aspf_cofibration_laws.py` run failed in this environment due to `pytest.ini` invocation flags, so it was re-run with `-c /dev/null` and succeeded; `scripts/extract_test_evidence.py` was run to update `out/test_evidence.json` (file updated and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a225c3ffa483249420c105703de5ec)