### PR TITLE
Normalize payload-shape decoding at analysis boundaries

### DIFF
--- a/scripts/policy_check.py
+++ b/scripts/policy_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import ast
 import json
 import os
 import re
@@ -1290,6 +1291,16 @@ def check_ambiguity_contract() -> None:
         _fail(["ambiguity contract policy check failed", *details])
 
 
+
+_SEMANTIC_CORE_PAYLOAD_BRANCH_MODULES = (
+    REPO_ROOT / "src" / "gabion" / "analysis" / "dataflow_audit.py",
+    REPO_ROOT / "src" / "gabion" / "analysis" / "timeout_context.py",
+)
+
+_ALLOWED_PAYLOAD_BRANCH_FUNCTION_PREFIXES = (
+    "_decode_",
+)
+
 _KNOWN_ADAPTER_SURFACES = {
     "bundle-inference": "bundle_inference",
     "decision-surfaces": "decision_surfaces",
@@ -1298,6 +1309,98 @@ _KNOWN_ADAPTER_SURFACES = {
     "rewrite-plan-support": "rewrite_plan_support",
 }
 
+
+
+def _raw_payload_branching_violations(path: Path) -> list[str]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{path}: failed to read source ({exc})"]
+    try:
+        module = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}: failed to parse source ({exc})"]
+
+    function_ranges: list[tuple[int, int, str]] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef):
+            start = int(getattr(node, "lineno", 0) or 0)
+            end = int(getattr(node, "end_lineno", start) or start)
+            function_ranges.append((start, end, node.name))
+
+    def _function_name_for_line(line_no: int) -> str | None:
+        best: tuple[int, str] | None = None
+        for start, end, name in function_ranges:
+            if start <= line_no <= end:
+                width = end - start
+                if best is None or width < best[0]:
+                    best = (width, name)
+        return best[1] if best is not None else None
+
+    def _is_allowed(line_no: int) -> bool:
+        name = _function_name_for_line(line_no)
+        if name is None:
+            return False
+        return name.startswith(_ALLOWED_PAYLOAD_BRANCH_FUNCTION_PREFIXES)
+
+    def _pattern_mentions_raw_payload(pattern: ast.pattern) -> bool:
+        if isinstance(pattern, ast.MatchClass):
+            cls = pattern.cls
+            if isinstance(cls, ast.Name) and cls.id in {"Mapping", "list"}:
+                return True
+            if isinstance(cls, ast.Attribute) and cls.attr in {"Mapping", "list"}:
+                return True
+        for child in ast.iter_child_nodes(pattern):
+            if isinstance(child, ast.pattern) and _pattern_mentions_raw_payload(child):
+                return True
+        return False
+
+    def _isinstance_mentions_raw_payload(call: ast.Call) -> bool:
+        if not (isinstance(call.func, ast.Name) and call.func.id == "isinstance"):
+            return False
+        if len(call.args) < 2:
+            return False
+        type_arg = call.args[1]
+        targets: list[ast.expr] = []
+        if isinstance(type_arg, ast.Tuple):
+            targets.extend(type_arg.elts)
+        else:
+            targets.append(type_arg)
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in {"Mapping", "list"}:
+                return True
+            if isinstance(target, ast.Attribute) and target.attr in {"Mapping", "list"}:
+                return True
+        return False
+
+    try:
+        display_path = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        display_path = str(path)
+
+    violations: list[str] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.match_case):
+            lineno = int(getattr(node.pattern, "lineno", 0) or 0)
+            if lineno > 0 and _pattern_mentions_raw_payload(node.pattern) and not _is_allowed(lineno):
+                violations.append(f"{display_path}:{lineno}: raw Mapping/list match outside boundary decode")
+        if isinstance(node, ast.Call):
+            lineno = int(getattr(node, "lineno", 0) or 0)
+            if lineno > 0 and _isinstance_mentions_raw_payload(node) and not _is_allowed(lineno):
+                violations.append(f"{display_path}:{lineno}: isinstance Mapping/list branch outside boundary decode")
+    return violations
+
+
+def check_semantic_core_payload_branching() -> None:
+    errors: list[str] = []
+    for path in _SEMANTIC_CORE_PAYLOAD_BRANCH_MODULES:
+        check_deadline()
+        errors.extend(_raw_payload_branching_violations(path))
+    if errors:
+        _fail([
+            "semantic-core payload branching policy check failed",
+            *errors,
+        ])
 
 def check_adapter_surface_policy() -> None:
     errors: list[str] = []
