### PR TITLE
Add ASPF/taint crosswalk map, marker protocol normalization, and enforcement check

### DIFF
--- a/docs/aspf_taint_isomorphism_map.yaml
+++ b/docs/aspf_taint_isomorphism_map.yaml
@@ -1,0 +1,148 @@
+entries:
+  - in_step: in-46
+    concept: crosswalk_enforcement_prevents_speculative_duplication
+    existing_modules:
+      - scripts/policy_check.py
+      - src/gabion/analysis/dataflow_audit.py
+    existing_identifiers:
+      - AspfOneCell
+      - AspfTwoCellWitness
+      - DomainToAspfCofibration
+      - append_delta_record
+      - NeverInvariantSink
+      - NEVER_INVARIANTS_SPEC
+    existing_artifacts_or_projections:
+      - docs/normative_enforcement_map.yaml
+      - out/test_evidence.json
+      - artifacts/audit_snapshots/LATEST
+    gap_status: partial
+    rationale: Existing ASPF and never surfaces are present; explicit taint/isomorphism crosswalk and acknowledgement enforcement are now documented but remain emergent in runtime semantics.
+
+  - in_step: in-47
+    concept: architecture_constraint_enforcement
+    existing_modules:
+      - scripts/policy_check.py
+      - src/gabion/config.py
+      - src/gabion/analysis/marker_protocol.py
+    existing_identifiers:
+      - DomainToAspfCofibration
+      - NEVER_INVARIANTS_SPEC
+      - NeverInvariantSink
+    existing_artifacts_or_projections:
+      - docs/aspf_taint_isomorphism_map.yaml
+      - docs/normative_clause_index.md
+    gap_status: emergent
+    rationale: Enforcement hooks exist and now fail fast on missing crosswalk coverage; deeper taint/lifecycle coupling still needs implementation units.
+
+  - in_step: in-48
+    concept: marker_kernel_before_extraction
+    existing_modules:
+      - src/gabion/analysis/marker_protocol.py
+      - src/gabion/invariants.py
+      - src/gabion/exceptions.py
+    existing_identifiers:
+      - NeverInvariantSink
+      - NEVER_INVARIANTS_SPEC
+    existing_artifacts_or_projections:
+      - src/gabion/analysis/dataflow_audit.py
+      - artifacts/audit_snapshots/LATEST
+    gap_status: partial
+    rationale: Marker kernel and deterministic IDs exist for never callsites with backward-compatible plain reason handling; non-never families are still new work.
+
+  - in_step: in-49
+    concept: runtime_shape_before_static_projection
+    existing_modules:
+      - src/gabion/invariants.py
+      - src/gabion/exceptions.py
+      - src/gabion/analysis/dataflow_audit.py
+    existing_identifiers:
+      - NeverInvariantSink
+      - append_delta_record
+    existing_artifacts_or_projections:
+      - out/test_evidence.json
+      - artifacts/audit_snapshots/LATEST
+    gap_status: partial
+    rationale: Runtime never exceptions now carry normalized payloads consumed by analysis surfaces; static taint schemas remain pending.
+
+  - in_step: in-50
+    concept: static_normalization_before_aspf_projection
+    existing_modules:
+      - src/gabion/config.py
+      - src/gabion/analysis/dataflow_audit.py
+      - src/gabion/analysis/projection_registry.py
+    existing_identifiers:
+      - NEVER_INVARIANTS_SPEC
+      - NeverInvariantSink
+    existing_artifacts_or_projections:
+      - artifacts/audit_snapshots/LATEST/never_invariants.json
+      - gabion.toml
+    gap_status: emergent
+    rationale: Config now supports marker-family defaults while static projection keeps legacy never compatibility; generalized marker families are staged.
+
+  - in_step: in-51
+    concept: aspf_projection_reuse_before_taint_semantics
+    existing_modules:
+      - src/gabion/analysis/aspf_core.py
+      - src/gabion/analysis/aspf_morphisms.py
+      - src/gabion/analysis/forest_spec.py
+    existing_identifiers:
+      - AspfOneCell
+      - AspfTwoCellWitness
+      - DomainToAspfCofibration
+      - NeverInvariantSink
+    existing_artifacts_or_projections:
+      - artifacts/audit_snapshots/LATEST/forest.json
+      - artifacts/audit_snapshots/LATEST/projection_registry.json
+    gap_status: partial
+    rationale: ASPF/forest projection surfaces are deterministic and reusable; dedicated taint projections derived from marker+ASPF carriers are new.
+
+  - in_step: in-52
+    concept: taint_semantics_before_lifecycle
+    existing_modules:
+      - src/gabion/analysis/dataflow_audit.py
+      - src/gabion/analysis/marker_protocol.py
+      - src/gabion/analysis/forest_spec.py
+    existing_identifiers:
+      - NeverInvariantSink
+      - NEVER_INVARIANTS_SPEC
+      - AspfTwoCellWitness
+    existing_artifacts_or_projections:
+      - artifacts/audit_snapshots/LATEST/never_invariants.json
+      - out/test_evidence.json
+    gap_status: new
+    rationale: Marker parsing emits structured links and marker metadata, but dedicated taint taxonomies, loci, and witness erasure validation remain new surfaces.
+
+  - in_step: in-53
+    concept: lifecycle_governance_closure
+    existing_modules:
+      - scripts/policy_check.py
+      - src/gabion/analysis/marker_protocol.py
+      - src/gabion/analysis/dataflow_audit.py
+    existing_identifiers:
+      - NEVER_INVARIANTS_SPEC
+      - NeverInvariantSink
+    existing_artifacts_or_projections:
+      - docs/normative_enforcement_map.yaml
+      - artifacts/out/ci_watch
+    gap_status: emergent
+    rationale: Lifecycle fields exist in marker payload contract and policy checks enforce acknowledgement discipline; machine-readable promotion/demotion protocol artifacts are pending.
+
+  - in_step: in-58
+    concept: quotient_discipline_institutionalization
+    existing_modules:
+      - docs/aspf_taint_isomorphism_map.yaml
+      - scripts/policy_check.py
+      - src/gabion/analysis/marker_protocol.py
+    existing_identifiers:
+      - AspfOneCell
+      - AspfTwoCellWitness
+      - DomainToAspfCofibration
+      - append_delta_record
+      - NeverInvariantSink
+      - NEVER_INVARIANTS_SPEC
+    existing_artifacts_or_projections:
+      - docs/normative_clause_index.md
+      - out/test_evidence.json
+      - artifacts/audit_snapshots/LATEST
+    gap_status: partial
+    rationale: Deterministic crosswalk + marker normalization make quotient discipline explicit; full taint/lifecycle institutionalization requires remaining implementation units.

