### PR TITLE
Refactor semantic runtime toggles from env reads to explicit policy config

### DIFF
--- a/src/gabion/analysis/projection_registry.py
+++ b/src/gabion/analysis/projection_registry.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
-import os
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from typing import Iterable, Mapping
 
 from gabion.analysis.projection_normalize import (
@@ -27,17 +29,19 @@ from gabion.json_types import JSONValue
 _PROJECTION_REGISTRY_GAS_LIMIT_DEFAULT = 1_000_000
 
 
+@dataclass(frozen=True)
+class ProjectionRegistryRuntimeConfig:
+    gas_limit: int = _PROJECTION_REGISTRY_GAS_LIMIT_DEFAULT
+
+
+_PROJECTION_REGISTRY_RUNTIME_CONFIG: ContextVar[ProjectionRegistryRuntimeConfig] = ContextVar(
+    "gabion_projection_registry_runtime_config",
+    default=ProjectionRegistryRuntimeConfig(),
+)
+
+
 def _projection_registry_gas_limit() -> int:
-    raw = os.getenv("GABION_PROJECTION_REGISTRY_GAS_LIMIT", "").strip()
-    if not raw:
-        return _PROJECTION_REGISTRY_GAS_LIMIT_DEFAULT
-    try:
-        value = int(raw)
-    except ValueError:
-        never(
-            "invalid projection registry gas limit",
-            value=raw,
-        )
+    value = int(_PROJECTION_REGISTRY_RUNTIME_CONFIG.get().gas_limit)
     if value <= 0:
         never(
             "invalid projection registry gas limit",
@@ -601,3 +605,25 @@ def build_registered_specs() -> dict[str, ProjectionSpec]:
 
 
 REGISTERED_SPECS = build_registered_specs()
+
+
+def set_projection_registry_runtime_config(
+    config: ProjectionRegistryRuntimeConfig,
+) -> Token[ProjectionRegistryRuntimeConfig]:
+    return _PROJECTION_REGISTRY_RUNTIME_CONFIG.set(config)
+
+
+def reset_projection_registry_runtime_config(
+    token: Token[ProjectionRegistryRuntimeConfig],
+) -> None:
+    _PROJECTION_REGISTRY_RUNTIME_CONFIG.reset(token)
+
+
+@contextmanager
+def projection_registry_runtime_config_scope(config: ProjectionRegistryRuntimeConfig):
+    token = set_projection_registry_runtime_config(config)
+    try:
+        yield
+    finally:
+        reset_projection_registry_runtime_config(token)
+

--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -37,7 +37,7 @@ from gabion.commands import (
     progress_contract as progress_timeline,
     transport_policy,
 )
-from gabion.runtime import deadline_policy, env_policy, path_policy
+from gabion.runtime import deadline_policy, env_policy, path_policy, policy_runtime
 
 DATAFLOW_COMMAND = command_ids.DATAFLOW_COMMAND
 CHECK_COMMAND = command_ids.CHECK_COMMAND
@@ -312,6 +312,7 @@ def configure_runtime_flags(
             "Removed transport flags (--transport/--direct-run-override-evidence/--override-record-json). "
             "Use --carrier and --carrier-override-record."
         )
+    policy_runtime.apply_runtime_policy_from_env()
     env_policy.apply_cli_timeout_flag(timeout=timeout)
     carrier_text = None if carrier is None else str(carrier.value)
     carrier_override_record_text = (
@@ -1283,6 +1284,13 @@ def build_dataflow_payload(opts: argparse.Namespace) -> JSONObject:
         "synthesis_merge_overlap": opts.synthesis_merge_overlap,
         "structure_tree": structure_tree_target,
         "structure_metrics": structure_metrics_target,
+        "proof_mode": getattr(opts, "proof_mode", None),
+        "order_policy": getattr(opts, "order_policy", None),
+        "order_telemetry": getattr(opts, "order_telemetry", None),
+        "order_enforce_canonical_allowlist": getattr(opts, "order_enforce_canonical_allowlist", None),
+        "order_deadline_probe": getattr(opts, "order_deadline_probe", None),
+        "derivation_cache_max_entries": getattr(opts, "derivation_cache_max_entries", None),
+        "projection_registry_gas_limit": getattr(opts, "projection_registry_gas_limit", None),
         }
     )
     return payload

--- a/src/gabion/commands/transport_policy.py
+++ b/src/gabion/commands/transport_policy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-import os
 from pathlib import Path
 from typing import Callable, Literal, Mapping, TypeAlias
 import warnings
@@ -72,13 +71,7 @@ def transport_override() -> TransportOverrideConfig | None:
 
 
 def transport_override_present() -> bool:
-    if transport_override() is not None:
-        return True
-    return (
-        DIRECT_RUN_ENV in os.environ
-        or DIRECT_RUN_OVERRIDE_EVIDENCE_ENV in os.environ
-        or OVERRIDE_RECORD_JSON_ENV in os.environ
-    )
+    return transport_override() is not None
 
 
 def set_transport_override(
@@ -172,15 +165,7 @@ def _resolve_transport_controls() -> tuple[bool, str | None]:
             direct_requested,
             record_json.strip() if isinstance(record_json, str) else None,
         )
-    direct_flag = os.getenv(DIRECT_RUN_ENV, "").strip().lower()
-    direct_requested = direct_flag in {"1", "true", "yes", "on"}
-    override_evidence = os.getenv(DIRECT_RUN_OVERRIDE_EVIDENCE_ENV, "").strip() or None
-    override_record_json = os.getenv(OVERRIDE_RECORD_JSON_ENV)
-    if direct_flag or override_evidence or (
-        isinstance(override_record_json, str) and override_record_json.strip()
-    ):
-        _warn_legacy_transport_env_usage()
-    return (direct_requested, override_record_json)
+    return (False, None)
 
 
 # gabion:decision_protocol

--- a/src/gabion/runtime/__init__.py
+++ b/src/gabion/runtime/__init__.py
@@ -5,5 +5,6 @@ __all__ = [
     "env_policy",
     "json_io",
     "path_policy",
+    "policy_runtime",
     "stable_encode",
 ]

--- a/src/gabion/runtime/policy_runtime.py
+++ b/src/gabion/runtime/policy_runtime.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+from gabion.analysis.derivation_cache import DerivationCacheConfig, derivation_cache_config_scope
+from gabion.analysis.projection_registry import (
+    ProjectionRegistryRuntimeConfig,
+    projection_registry_runtime_config_scope,
+)
+from gabion.commands.transport_policy import TransportOverrideConfig, transport_override_scope
+from gabion.invariants import ProofModeConfig, proof_mode_config_scope
+from gabion.order_contract import OrderPolicy, OrderRuntimeConfig, order_runtime_config_scope
+
+
+_STRICT_VALUES = {"1", "true", "yes", "on", "strict"}
+
+
+@dataclass(frozen=True)
+class RuntimePolicyConfig:
+    proof_mode_enabled: bool = False
+    order_policy: OrderPolicy | None = None
+    order_caller_sorted: bool = False
+    order_telemetry_enabled: bool = False
+    order_enforce_canonical_allowlist: bool = False
+    order_deadline_probe_enabled: bool = False
+    transport_direct_requested: bool | None = None
+    transport_override_record_json: str | None = None
+    derivation_cache_max_entries: int = 4096
+    projection_registry_gas_limit: int = 1_000_000
+
+
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name, "")
+    return value.strip().lower() in _STRICT_VALUES
+
+
+def _env_optional_policy(name: str) -> OrderPolicy | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"off", "false", "0"}:
+        return OrderPolicy.SORT
+    if normalized in {"on", "true", "1"}:
+        return OrderPolicy.ENFORCE
+    for candidate in OrderPolicy:
+        if candidate.value == normalized:
+            return candidate
+    return None
+
+
+def runtime_policy_from_env() -> RuntimePolicyConfig:
+    direct_requested = _env_flag("GABION_DIRECT_RUN")
+    override_record_json = os.getenv("GABION_OVERRIDE_RECORD_JSON")
+    return RuntimePolicyConfig(
+        proof_mode_enabled=_env_flag("GABION_PROOF_MODE"),
+        order_policy=_env_optional_policy("GABION_ORDER_POLICY"),
+        order_caller_sorted=os.getenv("GABION_CALLER_SORTED") == "1",
+        order_telemetry_enabled=os.getenv("GABION_ORDER_TELEMETRY") == "1",
+        order_enforce_canonical_allowlist=_env_flag(
+            "GABION_ENFORCE_CANONICAL_SORT_ALLOWLIST"
+        ),
+        order_deadline_probe_enabled=os.getenv("GABION_ORDER_DEADLINE_PROBE") == "1",
+        transport_direct_requested=(True if direct_requested else None),
+        transport_override_record_json=(
+            override_record_json.strip()
+            if isinstance(override_record_json, str) and override_record_json.strip()
+            else None
+        ),
+        derivation_cache_max_entries=max(
+            1,
+            int(os.getenv("GABION_DERIVATION_CACHE_MAX_ENTRIES", "4096") or "4096"),
+        ),
+        projection_registry_gas_limit=max(
+            1,
+            int(os.getenv("GABION_PROJECTION_REGISTRY_GAS_LIMIT", "1000000") or "1000000"),
+        ),
+    )
+
+
+
+
+def apply_runtime_policy(config: RuntimePolicyConfig) -> None:
+    from gabion.analysis.derivation_cache import set_derivation_cache_config
+    from gabion.analysis.projection_registry import set_projection_registry_runtime_config
+    from gabion.commands.transport_policy import set_transport_override
+    from gabion.invariants import set_proof_mode_config
+    from gabion.order_contract import set_order_runtime_config
+
+    set_proof_mode_config(ProofModeConfig(enabled=config.proof_mode_enabled))
+    set_order_runtime_config(
+        OrderRuntimeConfig(
+            default_policy=config.order_policy,
+            legacy_caller_sorted=config.order_caller_sorted,
+            telemetry_enabled=config.order_telemetry_enabled,
+            enforce_canonical_allowlist=config.order_enforce_canonical_allowlist,
+            deadline_probe_enabled=config.order_deadline_probe_enabled,
+        )
+    )
+    set_transport_override(
+        TransportOverrideConfig(
+            direct_requested=config.transport_direct_requested,
+            override_record_json=config.transport_override_record_json,
+        )
+    )
+    set_derivation_cache_config(
+        DerivationCacheConfig(max_entries=config.derivation_cache_max_entries)
+    )
+    set_projection_registry_runtime_config(
+        ProjectionRegistryRuntimeConfig(gas_limit=config.projection_registry_gas_limit)
+    )
+
+
+def apply_runtime_policy_from_env() -> None:
+    apply_runtime_policy(runtime_policy_from_env())
+
+
+@contextmanager
+def runtime_policy_scope(config: RuntimePolicyConfig) -> Iterator[None]:
+    with ExitStack() as stack:
+        stack.enter_context(
+            proof_mode_config_scope(ProofModeConfig(enabled=config.proof_mode_enabled))
+        )
+        stack.enter_context(
+            order_runtime_config_scope(
+                OrderRuntimeConfig(
+                    default_policy=config.order_policy,
+                    legacy_caller_sorted=config.order_caller_sorted,
+                    telemetry_enabled=config.order_telemetry_enabled,
+                    enforce_canonical_allowlist=config.order_enforce_canonical_allowlist,
+                    deadline_probe_enabled=config.order_deadline_probe_enabled,
+                )
+            )
+        )
+        stack.enter_context(
+            transport_override_scope(
+                TransportOverrideConfig(
+                    direct_requested=config.transport_direct_requested,
+                    override_record_json=config.transport_override_record_json,
+                )
+            )
+        )
+        stack.enter_context(
+            derivation_cache_config_scope(
+                DerivationCacheConfig(max_entries=config.derivation_cache_max_entries)
+            )
+        )
+        stack.enter_context(
+            projection_registry_runtime_config_scope(
+                ProjectionRegistryRuntimeConfig(
+                    gas_limit=config.projection_registry_gas_limit
+                )
+            )
+        )
+        yield