@@ -1328,9 +1431,10 @@ def main():
     parser.add_argument("--normative-map", action="store_true", help="validate docs/normative_enforcement_map.yaml")
     parser.add_argument("--tier2-residue-contract", action="store_true", help="run tier-2 residue policy checks")
     parser.add_argument("--adapter-surfaces", action="store_true", help="validate configured adapter surface requirements")
+    parser.add_argument("--semantic-core-payload-branching", action="store_true", help="forbid raw Mapping/list payload branching outside boundary decode functions")
     args = parser.parse_args()
 
-    if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map and not args.tier2_residue_contract and not args.adapter_surfaces:
+    if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map and not args.tier2_residue_contract and not args.adapter_surfaces and not args.semantic_core_payload_branching:
         args.workflows = True
 
     with _policy_deadline_scope():
@@ -1346,6 +1450,8 @@ def main():
             check_tier2_residue_contract()
         if args.adapter_surfaces:
             check_adapter_surface_policy()
+        if args.semantic_core_payload_branching:
+            check_semantic_core_payload_branching()
     return 0
 
 

--- a/src/gabion/analysis/timeout_context.py
+++ b/src/gabion/analysis/timeout_context.py
@@ -97,6 +97,51 @@ class _InternedCallSite:
     site: _CallSite
 
 
+@dataclass(frozen=True)
+class _DeadlineProfileSiteRow:
+    path: str
+    qual: str
+    check_count: int
+    elapsed_between_checks_ns: int
+    max_gap_ns: int
+
+
+@dataclass(frozen=True)
+class _DeadlineProfileEdgeRow:
+    from_path: str
+    from_qual: str
+    to_path: str
+    to_qual: str
+    transition_count: int
+    elapsed_ns: int
+    max_gap_ns: int
+
+
+@dataclass(frozen=True)
+class _DeadlineProfileIoRow:
+    name: str
+    event_count: int
+    elapsed_ns: int
+    max_event_ns: int
+    bytes_total: int
+
+
+@dataclass(frozen=True)
+class _DecodedDeadlineProfile:
+    checks_total: int
+    total_elapsed_ns: int
+    wall_total_elapsed_ns: int
+    unattributed_elapsed_ns: int
+    ticks_consumed: object
+    ticks_per_ns: object
+    sites: tuple[_DeadlineProfileSiteRow, ...]
+    edges: tuple[_DeadlineProfileEdgeRow, ...]
+    io: tuple[_DeadlineProfileIoRow, ...]
+    sites_total: int
+    edges_total: int
+    io_total: int
+
+
 class TimeoutExceeded(TimeoutError):
     def __init__(self, context: TimeoutContext) -> None:
         super().__init__("Analysis timed out.")
@@ -534,31 +579,14 @@ def _timeout_progress_snapshot(
     forest: Forest,
     deadline_profile,
 ) -> dict[str, JSONValue]:
+    decoded_profile = _decode_deadline_profile_payload(deadline_profile)
     checks_total = 0
     site_count = 0
-    match deadline_profile:
-        case Mapping() as profile_map:
-            checks_total = int(profile_map.get("checks_total", 0) or 0)
-            match profile_map.get("sites"):
-                case list() as site_rows:
-                    site_count = len(site_rows)
-                case _:
-                    pass
-        case _:
-            pass
+    checks_total = decoded_profile.checks_total
+    site_count = len(decoded_profile.sites)
     forest_nodes = len(forest.nodes)
     forest_alts = len(forest.alts)