--- a/gabion.toml
+++ b/gabion.toml
@@ -85,6 +85,19 @@ never = [
   "gabion.exceptions.NeverThrown",
 ]
 
+[exceptions.markers]
+never = [
+  "NeverRaise",
+  "gabion.NeverRaise",
+  "gabion.exceptions.NeverRaise",
+  "NeverThrown",
+  "gabion.NeverThrown",
+  "gabion.exceptions.NeverThrown",
+  "never",
+  "gabion.never",
+  "gabion.invariants.never",
+]
+
 [fingerprints]
 synth_min_occurrences = 2
 synth_version = "synth@1"

--- a/src/gabion/analysis/marker_protocol.py
+++ b/src/gabion/analysis/marker_protocol.py
@@ -1,0 +1,113 @@
+"""Marker protocol contracts for invariant and analysis surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from hashlib import sha1
+import json
+from typing import Mapping, Sequence
+
+
+class MarkerKind(StrEnum):
+    NEVER = "never"
+
+
+class MarkerLifecycleState(StrEnum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    ROLLED_BACK = "rolled_back"
+
+
+@dataclass(frozen=True)
+class SemanticReference:
+    kind: str
+    value: str
+
+
+@dataclass(frozen=True)
+class MarkerPayload:
+    marker_kind: MarkerKind
+    reason: str
+    owner: str
+    expiry: str
+    lifecycle_state: MarkerLifecycleState
+    links: tuple[SemanticReference, ...]
+    env: dict[str, object]
+
+
+DEFAULT_MARKER_ALIASES: dict[MarkerKind, tuple[str, ...]] = {
+    MarkerKind.NEVER: (
+        "never",
+        "gabion.never",
+        "gabion.invariants.never",
+    )
+}
+
+
+def normalize_semantic_links(raw_links: Sequence[Mapping[str, str]]) -> tuple[SemanticReference, ...]:
+    normalized = tuple(
+        SemanticReference(kind=str(raw.get("kind", "")).strip(), value=str(raw.get("value", "")).strip())
+        for raw in raw_links
+    )
+    return tuple(
+        sorted(
+            (item for item in normalized if item.kind and item.value),
+            key=lambda item: (item.kind, item.value),
+        )
+    )
+
+
+def normalize_marker_payload(
+    *,
+    reason: str,
+    env: Mapping[str, object] = {},
+    marker_kind: MarkerKind = MarkerKind.NEVER,
+    owner: str = "",
+    expiry: str = "",
+    lifecycle_state: MarkerLifecycleState = MarkerLifecycleState.ACTIVE,
+    links: Sequence[Mapping[str, str]] = (),
+) -> MarkerPayload:
+    normalized_reason = (reason or "never() invariant reached").strip()
+    env_payload = {str(key): value for key, value in env.items()}
+    return MarkerPayload(
+        marker_kind=marker_kind,
+        reason=normalized_reason,
+        owner=owner.strip(),
+        expiry=expiry.strip(),
+        lifecycle_state=lifecycle_state,
+        links=normalize_semantic_links(links),
+        env=env_payload,
+    )
+
+
+def marker_identity(payload: MarkerPayload) -> str:
+    identity_payload = {
+        "marker_kind": payload.marker_kind.value,
+        "reason": payload.reason,
+        "owner": payload.owner,
+        "expiry": payload.expiry,
+        "lifecycle_state": payload.lifecycle_state.value,
+        "links": [{"kind": link.kind, "value": link.value} for link in payload.links],
+    }
+    encoded = json.dumps(identity_payload, separators=(",", ":"), sort_keys=True)
+    digest = sha1(encoded.encode("utf-8")).hexdigest()[:12]
+    return f"{payload.marker_kind.value}:{digest}"
+
+
+def never_marker_payload(
+    *,
+    reason: str = "",
+    env: Mapping[str, object] = {},
+    owner: str = "",
+    expiry: str = "",
+    links: Sequence[Mapping[str, str]] = (),
+) -> MarkerPayload:
+    return normalize_marker_payload(
+        reason=reason,
+        env=env,
+        marker_kind=MarkerKind.NEVER,
+        owner=owner,
+        expiry=expiry,
+        links=links,
+    )

--- a/src/gabion/config.py
+++ b/src/gabion/config.py
@@ -137,7 +137,39 @@ def exception_never_list(section: TomlTable | None) -> list[str]:
         return []
     if not isinstance(section, dict):
         return []
+    markers = exception_marker_families(section)
+    if "never" in markers and markers["never"]:
+        return markers["never"]
     return _normalize_name_list(section.get("never"))
+
+
+def exception_marker_families(section: TomlTable | None) -> dict[str, list[str]]:
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        return {}
+    markers = section.get("markers")
+    if not isinstance(markers, dict):
+        return {}
+    families: dict[str, list[str]] = {}
+    for family, payload in markers.items():
+        check_deadline()
+        family_name = str(family).strip()
+        if not family_name:
+            continue
+        families[family_name] = _normalize_name_list(payload)
+    return families
+
+
+def exception_marker_family(section: TomlTable | None, family: str) -> list[str]:
+    if not family.strip():
+        return []
+    families = exception_marker_families(section)
+    if family in families and families[family]:
+        return families[family]
+    if family == "never":
+        return exception_never_list(section)
+    return []
 
 
 def dataflow_deadline_roots(section: TomlTable | None) -> list[str]:

--- a/src/gabion/exceptions.py
+++ b/src/gabion/exceptions.py
@@ -1,5 +1,13 @@
 """Exception protocol markers for Gabion analysis."""
 
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gabion.analysis.marker_protocol import MarkerPayload
+
 
 class NeverRaise(RuntimeError):
     """Sentinel exception that should be statically unreachable.
