### PR TITLE
Remove non-never coverage pragmas and add explicit YAML boot-time invariant

### DIFF
--- a/scripts/sppf_status_audit.py
+++ b/scripts/sppf_status_audit.py
@@ -8,9 +8,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-try:  # pragma: no cover - import form depends on invocation mode
+try:
     from scripts.deadline_runtime import DeadlineBudget, deadline_scope_from_lsp_env
-except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+except ModuleNotFoundError:
     from deadline_runtime import DeadlineBudget, deadline_scope_from_lsp_env
 from gabion.analysis.timeout_context import check_deadline, deadline_loop_iter
 from gabion.order_contract import ordered_or_sorted
@@ -209,5 +209,5 @@ def main(argv: list[str] | None = None) -> int:
         return code
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/gabion/refactor/engine.py
+++ b/src/gabion/refactor/engine.py
@@ -2,7 +2,6 @@
 # gabion:decision_protocol_module
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -330,7 +329,7 @@ def _module_expr_to_str(expr):
             parts.append(cast(cst.Name, current).value)
         if parts:
             return ".".join(reversed(parts))
-    return None  # pragma: no cover
+    return None
 
 
 def _has_typing_import(body: list[cst.CSTNode]) -> bool:
@@ -620,7 +619,7 @@ def _rewrite_call_sites_in_project(
         warnings.extend(call_warnings)
         if updated_module is not None:
             new_source = updated_module.code
-            if new_source != source:  # pragma: no cover
+            if new_source != source:
                 end_line = len(source.splitlines())
                 edits.append(
                     TextEdit(

--- a/src/gabion/tooling/governance_rules.py
+++ b/src/gabion/tooling/governance_rules.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib import import_module
 from pathlib import Path
 from typing import Mapping
 
-try:
-    import yaml
-except ImportError:  # pragma: no cover - dependency is pinned in pyproject
-    yaml = None
+
+def _load_yaml_module():
+    try:
+        module = import_module("yaml")
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyYAML is required by the pinned governance toolchain; run `mise install` to provision dependencies."
+        ) from exc
+    return module
+
+
+yaml = _load_yaml_module()
 
 
 @dataclass(frozen=True)
@@ -71,9 +80,6 @@ class ControllerDriftPolicy:
 
 
 def _yaml_loader():
-    if yaml is None:
-        raise RuntimeError("PyYAML is required to load docs/governance_rules.yaml")
-
     class Loader(yaml.SafeLoader):
         pass
 

--- a/tests/test_governance_rules_policy.py
+++ b/tests/test_governance_rules_policy.py
@@ -112,15 +112,17 @@ controller_drift:
         governance_rules.load_governance_rules(remediation_not_mapping)
 
 
-# gabion:evidence E:call_footprint::tests/test_governance_rules_policy.py::test_governance_rules_loader_none_and_gate_filtering::governance_rules.py::gabion.tooling.governance_rules._yaml_loader::governance_rules.py::gabion.tooling.governance_rules.load_governance_rules
-def test_governance_rules_loader_none_and_gate_filtering(tmp_path: Path) -> None:
-    original_yaml = governance_rules.yaml
-    try:
-        governance_rules.yaml = None
-        with pytest.raises(RuntimeError):
-            governance_rules._yaml_loader()
-    finally:
-        governance_rules.yaml = original_yaml
+# gabion:evidence E:call_footprint::tests/test_governance_rules_policy.py::test_governance_rules_loader_none_and_gate_filtering::governance_rules.py::gabion.tooling.governance_rules._load_yaml_module::governance_rules.py::gabion.tooling.governance_rules.load_governance_rules
+def test_governance_rules_loader_none_and_gate_filtering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_missing_yaml(_: str):
+        raise ImportError("missing yaml")
+
+    monkeypatch.setattr(governance_rules, "import_module", _raise_missing_yaml)
+    with pytest.raises(RuntimeError, match="PyYAML is required"):
+        governance_rules._load_yaml_module()
 
     mixed = tmp_path / "mixed.yaml"
     mixed.write_text(


### PR DESCRIPTION
### Motivation
- Remove incorrect `# pragma: no cover` usage on branches that are regular runtime paths so coverage semantics match actual control flow.
- Replace an optional-import sentinel with an explicit boot-time invariant to fail fast when a pinned dependency is missing.
- Ensure no `# pragma: no cover` remains unless the branch is discharged by `never(...)` as required by repository policy.

### Description
- Removed `# pragma: no cover` from the reachable fallback in `_module_expr_to_str` and from the source-diff guard in `_rewrite_call_sites_in_project` in `src/gabion/refactor/engine.py`, and removed an unused `Sequence` import.
- Reworked YAML import handling in `src/gabion/tooling/governance_rules.py` by adding `_load_yaml_module()` which uses `importlib.import_module("yaml")` and raises a clear `RuntimeError` when `PyYAML` is missing, and wired `yaml` through that loader instead of relying on a `yaml = None` sentinel.
- Removed `# pragma: no cover` annotations from `scripts/sppf_status_audit.py` for the import fallback and the `__main__` guard so both paths are treated as normal runtime code.
- Updated `tests/test_governance_rules_policy.py` to exercise the new boot-time dependency check by monkeypatching `import_module` to raise `ImportError` and asserting the `RuntimeError` from `_load_yaml_module()`.

### Testing
- Ran `PYTHONPATH=src:. python scripts/policy_check.py --workflows` which executed successfully in the adjusted environment (exit 0).
- Ran `PYTHONPATH=src:. python scripts/policy_check.py --ambiguity-contract` which executed successfully (exit 0).
- Ran `python -m ruff check` on the modified files and fixed an unused-import; ruff checks passed.
- Ran targeted pytest invocations (`PYTHONPATH=src:. python -m pytest -o addopts='' tests/test_refactor_engine_helpers.py::test_module_expr_to_str tests/test_sppf_status_audit.py tests/test_governance_rules_policy.py`) and all targeted tests passed after the changes (15 passed).
- Note: `mise exec -- python scripts/policy_check.py --workflows` failed in this container due to `mise` environment/tool resolution issues unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a225dfe5dc83248125844ec58b6de1)