-    ticks_per_ns = None
-    match deadline_profile:
-        case Mapping() as profile_map:
-            profile_ticks_per_ns = profile_map.get("ticks_per_ns")
-            match profile_ticks_per_ns:
-                case int() | float():
-                    ticks_per_ns = float(profile_ticks_per_ns)
-                case _:
-                    pass
-        case _:
-            pass
+    ticks_per_ns = decoded_profile.ticks_per_ns
     progressed = (
         (forest_nodes + forest_alts) > 0
         or checks_total >= _TIMEOUT_PROGRESS_CHECKS_FLOOR
@@ -594,18 +622,114 @@ def _timeout_progress_snapshot(
     }
 
 
+# gabion:ambiguity_boundary
+def _decode_deadline_profile_payload(profile: object) -> _DecodedDeadlineProfile:
+    if not isinstance(profile, Mapping):
+        return _DecodedDeadlineProfile(
+            checks_total=0,
+            total_elapsed_ns=0,
+            wall_total_elapsed_ns=0,
+            unattributed_elapsed_ns=0,
+            ticks_consumed=None,
+            ticks_per_ns=None,
+            sites=(),
+            edges=(),
+            io=(),
+            sites_total=0,
+            edges_total=0,
+            io_total=0,
+        )
+
+    ticks_consumed_raw = profile.get("ticks_consumed")
+    ticks_consumed = int(ticks_consumed_raw) if ticks_consumed_raw is not None else None
+    sites_raw = profile.get("sites")
+    edges_raw = profile.get("edges")
+    io_raw = profile.get("io")
+    ticks_per_ns_raw = profile.get("ticks_per_ns")
+    ticks_per_ns = (
+        float(ticks_per_ns_raw)
+        if isinstance(ticks_per_ns_raw, int | float)
+        else None
+    )
+    return _DecodedDeadlineProfile(
+        checks_total=int(profile.get("checks_total", 0) or 0),
+        total_elapsed_ns=int(profile.get("total_elapsed_ns", 0) or 0),
+        wall_total_elapsed_ns=int(profile.get("wall_total_elapsed_ns", 0) or 0),
+        unattributed_elapsed_ns=int(profile.get("unattributed_elapsed_ns", 0) or 0),
+        ticks_consumed=ticks_consumed,
+        ticks_per_ns=ticks_per_ns,
+        sites=tuple(_decode_deadline_profile_site_rows(sites_raw)),
+        edges=tuple(_decode_deadline_profile_edge_rows(edges_raw)),
+        io=tuple(_decode_deadline_profile_io_rows(io_raw)),
+        sites_total=len(sites_raw) if isinstance(sites_raw, list) else 0,
+        edges_total=len(edges_raw) if isinstance(edges_raw, list) else 0,
+        io_total=len(io_raw) if isinstance(io_raw, list) else 0,
+    )
+
+
+# gabion:ambiguity_boundary
+def _decode_deadline_profile_site_rows(rows: object) -> Iterator[_DeadlineProfileSiteRow]:
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        yield _DeadlineProfileSiteRow(
+            path=str(row.get("path", "") or ""),
+            qual=str(row.get("qual", "") or ""),
+            check_count=int(row.get("check_count", 0) or 0),
+            elapsed_between_checks_ns=int(row.get("elapsed_between_checks_ns", 0) or 0),
+            max_gap_ns=int(row.get("max_gap_ns", 0) or 0),
+        )
+
+
+# gabion:ambiguity_boundary
+def _decode_deadline_profile_edge_rows(rows: object) -> Iterator[_DeadlineProfileEdgeRow]:
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        yield _DeadlineProfileEdgeRow(
+            from_path=str(row.get("from_path", "") or ""),
+            from_qual=str(row.get("from_qual", "") or ""),
+            to_path=str(row.get("to_path", "") or ""),
+            to_qual=str(row.get("to_qual", "") or ""),
+            transition_count=int(row.get("transition_count", 0) or 0),
+            elapsed_ns=int(row.get("elapsed_ns", 0) or 0),
+            max_gap_ns=int(row.get("max_gap_ns", 0) or 0),
+        )
+
+
+# gabion:ambiguity_boundary
+def _decode_deadline_profile_io_rows(rows: object) -> Iterator[_DeadlineProfileIoRow]:
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        yield _DeadlineProfileIoRow(
+            name=str(row.get("name", "") or ""),
+            event_count=int(row.get("event_count", 0) or 0),
+            elapsed_ns=int(row.get("elapsed_ns", 0) or 0),
+            max_event_ns=int(row.get("max_event_ns", 0) or 0),
+            bytes_total=int(row.get("bytes_total", 0) or 0),
+        )
+
+
 def render_deadline_profile_markdown(
     profile: Mapping[str, JSONValue],
     *,
     max_rows: int = 25,
 ) -> str:
+    decoded_profile = _decode_deadline_profile_payload(profile)
     lines: list[str] = ["# Deadline Profile Heat", ""]
-    checks_total = int(profile.get("checks_total", 0) or 0)
-    total_elapsed_ns = int(profile.get("total_elapsed_ns", 0) or 0)
-    wall_total_elapsed_ns = int(profile.get("wall_total_elapsed_ns", 0) or 0)
-    ticks_consumed = profile.get("ticks_consumed")
-    ticks_per_ns = profile.get("ticks_per_ns")
-    unattributed_ns = int(profile.get("unattributed_elapsed_ns", 0) or 0)
+    checks_total = decoded_profile.checks_total
+    total_elapsed_ns = decoded_profile.total_elapsed_ns
+    wall_total_elapsed_ns = decoded_profile.wall_total_elapsed_ns
+    ticks_consumed = decoded_profile.ticks_consumed
+    ticks_per_ns = decoded_profile.ticks_per_ns
+    unattributed_ns = decoded_profile.unattributed_elapsed_ns
     lines.append(f"- checks_total: `{checks_total}`")
     lines.append(f"- total_elapsed_ns: `{total_elapsed_ns}`")
     lines.append(f"- wall_total_elapsed_ns: `{wall_total_elapsed_ns}`")
@@ -622,81 +746,52 @@ def render_deadline_profile_markdown(
     lines.append("")
     lines.append("| path | qual | checks | elapsed_ns | max_gap_ns |")
     lines.append("| --- | --- | ---: | ---: | ---: |")
-    sites = profile.get("sites", [])
-    match sites:
-        case list() as site_rows:
-            for row in site_rows[:max_rows]:
-                match row:
-                    case Mapping() as row_map:
-                        lines.append(
-                            "| {path} | {qual} | {checks} | {elapsed} | {gap} |".format(
-                                path=str(row_map.get("path", "") or ""),
-                                qual=str(row_map.get("qual", "") or ""),
-                                checks=int(row_map.get("check_count", 0) or 0),
-                                elapsed=int(
-                                    row_map.get("elapsed_between_checks_ns", 0) or 0
-                                ),
-                                gap=int(row_map.get("max_gap_ns", 0) or 0),
-                            )
-                        )
-                    case _:
-                        pass
-            if len(site_rows) > max_rows:
-                lines.append("| ... | ... | ... | ... | ... |")
-        case _:
-            pass
+    for row in decoded_profile.sites[:max_rows]:
+        lines.append(
+            "| {path} | {qual} | {checks} | {elapsed} | {gap} |".format(
+                path=row.path,
+                qual=row.qual,
+                checks=row.check_count,
+                elapsed=row.elapsed_between_checks_ns,
+                gap=row.max_gap_ns,
+            )
+        )
+    if decoded_profile.sites_total > max_rows:
+        lines.append("| ... | ... | ... | ... | ... |")
     lines.append("")
     lines.append("## Transition Heat")
     lines.append("")
     lines.append("| from | to | transitions | elapsed_ns | max_gap_ns |")
     lines.append("| --- | --- | ---: | ---: | ---: |")
-    edges = profile.get("edges", [])
-    match edges:
-        case list() as edge_rows:
-            for row in edge_rows[:max_rows]:
-                match row:
-                    case Mapping() as row_map:
-                        lines.append(
-                            "| {source} | {target} | {count} | {elapsed} | {gap} |".format(
-                                source=f"{str(row_map.get('from_path', '') or '')}:{str(row_map.get('from_qual', '') or '')}",
-                                target=f"{str(row_map.get('to_path', '') or '')}:{str(row_map.get('to_qual', '') or '')}",
-                                count=int(row_map.get("transition_count", 0) or 0),
-                                elapsed=int(row_map.get("elapsed_ns", 0) or 0),
-                                gap=int(row_map.get("max_gap_ns", 0) or 0),
-                            )
-                        )
-                    case _:
-                        pass
-            if len(edge_rows) > max_rows:
-                lines.append("| ... | ... | ... | ... | ... |")
-        case _:
-            pass
+    for row in decoded_profile.edges[:max_rows]:
+        lines.append(
+            "| {source} | {target} | {count} | {elapsed} | {gap} |".format(
+                source=f"{row.from_path}:{row.from_qual}",
+                target=f"{row.to_path}:{row.to_qual}",
+                count=row.transition_count,
+                elapsed=row.elapsed_ns,
+                gap=row.max_gap_ns,
+            )
+        )
+    if decoded_profile.edges_total > max_rows:
+        lines.append("| ... | ... | ... | ... | ... |")
     lines.append("")
     lines.append("## I/O Heat")
     lines.append("")
     lines.append("| io | events | elapsed_ns | max_event_ns | bytes_total |")
     lines.append("| --- | ---: | ---: | ---: | ---: |")
-    io_rows = profile.get("io", [])
-    match io_rows:
-        case list() as deadline_io_rows:
-            for row in deadline_io_rows[:max_rows]:
-                match row:
-                    case Mapping() as row_map:
-                        lines.append(
-                            "| {name} | {events} | {elapsed} | {max_event} | {bytes_total} |".format(
-                                name=str(row_map.get("name", "") or ""),
-                                events=int(row_map.get("event_count", 0) or 0),
-                                elapsed=int(row_map.get("elapsed_ns", 0) or 0),
-                                max_event=int(row_map.get("max_event_ns", 0) or 0),
-                                bytes_total=int(row_map.get("bytes_total", 0) or 0),
-                            )
-                        )
-                    case _:
-                        pass
-            if len(deadline_io_rows) > max_rows:
-                lines.append("| ... | ... | ... | ... | ... |")
-        case _:
-            pass
+    for row in decoded_profile.io[:max_rows]:
+        lines.append(
+            "| {name} | {events} | {elapsed} | {max_event} | {bytes_total} |".format(
+                name=row.name,
+                events=row.event_count,
+                elapsed=row.elapsed_ns,
+                max_event=row.max_event_ns,
+                bytes_total=row.bytes_total,
+            )
+        )
+    if decoded_profile.io_total > max_rows:
+        lines.append("| ... | ... | ... | ... | ... |")
     lines.append("")
     return "\n".join(lines)
 
@@ -836,25 +931,36 @@ def _function_site(
 
 
 def _site_part_from_payload(value: object) -> object:
+    decoded = _decode_site_part_payload(value)
+    return decoded
+
+
+# gabion:ambiguity_boundary
+def _decode_site_part_payload(value: object) -> object:
     match value:
         case _FileSite():
             return value
         case Mapping() as mapping_value:
-            kind = str(mapping_value.get("kind", "") or "")
-            key_payload = mapping_value.get("key")
-            match (kind, key_payload):
-                case ("FileSite", [str() as path]):
-                    return _FileSite(path)
-                case _:
-                    never("invalid site key mapping payload", payload_kind=kind)
-                    return mapping_value  # pragma: no cover - never() raises
+            return _decode_site_mapping_payload(mapping_value)
         case list() as payload_list:
-            return tuple(_site_part_from_payload(part) for part in payload_list)
+            return tuple(_decode_site_part_payload(part) for part in payload_list)
         case None | str() | int() | float() | bool():
             return value
         case _:
             never("invalid site key payload value", value_type=type(value).__name__)
             return value  # pragma: no cover - never() raises
+
+
+# gabion:ambiguity_boundary
+def _decode_site_mapping_payload(mapping_value: Mapping[object, object]) -> _FileSite:
+    kind = str(mapping_value.get("kind", "") or "")
+    key_payload = mapping_value.get("key")
+    match (kind, key_payload):
+        case ("FileSite", [str() as path]):
+            return _FileSite(path)
+        case _:
+            never("invalid site key mapping payload", payload_kind=kind)
+            return _FileSite(path="")  # pragma: no cover - never() raises
 
 
 def _site_part_to_payload(value: object) -> JSONValue:
@@ -898,14 +1004,7 @@ def build_site_index(
 def pack_call_stack(
     sites,
 ) -> PackedCallStack:
-    normalized: list[_CallSite] = []
-    for site in sites:
-        match site:
-            case _CallSite() as payload:
-                pass
-            case _:
-                payload = _normalize_site_payload(site)
-        normalized.append(payload)
+    normalized = _decode_call_stack_sites(sites)
     unique: dict[tuple[str, tuple[object, ...]], _InternedCallSite] = {}
     for entry in normalized:
         key = (entry.kind, entry.frozen_key())
@@ -932,38 +1031,45 @@ def pack_call_stack(
     )
 
 
+# gabion:ambiguity_boundary
+def _decode_call_stack_sites(sites: Iterable[object]) -> list[_CallSite]:
+    normalized: list[_CallSite] = []
+    for site in sites:
+        match site:
+            case _CallSite() as payload:
+                normalized.append(payload)
+            case Mapping() as payload_map:
+                normalized.append(_decode_site_payload(payload_map))
+            case _:
+                never("invalid call stack site payload", payload_type=type(site).__name__)
+    return normalized
+
+
 def _normalize_site_payload(
     site: Mapping[str, object],
 ) -> _CallSite:
+    return _decode_site_payload(site)
+
+
+# gabion:ambiguity_boundary
+def _decode_site_payload(site: Mapping[object, object]) -> _CallSite:
     kind = str(site.get("kind", "") or "FunctionSite")
     key_payload = site.get("key")
-    match key_payload:
-        case list() as key_entries if key_entries:
-            key = [value for value in key_entries]
-            first = key[0]
-            second = key[1] if key[1:] else None
-            match (first, second):
-                case (str() as path_value, str() as qual_value):
-                    key = [_FileSite(path_value), qual_value, *key[2:]]
-                case _:
-                    pass
-            key_tuple = tuple(_site_part_from_payload(value) for value in key)
-            return _CallSite(
-                kind=kind,
-                key=key_tuple,
-            )
-        case _:
-            pass
+    if isinstance(key_payload, list) and key_payload:
+        key = [value for value in key_payload]
+        first = key[0]
+        second = key[1] if key[1:] else None
+        if isinstance(first, str) and isinstance(second, str):
+            key = [_FileSite(first), second, *key[2:]]
+        key_tuple = tuple(_decode_site_part_payload(value) for value in key)
+        return _CallSite(kind=kind, key=key_tuple)
+
     path = str(site.get("path", "") or "")
     qual = str(site.get("qual", "") or "")
     if not path or not qual:
-        never("site payload missing path/qual", site=dict(site))
+        never("site payload missing path/qual", site={str(key): value for key, value in site.items()})
     span = site.get("span")
-    match span:
-        case list() as span_values:
-            span_list = list(span_values)
-        case _:
-            span_list = None
+    span_list = list(span) if isinstance(span, list) else None
     return _function_site(path=path, qual=qual, span=span_list)
 
 


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc runtime branching on raw Mapping/list payloads inside semantic-core modules by centralizing shape decoding at explicit boundary functions.
- Make core traversal and projection logic operate on typed/validated structures so downstream code can be branchless and deterministic.
- Add an automated policy check to prevent re-introducing raw payload branching in semantic-core modules.

### Description
- Introduced typed DTOs and boundary decoders in `src/gabion/analysis/timeout_context.py` (`_DecodedDeadlineProfile`, `_DeadlineProfileSiteRow/_EdgeRow/_IoRow`, `_decode_*` helpers) and updated progress/markdown rendering and call-stack packing to consume decoded forms instead of matching raw payload shapes.
- Added call-site/site payload decoders (`_decode_site_part_payload`, `_decode_site_mapping_payload`, `_decode_site_payload`, `_decode_call_stack_sites`) and made `pack_call_stack` operate on `_CallSite` instances only. (timeout_context changes)
- Refactored projection span / ambiguity suite parsing in `src/gabion/analysis/dataflow_audit.py` by adding `_ProjectionSpan`, `_AmbiguitySuiteRow`, `_decode_projection_span`, `_decode_ambiguity_suite_row` and routing `_ambiguity_suite_row_to_suite` through the decode surface so core consumers receive typed values.
- Added a new policy/lint check in `scripts/policy_check.py` (`_raw_payload_branching_violations` + `--semantic-core-payload-branching`) that parses semantic-core modules and flags `match`/`isinstance` branches on raw `Mapping`/`list` outside `_decode_*` boundary functions.
- Added tests in `tests/test_ci_governance_scripts.py` to validate the new policy detector (allows `_decode_` functions and flags non-decode functions).

### Testing
- Ran targeted unit tests: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_timeout_context.py tests/test_deadline_coverage.py tests/test_dataflow_audit_ambiguity_suite.py tests/test_ci_governance_scripts.py` and all tests passed (`108 passed`).
- Ran policy checks: `PYTHONPATH=src python scripts/policy_check.py --workflows` succeeded.
- Ran ambiguity contract check: `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract` and addressed initial findings by marking boundary decode functions, after which the check passed.
- Ran the new semantic-core detector: `PYTHONPATH=src python scripts/policy_check.py --semantic-core-payload-branching` and it returned clean (no violations for the updated modules).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a227d53f748324a39cfd338d4d830a)