@@ -8,6 +16,30 @@ class NeverRaise(RuntimeError):
     to be proven unreachable by analysis. If it is reachable, Gabion should
     treat it as a violation.
     """
+
+    def __init__(self, message: str, *, marker_payload: MarkerPayload | None = None):
+        from gabion.analysis.marker_protocol import marker_identity, never_marker_payload
+
+        super().__init__(message)
+        payload = marker_payload or never_marker_payload(reason=message)
+        self.marker_payload = payload
+        self.marker_id = marker_identity(payload)
+        self.marker_kind = payload.marker_kind.value
+
+    @property
+    def marker_payload_dict(self) -> dict[str, object]:
+        payload = asdict(self.marker_payload)
+        links = payload.get("links")
+        if isinstance(links, list):
+            payload["links"] = [
+                {
+                    "kind": str(link.get("kind", "")),
+                    "value": str(link.get("value", "")),
+                }
+                for link in links
+                if isinstance(link, dict)
+            ]
+        return payload
 
 
 class NeverThrown(NeverRaise):

--- a/src/gabion/invariants.py
+++ b/src/gabion/invariants.py
@@ -36,9 +36,21 @@ def never(reason: str = "", **env: object) -> NoReturn:
     The analysis treats this as a sink that should be proven unreachable. The
     optional env payload is metadata only; it is not evaluated at runtime.
     """
