### PR TITLE
Reify analysis identities with strict typed decode boundaries

### DIFF
--- a/src/gabion/analysis/dataflow_audit.py
+++ b/src/gabion/analysis/dataflow_audit.py
@@ -8496,6 +8496,39 @@ class _CacheIdentity:
             return cls.from_digest(digest)
         return cls.from_digest(identity)
 
+    @classmethod
+    def from_boundary_required(cls, raw_identity, *, field: str) -> "_CacheIdentity":
+        identity = cls.from_boundary(raw_identity)
+        if identity is None:
+            never("invalid cache identity", field=field)
+            return cls(value="")  # pragma: no cover - never() raises
+        return identity
+
+
+@dataclass(frozen=True)
+class _ResumeCacheIdentityPair:
+    canonical_index: _CacheIdentity
+    canonical_projection: _CacheIdentity
+
+    def encode(self) -> dict[str, str]:
+        return {
+            "index_cache_identity": self.canonical_index.value,
+            "projection_cache_identity": self.canonical_projection.value,
+        }
+
+    @classmethod
+    def decode_required(cls, payload: Mapping[str, JSONValue]) -> "_ResumeCacheIdentityPair":
+        return cls(
+            canonical_index=_CacheIdentity.from_boundary_required(
+                payload.get("index_cache_identity"),
+                field="index_cache_identity",
+            ),
+            canonical_projection=_CacheIdentity.from_boundary_required(
+                payload.get("projection_cache_identity"),
+                field="projection_cache_identity",
+            ),
+        )
+
 
 def _sorted_text(values = None) -> tuple[str, ...]:
     if values is None:
@@ -15451,14 +15484,11 @@ def _analysis_index_resume_variant_payload(payload: Mapping[str, JSONValue]) -> 
         for key in payload
         if str(key) != _ANALYSIS_INDEX_RESUME_VARIANTS_KEY
     }
-    index_identity = _CacheIdentity.from_boundary(variant_payload.get("index_cache_identity"))
-    if index_identity is not None:
-        variant_payload["index_cache_identity"] = index_identity.value
-    projection_identity = _CacheIdentity.from_boundary(
-        variant_payload.get("projection_cache_identity")
-    )
-    if projection_identity is not None:
-        variant_payload["projection_cache_identity"] = projection_identity.value
+    try:
+        identities = _ResumeCacheIdentityPair.decode_required(variant_payload)
+    except NeverThrown:
+        return variant_payload
+    variant_payload.update(identities.encode())
     return variant_payload
 
 
@@ -15489,20 +15519,16 @@ def _with_analysis_index_resume_variants(
     payload: JSONObject,
     previous_payload,
 ) -> JSONObject:
-    current_identity = _CacheIdentity.from_boundary(payload.get("index_cache_identity"))
+    identities = _ResumeCacheIdentityPair.decode_required(payload)
     variants = _analysis_index_resume_variants(previous_payload)
-    if current_identity is not None:
-        payload["index_cache_identity"] = current_identity.value
-        variants[current_identity.value] = _analysis_index_resume_variant_payload(payload)
-    projection_identity = _CacheIdentity.from_boundary(payload.get("projection_cache_identity"))
-    if projection_identity is not None:
-        payload["projection_cache_identity"] = projection_identity.value
+    payload.update(identities.encode())
+    variants[identities.canonical_index.value] = _analysis_index_resume_variant_payload(payload)
     if not variants:
         return payload
     ordered_variant_keys = sort_once(variants.keys(), source = 'src/gabion/analysis/dataflow_audit.py:15360')