--- a/tests/test_derivation_cache.py
+++ b/tests/test_derivation_cache.py
@@ -19,7 +19,7 @@ from gabion.analysis.derivation_persistence import (
     write_derivation_checkpoint,
 )
 from gabion.exceptions import NeverThrown
-from tests.env_helpers import env_scope
+from gabion.runtime.policy_runtime import RuntimePolicyConfig, runtime_policy_scope
 
 
 # gabion:evidence E:call_footprint::tests/test_derivation_cache.py::test_structural_key_atom_canonicalizes_mapping_order_and_preserves_list_order::aspf.py::gabion.analysis.aspf.structural_key_atom
@@ -268,11 +268,11 @@ def test_global_derivation_cache_helpers_reset_and_env_parse() -> None:
 
 
 # gabion:evidence E:function_site::derivation_cache.py::gabion.analysis.derivation_cache.reset_global_derivation_cache
-def test_global_derivation_cache_helpers_invalid_env_uses_default() -> None:
-    with env_scope({"GABION_DERIVATION_CACHE_MAX_ENTRIES": "not-an-int"}):
+def test_global_derivation_cache_helpers_runtime_config() -> None:
+    with runtime_policy_scope(RuntimePolicyConfig(derivation_cache_max_entries=4096)):
         runtime = reset_global_derivation_cache()
     assert runtime.max_entries == 4096