-    _ = env
-    message = reason or "never() invariant reached"
-    raise NeverThrown(message)
+    from gabion.analysis.marker_protocol import never_marker_payload
+
+    owner = str(env.get("owner", ""))
+    expiry = str(env.get("expiry", ""))
+    raw_links = env.get("links", ())
+    links = raw_links if isinstance(raw_links, list) else ()
+    extra_env = {key: value for key, value in env.items() if key not in {"owner", "expiry", "links"}}
+    payload = never_marker_payload(
+        reason=reason,
+        env=extra_env,
+        owner=owner,
+        expiry=expiry,
+        links=tuple(item for item in links if isinstance(item, dict)),
+    )
+    raise NeverThrown(payload.reason, marker_payload=payload)
 
 
 def proof_mode() -> bool:

--- a/tests/test_ci_governance_scripts.py
+++ b/tests/test_ci_governance_scripts.py
@@ -406,3 +406,36 @@ def semantic(value: object) -> object:
     )
     violations = policy_check._raw_payload_branching_violations(module)
     assert violations
+
+
+def test_policy_check_aspf_crosswalk_validates_repo_map() -> None:
+    original_changed = policy_check._changed_repo_paths
+    try:
+        policy_check._changed_repo_paths = lambda: set()  # type: ignore[assignment]
+        policy_check.check_aspf_taint_crosswalk_ack()
+    finally:
+        policy_check._changed_repo_paths = original_changed  # type: ignore[assignment]
+
+
+def test_policy_check_aspf_crosswalk_requires_ack_file(tmp_path: Path) -> None:
+    map_path = tmp_path / "aspf_taint_isomorphism_map.yaml"
+    map_path.write_text("entries: []\n", encoding="utf-8")
+    no_change = tmp_path / "aspf_taint_isomorphism_no_change.yaml"
+    no_change.write_text("{}\n", encoding="utf-8")
+
+    original_map = policy_check.ASPF_TAINT_MAP
+    original_no_change = policy_check.ASPF_TAINT_NO_CHANGE
+    original_changed = policy_check._changed_repo_paths
+    try:
+        policy_check.ASPF_TAINT_MAP = map_path
+        policy_check.ASPF_TAINT_NO_CHANGE = no_change
+        policy_check._changed_repo_paths = lambda: {"src/gabion/invariants.py"}  # type: ignore[assignment]
+        try:
+            policy_check.check_aspf_taint_crosswalk_ack()
+            assert False, "expected ASPF crosswalk check to fail"
+        except SystemExit as exc:
+            assert exc.code == 2
+    finally:
+        policy_check.ASPF_TAINT_MAP = original_map
+        policy_check.ASPF_TAINT_NO_CHANGE = original_no_change
+        policy_check._changed_repo_paths = original_changed  # type: ignore[assignment]

--- a/tests/test_config_edges.py
+++ b/tests/test_config_edges.py
@@ -59,6 +59,9 @@ def test_config_helpers_cover_bool_and_lists() -> None:
     assert config.exception_never_list(None) == []
     assert config.exception_never_list("bad") == []
     assert config.exception_never_list({"never": "A, B"}) == ["A", "B"]
+    marker_section = {"markers": {"never": ["N1", "N2"], "taint": ["T1"]}}
+    assert config.exception_never_list(marker_section) == ["N1", "N2"]
+    assert config.exception_marker_family(marker_section, "taint") == ["T1"]
 
 
 # gabion:evidence E:call_footprint::tests/test_config_edges.py::test_normalize_name_list_ignores_non_string_entries::config.py::gabion.config._normalize_name_list