-    if current_identity is not None and current_identity.value in ordered_variant_keys:
-        ordered_variant_keys.remove(current_identity.value)
-        ordered_variant_keys.append(current_identity.value)
+    if identities.canonical_index.value in ordered_variant_keys:
+        ordered_variant_keys.remove(identities.canonical_index.value)
+        ordered_variant_keys.append(identities.canonical_index.value)
     if len(ordered_variant_keys) > _ANALYSIS_INDEX_RESUME_MAX_VARIANTS:
         ordered_variant_keys = ordered_variant_keys[-_ANALYSIS_INDEX_RESUME_MAX_VARIANTS :]
     payload[_ANALYSIS_INDEX_RESUME_VARIANTS_KEY] = {
@@ -15522,14 +15548,16 @@ def _serialize_analysis_index_resume_payload(
     profiling_v1 = None,
     previous_payload = None,
 ) -> JSONObject:
-    canonical_index_identity = _CacheIdentity.from_boundary(index_cache_identity)
-    canonical_projection_identity = _CacheIdentity.from_boundary(
-        projection_cache_identity
+    identities = _ResumeCacheIdentityPair(
+        canonical_index=_CacheIdentity.from_boundary_required(
+            index_cache_identity,
+            field="index_cache_identity",
+        ),
+        canonical_projection=_CacheIdentity.from_boundary_required(
+            projection_cache_identity,
+            field="projection_cache_identity",
+        ),
     )
-    if canonical_index_identity is None:
-        never("resume serialization requires canonical index identity")  # pragma: no cover - invariant sink
-    if canonical_projection_identity is None:
-        never("resume serialization requires canonical projection identity")  # pragma: no cover - invariant sink
     hydrated_path_keys = sort_once(
         (
             _analysis_collection_resume_path_key(path)
@@ -15564,8 +15592,7 @@ def _serialize_analysis_index_resume_payload(
         "format_version": 1,
         "phase": "analysis_index_hydration",
         "resume_digest": resume_digest,
-        "index_cache_identity": canonical_index_identity.value,
-        "projection_cache_identity": canonical_projection_identity.value,
+        **identities.encode(),
         "hydrated_paths": hydrated_path_keys,
         "hydrated_paths_count": len(hydrated_path_keys),
         "function_count": len(by_qual),
@@ -15606,19 +15633,15 @@ def _load_analysis_index_resume_payload(
     expected_index_identity = _CacheIdentity.from_boundary(expected_index_cache_identity)
     expected_projection_identity = _CacheIdentity.from_boundary(expected_projection_cache_identity)
     selected_payload: Mapping[str, JSONValue] = payload
-    if expected_index_cache_identity:
-        if expected_index_identity is None:
-            never("invalid expected index cache identity")  # pragma: no cover - invariant sink
-        resume_identity = _CacheIdentity.from_boundary(payload.get("index_cache_identity"))
-        if resume_identity != expected_index_identity:
+    if expected_index_identity is not None:
+        selected_identity = _CacheIdentity.from_boundary(selected_payload.get("index_cache_identity"))
+        if selected_identity != expected_index_identity:
             variants = _analysis_index_resume_variants(payload)
             variant = _resume_variant_for_identity(variants, expected_index_identity)
             if variant is None:
                 return hydrated_paths, by_qual, symbol_table, class_index
             selected_payload = variant
-    if expected_projection_cache_identity:
-        if expected_projection_identity is None:
-            never("invalid expected projection cache identity")  # pragma: no cover - invariant sink
+    if expected_projection_identity is not None:
         projection_identity = _CacheIdentity.from_boundary(
             selected_payload.get("projection_cache_identity")
         )

--- a/tests/test_dataflow_audit_helpers.py
+++ b/tests/test_dataflow_audit_helpers.py
@@ -4208,6 +4208,30 @@ def test_resume_index_and_collection_loader_additional_edge_rows(tmp_path: Path)
 
 
 # gabion:evidence E:call_footprint::tests/test_dataflow_audit_helpers.py::test_load_analysis_index_resume_payload_uses_variant_for_matching_identity::dataflow_audit.py::gabion.analysis.dataflow_audit._load_analysis_index_resume_payload::test_dataflow_audit_helpers.py::tests.test_dataflow_audit_helpers._load
+def test_resume_cache_identity_pair_round_trip() -> None:
+    da = _load()
+    payload = {
+        "index_cache_identity": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "projection_cache_identity": "aspf:sha1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }
+    identities = da._ResumeCacheIdentityPair.decode_required(payload)
+    assert identities.encode() == {
+        "index_cache_identity": "aspf:sha1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "projection_cache_identity": "aspf:sha1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }
+
+
+def test_resume_cache_identity_pair_decode_rejects_partial_identity() -> None:
+    da = _load()
+    with pytest.raises(NeverThrown):
+        da._ResumeCacheIdentityPair.decode_required(
+            {
+                "index_cache_identity": "",
+                "projection_cache_identity": "bad",
+            }
+        )
+
+
 def test_load_analysis_index_resume_payload_uses_variant_for_matching_identity(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_timeout_context.py
+++ b/tests/test_timeout_context.py
@@ -226,6 +226,25 @@ def test_pack_call_stack_accepts_list_key_part() -> None:
     ]
 
 
+def test_function_site_identity_payload_round_trip() -> None:
+    packed = pack_call_stack(
+        [
+            {
+                "kind": "FunctionSite",
+                "key": [{"kind": "FileSite", "key": ["a.py"]}, "mod.fn", 1, 2, 3, 4],
+            }
+        ]
+    )
+    payload = packed.as_payload()
+    restored = pack_call_stack(payload["site_table"])
+    assert restored.as_payload()["site_table"] == payload["site_table"]
+
+
+def test_function_site_identity_decode_rejects_partial_identity() -> None:
+    with pytest.raises(NeverThrown):
+        pack_call_stack([{"path": "a.py", "qual": "", "span": [1, 2, 3]}])
+
+
 # gabion:evidence E:call_footprint::tests/test_timeout_context.py::test_pack_call_stack_uses_first_seen_site_order::timeout_context.py::gabion.analysis.timeout_context.pack_call_stack
 def test_pack_call_stack_uses_first_seen_site_order() -> None:
     packed = pack_call_stack(


### PR DESCRIPTION
### Motivation
- Prevent creation of invalid/partial identity objects by centralizing validation at the decode/constructor boundary for callsite and cache identities.
- Replace ad-hoc dictionary payload handling with typed encode/decode helpers so downstream code no longer needs to defensively check for missing identity parts.
- Make identity invariants explicit and enforceable to reduce hidden runtime `never(...)` defenses and simplify packing/serialization logic.

### Description
- Introduced `_FunctionSiteIdentity` and enhanced `_FileSite` with `decode_payload` in `src/gabion/analysis/timeout_context.py` so function/file site payloads are validated and represented as fully-formed values before being used to build canonical site keys and pack call stacks.
- Added `_ResumeCacheIdentityPair` and `_CacheIdentity.from_boundary_required` in `src/gabion/analysis/dataflow_audit.py` and replaced ad-hoc resume identity handling with typed `decode_required`/`encode` flows for resume payloads and variants.
- Replaced dictionary/optional-branch identity decoding paths with the new typed decode helpers in resume serialization/deserialization and call-stack normalization so invalid/partial identities are rejected at boundary decode time.
- Added round-trip and invalid-decode tests for both identity surfaces and refreshed `out/test_evidence.json`; tests added/updated in `tests/test_timeout_context.py` and `tests/test_dataflow_audit_helpers.py`.

### Testing
- Ran targeted pytest for the modified suites with `PYTHONPATH=src python -m pytest -o addopts='' tests/test_timeout_context.py tests/test_dataflow_audit_helpers.py -q` and observed all tests pass (`218 passed`).
- Ran policy checks `PYTHONPATH=src python scripts/policy_check.py --workflows` and `--ambiguity-contract` and both completed successfully after addressing ambiguity-policy annotations.
- Re-ran evidence collection with `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` to refresh `out/test_evidence.json` and committed the regenerated output.
- Note: an initial `mise exec` attempt was skipped due to local `mise.toml` trust requirements; validations were performed with `python` directly instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a227b713b083248bf933a41282d7ee)