-    with env_scope({"GABION_DERIVATION_CACHE_MAX_ENTRIES": "2"}):
+    with runtime_policy_scope(RuntimePolicyConfig(derivation_cache_max_entries=2)):
         runtime = reset_global_derivation_cache()
     assert runtime.max_entries == 2
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -4,7 +4,7 @@ import pytest
 
 from gabion import invariants
 from gabion.exceptions import NeverThrown
-from tests.env_helpers import env_scope
+from gabion.runtime.policy_runtime import RuntimePolicyConfig, runtime_policy_scope
 
 
 # gabion:evidence E:function_site::invariants.py::gabion.invariants.never
@@ -26,8 +26,8 @@ def test_require_not_none_strict_raises() -> None:
 
 
 # gabion:evidence E:call_footprint::tests/test_invariants.py::test_require_not_none_env_strict::env_helpers.py::tests.env_helpers.env_scope::invariants.py::gabion.invariants.require_not_none
-def test_require_not_none_env_strict() -> None:
-    with env_scope({"GABION_PROOF_MODE": "strict"}):
+def test_require_not_none_runtime_strict() -> None:
+    with runtime_policy_scope(RuntimePolicyConfig(proof_mode_enabled=True)):
         with pytest.raises(NeverThrown):
             invariants.require_not_none(None)
 