--- a/tests/test_marker_protocol.py
+++ b/tests/test_marker_protocol.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from gabion.analysis.marker_protocol import marker_identity, normalize_marker_payload
+from gabion.invariants import never
+from gabion.exceptions import NeverThrown
+
+
+def test_marker_identity_is_deterministic() -> None:
+    payload = normalize_marker_payload(
+        reason="boom",
+        owner="platform",
+        links=[
+            {"kind": "doc_id", "value": "in-46"},
+            {"kind": "policy_id", "value": "NCI-LSP-FIRST"},
+        ],
+    )
+    assert marker_identity(payload) == marker_identity(payload)
+
+
+def test_never_carries_marker_payload() -> None:
+    with pytest.raises(NeverThrown) as exc_info:
+        never(
+            "broken",
+            links=[{"kind": "doc_id", "value": "in-46"}],
+            owner="core",
+        )
+    assert exc_info.value.marker_kind == "never"
+    payload = exc_info.value.marker_payload_dict
+    assert payload["reason"] == "broken"
+    assert payload["owner"] == "core"


### PR DESCRIPTION
### Motivation

- Provide a deterministic, auditable crosswalk between ASPF/ASPF-projection surfaces and taint/marker semantics so changes to marker/ASPF-relevant code must be acknowledged.  
- Normalize runtime `never(...)` markers into a small marker protocol so analysis surfaces can consume structured metadata without breaking existing `NeverThrown` semantics.  
- Enforce crosswalk acknowledgement in policy tooling so architectural constraints are preserved when touching taint/marker/ASPF files.

### Description

- Added `docs/aspf_taint_isomorphism_map.yaml` with deterministic entries for `in-46`, `in-47`, `in-48`, `in-49`, `in-50`, `in-51`, `in-52`, `in-53`, and `in-58`, listing `in_step`, `concept`, `existing_modules`, `existing_identifiers`, `existing_artifacts_or_projections`, `gap_status` and `rationale`, and ordered by `in_step` then `concept`.  
- Extended `scripts/policy_check.py` with a new `check_aspf_taint_crosswalk_ack()` and `--aspf-taint-crosswalk` CLI flag that detects changes to taint/marker/ASPF-relevant paths and requires either map updates or a machine-readable no-change declaration; the check validates required `in_step` coverage and expected identifier anchors.  
- Introduced `src/gabion/analysis/marker_protocol.py` implementing marker kinds, lifecycle states, semantic link normalization, the `MarkerPayload` contract and deterministic `marker_identity()` construction.  
- Routed runtime `never(...)` through the marker kernel while preserving `NoReturn` and `NeverThrown` behavior by carrying normalized `MarkerPayload` on exception objects and exposing `marker_id`/`marker_kind` via `gabion.exceptions.NeverRaise`; updated `src/gabion/invariants.py` and `src/gabion/exceptions.py` accordingly.  
- Updated `src/gabion/config.py` and `gabion.toml` to support marker families under `[exceptions.markers]` with compatibility fallback to the legacy `[exceptions].never` list, and updated `src/gabion/analysis/dataflow_audit.py` to accept marker-family aliases and emit marker fields alongside legacy reports.  
- Added tests and small test helpers: `tests/test_marker_protocol.py`, extended `tests/test_config_edges.py` and `tests/test_ci_governance_scripts.py`, and refreshed `out/test_evidence.json` to reflect the new tests and evidence mappings.

### Testing

- Ran `PYTHONPATH=src mise exec -- python -m scripts.policy_check --workflows` and the new ASPF/taint crosswalk check executed without failure (environment warning about `mise` tool resolution is informational).  
- Ran `PYTHONPATH=src mise exec -- python -m scripts.policy_check --ambiguity-contract` and `PYTHONPATH=src mise exec -- python -m scripts.policy_check --aspf-taint-crosswalk` and both checks completed successfully.  
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/test_marker_protocol.py tests/test_config_edges.py tests/test_ci_governance_scripts.py` and all tests in that run passed (22 passed).  
- Ran `PYTHONPATH=src mise exec -- python -m scripts.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` was produced and committed (diff intentionally refreshed and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2654710cc832496216e2d3f9458aa)