### PR TITLE
Refactor auxiliary check flags into tagged CheckAuxMode protocol

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -2084,17 +2084,9 @@ def _default_check_artifact_flags() -> CheckArtifactFlags:
 
 def _default_check_delta_options() -> CheckDeltaOptions:
     return CheckDeltaOptions(
-        emit_test_obsolescence_state=False,
-        test_obsolescence_state=None,
-        emit_test_obsolescence_delta=False,
-        test_annotation_drift_state=None,
-        emit_test_annotation_drift_delta=False,
-        write_test_annotation_drift_baseline=False,
-        write_test_obsolescence_baseline=False,
-        emit_ambiguity_delta=False,
-        emit_ambiguity_state=False,
-        ambiguity_state=None,
-        write_ambiguity_baseline=False,
+        obsolescence_mode=check_contract.CheckAuxMode(kind="off"),
+        annotation_drift_mode=check_contract.CheckAuxMode(kind="off"),
+        ambiguity_mode=check_contract.CheckAuxMode(kind="off"),
         semantic_coverage_mapping=None,
     )
 

--- a/tests/test_check_contract.py
+++ b/tests/test_check_contract.py
@@ -21,17 +21,9 @@ def _artifact_flags() -> check_contract.CheckArtifactFlags:
 
 def _delta_options() -> check_contract.CheckDeltaOptions:
     return check_contract.CheckDeltaOptions(
-        emit_test_obsolescence_state=False,
-        test_obsolescence_state=None,
-        emit_test_obsolescence_delta=False,
-        test_annotation_drift_state=None,
-        emit_test_annotation_drift_delta=False,
-        write_test_annotation_drift_baseline=False,
-        write_test_obsolescence_baseline=False,
-        emit_ambiguity_delta=False,
-        emit_ambiguity_state=False,
-        ambiguity_state=None,
-        write_ambiguity_baseline=False,
+        obsolescence_mode=check_contract.CheckAuxMode(kind="off"),
+        annotation_drift_mode=check_contract.CheckAuxMode(kind="off"),
+        ambiguity_mode=check_contract.CheckAuxMode(kind="off"),
     )
 
 


### PR DESCRIPTION
### Motivation
- Make contradictory CLI/command payload combinations unrepresentable by replacing scattered boolean/path flags with a single tagged mode type for auxiliary check actions. 
- Centralize selection and normalization of auxiliary modes (obsolescence/annotation-drift/ambiguity) into one Decision Protocol so downstream code can assume a single canonical mode object. 

### Description
- Introduced `CheckAuxMode` and converted `CheckDeltaOptions` to hold `obsolescence_mode`, `annotation_drift_mode`, and `ambiguity_mode` in `src/gabion/commands/check_contract.py`, including validation and `to_payload` serialization.
- Updated CLI defaults and helpers in `src/gabion/cli.py` to construct `CheckDeltaOptions` with `CheckAuxMode` objects directly instead of multiple boolean/path flags.
- Added `_AuxiliaryMode`, `_AuxiliaryModeSelection`, `_auxiliary_mode_from_payload`, and `_select_auxiliary_mode_selection` to `src/gabion/server_core/command_orchestrator.py` to centralize payload normalization (including `aux_operation`) into normalized mode objects and removed the now-obsolete branch-level conflict guards.
- Adjusted tests and test helpers to use the new mode objects and refreshed the evidence artifact `out/test_evidence.json` to account for test-line shifts.

### Testing
- Ran static compile checks with `python -m py_compile` across modified modules which succeeded.
- Ran policy checks via `scripts/policy_check.py --workflows` and `--ambiguity-contract` under `PYTHONPATH=src`, which completed (the `mise` tool emitted a non-blocking remote metadata warning but did not block execution).
- Ran unit tests with `PYTHONPATH=src pytest -o addopts='' tests/test_check_contract.py tests/test_server_core_orchestrator_edges.py tests/test_cli_check_surface_edges.py` which resulted in all collected tests passing (`42 passed`).
- Regenerated test evidence with `scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and verified the refreshed `out/test_evidence.json` reflects the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a227a507b883249707497c0a86039c)