--- a/tests/test_runtime_policy_adapter.py
+++ b/tests/test_runtime_policy_adapter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from gabion import invariants
+from gabion.exceptions import NeverThrown
+from gabion.order_contract import ordered_or_sorted
+from gabion.runtime.policy_runtime import runtime_policy_from_env, runtime_policy_scope
+from tests.env_helpers import env_scope
+
+
+def test_runtime_policy_from_env_maps_order_and_proof_settings() -> None:
+    with env_scope({"GABION_PROOF_MODE": "strict", "GABION_ORDER_POLICY": "enforce"}):
+        config = runtime_policy_from_env()
+    assert config.proof_mode_enabled is True
+    assert config.order_policy is not None
+    assert config.order_policy.value == "enforce"
+
+
+def test_ambient_env_does_not_change_order_contract_without_adapter() -> None:
+    with env_scope({"GABION_ORDER_POLICY": "enforce"}):
+        assert ordered_or_sorted(["b", "a"], source="ambient-env") == ["a", "b"]
+
+
+def test_runtime_policy_scope_applies_order_policy_from_env_config() -> None:
+    with env_scope({"GABION_ORDER_POLICY": "enforce"}):
+        config = runtime_policy_from_env()
+    with runtime_policy_scope(config):
+        try:
+            ordered_or_sorted(["b", "a"], source="runtime-config")
+        except NeverThrown:
+            return
+    raise AssertionError("expected enforce policy to reject unsorted input")
+
+
+def test_ambient_env_does_not_change_proof_mode_without_adapter() -> None:
+    with env_scope({"GABION_PROOF_MODE": "strict"}):
+        assert invariants.require_not_none(None) is None

--- a/tests/test_transport_policy.py
+++ b/tests/test_transport_policy.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -13,38 +11,21 @@ from gabion.exceptions import NeverThrown
 from gabion.lsp_client import run_command, run_command_direct
 
 
-@contextmanager
-def _env_scope(updates: dict[str, str | None]):
-    originals = {key: os.environ.get(key) for key in updates}
-    try:
-        for key, value in updates.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-        yield
-    finally:
-        for key, value in originals.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-
-
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_transport_policy_denies_direct_for_governed_without_override
 def test_transport_policy_denies_direct_for_governed_without_override() -> None:
-    with _env_scope({transport_policy.DIRECT_RUN_ENV: "1", transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: None}):
+    with transport_policy.transport_override_scope(
+        transport_policy.TransportOverrideConfig(direct_requested=True)
+    ):
         with pytest.raises(NeverThrown):
             transport_policy.resolve_command_transport(command=command_ids.CHECK_COMMAND, runner=run_command)
 
 
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_transport_policy_allows_direct_for_governed_with_valid_override
 def test_transport_policy_allows_direct_for_governed_with_valid_override() -> None:
-    with _env_scope(
-        {
-            transport_policy.DIRECT_RUN_ENV: "1",
-            transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: "artifact://override/1",
-            transport_policy.OVERRIDE_RECORD_JSON_ENV: json.dumps(
+    with transport_policy.transport_override_scope(
+        transport_policy.TransportOverrideConfig(
+            direct_requested=True,
+            override_record_json=json.dumps(
                 {
                     "actor": "ci",
                     "rationale": "temporary",
@@ -55,7 +36,7 @@ def test_transport_policy_allows_direct_for_governed_with_valid_override() -> No
                     "evidence_links": ["artifact://override/1"],
                 }
             ),
-        }
+        )
     ):
         decision = transport_policy.resolve_command_transport(command=command_ids.CHECK_COMMAND, runner=run_command)
     assert decision.runner is run_command_direct
@@ -64,7 +45,9 @@ def test_transport_policy_allows_direct_for_governed_with_valid_override() -> No
 
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_transport_policy_keeps_direct_for_non_governed_command
 def test_transport_policy_keeps_direct_for_non_governed_command() -> None:
-    with _env_scope({transport_policy.DIRECT_RUN_ENV: "1", transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: None}):
+    with transport_policy.transport_override_scope(
+        transport_policy.TransportOverrideConfig(direct_requested=True)
+    ):
         decision = transport_policy.resolve_command_transport(
             command=command_ids.LSP_PARITY_GATE_COMMAND,
             runner=run_command,
@@ -74,13 +57,7 @@ def test_transport_policy_keeps_direct_for_non_governed_command() -> None:
 
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_transport_policy_unknown_command_without_direct_sets_no_policy
 def test_transport_policy_unknown_command_without_direct_sets_no_policy() -> None:
-    with _env_scope(
-        {
-            transport_policy.DIRECT_RUN_ENV: None,
-            transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: None,
-            transport_policy.OVERRIDE_RECORD_JSON_ENV: None,
-        }
-    ):
+    with transport_policy.transport_override_scope(None):
         decision = transport_policy.resolve_command_transport(
             command="gabion.unknown-command",
             runner=run_command,
@@ -90,26 +67,19 @@ def test_transport_policy_unknown_command_without_direct_sets_no_policy() -> Non
 
 
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_transport_override_scope_prefers_context_over_env
-def test_transport_override_scope_prefers_context_over_env() -> None:
-    with _env_scope(
-        {
-            transport_policy.DIRECT_RUN_ENV: "0",
-            transport_policy.DIRECT_RUN_OVERRIDE_EVIDENCE_ENV: "env://evidence",
-            transport_policy.OVERRIDE_RECORD_JSON_ENV: " {} ",
-        }
+def test_transport_override_scope_prefers_context_config() -> None:
+    with transport_policy.transport_override_scope(
+        transport_policy.TransportOverrideConfig(
+            direct_requested=True,
+            override_record_json="  {\"actor\":\"ci\"}  ",
+        )
     ):
-        with transport_policy.transport_override_scope(
-            transport_policy.TransportOverrideConfig(
-                direct_requested=True,
-                override_record_json="  {\"actor\":\"ci\"}  ",
-            )
-        ):
-            assert transport_policy.transport_override_present() is True
-            direct_requested, record_json = (
-                transport_policy._resolve_transport_controls()
-            )
-            assert direct_requested is True
-            assert record_json == "{\"actor\":\"ci\"}"
+        assert transport_policy.transport_override_present() is True
+        direct_requested, record_json = (
+            transport_policy._resolve_transport_controls()
+        )
+        assert direct_requested is True
+        assert record_json == "{\"actor\":\"ci\"}"
 
 
 # gabion:evidence E:function_site::test_transport_policy.py::tests.test_transport_policy.test_apply_cli_transport_flags_normalizes_strings_and_clears_override


### PR DESCRIPTION
### Motivation
- Remove ambient `os.environ` driven semantic branching from core/policy decision paths and centralize environment interpretation at a single boundary adapter. 
- Make runtime toggles explicit, plumbable via CLI/payload fields and context-scoped config objects to avoid hidden, process-wide behavior changes.

### Description
- Replaced direct env reads with explicit runtime config carriers and ContextVar-backed scopes in the semantic core for proof mode, order policy, transport override, derivation cache and projection registry by updating `src/gabion/invariants.py`, `src/gabion/order_contract.py`, `src/gabion/commands/transport_policy.py`, `src/gabion/analysis/derivation_cache.py`, and `src/gabion/analysis/projection_registry.py`.
- Added a boundary adapter `src/gabion/runtime/policy_runtime.py` that translates process env into a `RuntimePolicyConfig` and exposes `runtime_policy_from_env()`, `apply_runtime_policy(...)` and `runtime_policy_scope(...)` for scoped application.
- Threaded explicit runtime policy overrides through the CLI and command payloads by adding payload fields and invoking `policy_runtime.apply_runtime_policy_from_env()` in `src/gabion/cli.py`, and applying the effective `runtime_policy` inside the analysis call in `src/gabion/server_core/command_orchestrator.py` via `runtime_policy_scope`.
- Transport policy now honors only the explicit `TransportOverrideConfig` context (no ambient env fallback), and `derivation_cache` and `projection_registry` sizes/limits are read from ContextVar-backed configs instead of `os.getenv`.
- Added tests and adapters: new `tests/test_runtime_policy_adapter.py` plus updates to `tests/test_invariants.py`, `tests/test_order_contract.py`, `tests/test_projection_registry_edges.py`, `tests/test_transport_policy.py`, and `tests/test_derivation_cache.py` to assert parity when using explicit runtime config and that ambient env by itself no longer mutates semantic core behavior.

### Testing
- Ran policy checks: `PYTHONPATH=src python scripts/policy_check.py --workflows` and `PYTHONPATH=src python scripts/policy_check.py --ambiguity-contract`, both completed successfully.
- Unit test suite: `PYTHONPATH=src python -m pytest -o addopts='' tests/test_runtime_policy_adapter.py tests/test_invariants.py tests/test_order_contract.py tests/test_projection_registry_edges.py tests/test_transport_policy.py tests/test_derivation_cache.py` with all tests passing (`73 passed`).
- Static/packaging checks: `PYTHONPATH=src python -m compileall -q src/gabion tests/test_runtime_policy_adapter.py` succeeded.
- Evidence extraction: `PYTHONPATH=src python scripts/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` ran and `out/test_evidence.json` was refreshed to reflect the test changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a227ec61c48324a320468d6a00d9ca)