### PR TITLE
Refactor docflow compliance invariant dispatch by kind

### DIFF
--- a/src/gabion_governance/governance_audit_impl.py
+++ b/src/gabion_governance/governance_audit_impl.py
@@ -2028,6 +2028,158 @@ def _docflow_compliance_rows(
     op_registry = _docflow_predicates()
     evidence_rows = [row for row in rows if row.get("row_kind") == "evidence_key"]
     covered_evidence: set[str] = set()
+
+    def _handle_cover_invariant(
+        invariant: DocflowInvariant,
+        *,
+        matched: list[dict[str, object]],
+        evidence_matched: list[dict[str, object]],
+        active_flag: bool,
+        compliance: list[dict[str, object]],
+        covered_evidence: set[str],
+    ) -> None:
+        del matched
+        if not active_flag:
+            compliance.append(
+                {
+                    "row_kind": "docflow_compliance",
+                    "invariant": invariant.name,
+                    "invariant_kind": invariant.kind,
+                    "status": "proposed",
+                    "match_count": len(evidence_matched),
+                    "detail": "cover target missing" if not evidence_matched else None,
+                }
+            )
+            return
+        if evidence_matched:
+            for row in evidence_matched:
+                check_deadline()
+                evidence_id = str(row.get("evidence_id", "") or "")
+                if evidence_id:
+                    covered_evidence.add(evidence_id)
+            compliance.append(
+                {
+                    "row_kind": "docflow_compliance",
+                    "invariant": invariant.name,
+                    "invariant_kind": invariant.kind,
+                    "status": "compliant",
+                    "match_count": len(evidence_matched),
+                }
+            )
+            return
+        compliance.append(
+            {
+                "row_kind": "docflow_compliance",
+                "invariant": invariant.name,
+                "invariant_kind": invariant.kind,
+                "status": "contradicts",
+                "match_count": 0,
+                "detail": "cover target missing",
+            }
+        )
+
+    def _handle_never_invariant(
+        invariant: DocflowInvariant,
+        *,
+        matched: list[dict[str, object]],
+        evidence_matched: list[dict[str, object]],
+        active_flag: bool,
+        compliance: list[dict[str, object]],
+        covered_evidence: set[str],
+    ) -> None:
+        del evidence_matched
+        del covered_evidence
+        if not active_flag:
+            compliance.append(
+                {
+                    "row_kind": "docflow_compliance",
+                    "invariant": invariant.name,
+                    "invariant_kind": invariant.kind,
+                    "status": "proposed",
+                    "match_count": len(matched),
+                    "would_violate": bool(matched),
+                }
+            )
+            return
+        if matched:
+            for row in matched:
+                check_deadline()
+                compliance.append(
+                    {
+                        "row_kind": "docflow_compliance",
+                        "invariant": invariant.name,
+                        "invariant_kind": invariant.kind,
+                        "status": "contradicts",
+                        "match_count": len(matched),
+                        "path": row.get("path"),
+                        "qual": row.get("qual"),
+                        "source_row_kind": row.get("row_kind"),
+                    }
+                )
+            return
+        compliance.append(
+            {
+                "row_kind": "docflow_compliance",
+                "invariant": invariant.name,
+                "invariant_kind": invariant.kind,
+                "status": "compliant",
+                "match_count": 0,
+            }
+        )
+
+    def _handle_require_invariant(
+        invariant: DocflowInvariant,
+        *,
+        matched: list[dict[str, object]],
+        evidence_matched: list[dict[str, object]],
+        active_flag: bool,
+        compliance: list[dict[str, object]],
+        covered_evidence: set[str],
+    ) -> None:
+        del evidence_matched
+        del covered_evidence
+        if not active_flag:
+            compliance.append(
+                {
+                    "row_kind": "docflow_compliance",
+                    "invariant": invariant.name,
+                    "invariant_kind": invariant.kind,
+                    "status": "proposed",
+                    "match_count": len(matched),
+                    "would_violate": not bool(matched),
+                    "detail": "requirement missing" if not matched else None,
+                }
+            )
+            return
+        if matched:
+            compliance.append(
+                {
+                    "row_kind": "docflow_compliance",
+                    "invariant": invariant.name,
+                    "invariant_kind": invariant.kind,
+                    "status": "compliant",
+                    "match_count": len(matched),
+                }
+            )
+            return
+        compliance.append(
+            {
+                "row_kind": "docflow_compliance",
+                "invariant": invariant.name,
+                "invariant_kind": invariant.kind,
+                "status": "contradicts",
+                "match_count": 0,
+                "detail": "requirement missing",
+            }
+        )
+
+    Handler: TypeAlias = Callable[..., None]
+    handlers: dict[str, Handler] = {
+        "cover": _handle_cover_invariant,
+        "never": _handle_never_invariant,
+        "require": _handle_require_invariant,
+    }
+
     for invariant in invariants:
         check_deadline()
         matched = apply_spec(
@@ -2038,119 +2190,18 @@ def _docflow_compliance_rows(
         evidence_matched = [
             row for row in matched if row.get("row_kind") == "evidence_key"
         ]
-        if invariant.status != "active":
-            if invariant.kind == "cover":
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "proposed",
-                        "match_count": len(evidence_matched),
-                        "detail": "cover target missing" if not evidence_matched else None,
-                    }
-                )
-            elif invariant.kind == "never":
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "proposed",
-                        "match_count": len(matched),
-                        "would_violate": bool(matched),
-                    }
-                )
-            elif invariant.kind == "require":
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "proposed",
-                        "match_count": len(matched),
-                        "would_violate": not bool(matched),
-                        "detail": "requirement missing" if not matched else None,
-                    }
-                )
-            continue
-        if invariant.kind == "cover":
-            if evidence_matched:
-                for row in evidence_matched:
-                    check_deadline()
-                    evidence_id = str(row.get("evidence_id", "") or "")
-                    if evidence_id:
-                        covered_evidence.add(evidence_id)
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "compliant",
-                        "match_count": len(evidence_matched),
-                    }
-                )
-            else:
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "contradicts",
-                        "match_count": 0,
-                        "detail": "cover target missing",
-                    }
-                )
-            continue
-        if invariant.kind == "never":
-            if matched:
-                for row in matched:
-                    check_deadline()
-                    compliance.append(
-                        {
-                            "row_kind": "docflow_compliance",
-                            "invariant": invariant.name,
-                            "invariant_kind": invariant.kind,
-                            "status": "contradicts",
-                            "match_count": len(matched),
-                            "path": row.get("path"),
-                            "qual": row.get("qual"),
-                            "source_row_kind": row.get("row_kind"),
-                        }
-                    )
-            else:
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "compliant",
-                        "match_count": 0,
-                    }
-                )
-            continue
-        if invariant.kind == "require":
-            if matched:
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "compliant",
-                        "match_count": len(matched),
-                    }
-                )
-            else:
-                compliance.append(
-                    {
-                        "row_kind": "docflow_compliance",
-                        "invariant": invariant.name,
-                        "invariant_kind": invariant.kind,
-                        "status": "contradicts",
-                        "match_count": 0,
-                        "detail": "requirement missing",
-                    }
-                )
+        active_flag = invariant.status == "active"
+        handler = handlers.get(invariant.kind)
+        if handler is None:
+            never("unknown docflow invariant kind", kind=invariant.kind)
+        handler(
+            invariant,
+            matched=matched,
+            evidence_matched=evidence_matched,
+            active_flag=active_flag,
+            compliance=compliance,
+            covered_evidence=covered_evidence,
+        )
     for row in evidence_rows:
         check_deadline()
         evidence_id = str(row.get("evidence_id", "") or "")

--- a/tests/gabion/tooling/test_docflow_compliance_rows.py
+++ b/tests/gabion/tooling/test_docflow_compliance_rows.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from gabion_governance import governance_audit_impl as impl
+
+
+def _spec(name: str, predicate: str, **params: object):
+    return impl.spec_from_dict(
+        {
+            "spec_version": 1,
+            "name": name,
+            "domain": "docflow",
+            "pipeline": [
+                {
+                    "op": "select",
+                    "params": {
+                        "predicates": [predicate],
+                    },
+                }
+            ],
+            "params": params,
+        }
+    )
+
+
+# gabion:evidence E:call_footprint::tests/test_docflow_compliance_rows.py::test_docflow_compliance_rows_dispatches_cover_never_require_active_and_proposed::governance_audit_impl.py::gabion_governance.governance_audit_impl._docflow_compliance_rows
+def test_docflow_compliance_rows_dispatches_cover_never_require_active_and_proposed() -> None:
+    rows = [
+        {
+            "row_kind": "evidence_key",
+            "evidence_id": "E:covered",
+            "evidence_kind": "call_footprint",
+            "evidence_source": "covered-source",
+            "evidence_display": "covered evidence",
+        },
+        {
+            "row_kind": "evidence_key",
+            "evidence_id": "E:proposed",
+            "evidence_kind": "call_footprint",
+            "evidence_source": "proposed-source",
+            "evidence_display": "proposed evidence",
+        },
+        {"row_kind": "doc_missing_frontmatter", "path": "README.md", "qual": "README"},
+    ]
+    invariants = [
+        impl.DocflowInvariant(
+            name="cover-active",
+            kind="cover",
+            spec=_spec("cover-active", "evidence_source", evidence_source="covered-source"),
+            status="active",
+        ),
+        impl.DocflowInvariant(
+            name="cover-proposed",
+            kind="cover",
+            spec=_spec("cover-proposed", "evidence_source", evidence_source="proposed-source"),
+            status="proposed",
+        ),
+        impl.DocflowInvariant(
+            name="never-active",
+            kind="never",
+            spec=impl._make_invariant_spec("never-active", ["missing_frontmatter"]),
+            status="active",
+        ),
+        impl.DocflowInvariant(
+            name="never-proposed",
+            kind="never",
+            spec=impl._make_invariant_spec("never-proposed", ["missing_frontmatter"]),
+            status="proposed",
+        ),
+        impl.DocflowInvariant(
+            name="require-active",
+            kind="require",
+            spec=impl._make_invariant_spec("require-active", ["missing_frontmatter"]),
+            status="active",
+        ),
+        impl.DocflowInvariant(
+            name="require-proposed",
+            kind="require",
+            spec=impl._make_invariant_spec("require-proposed", ["missing_governance_ref"]),
+            status="proposed",
+        ),
+    ]
+
+    compliance = impl._docflow_compliance_rows(rows, invariants=invariants)
+
+    cover_active = next(row for row in compliance if row.get("invariant") == "cover-active")
+    assert cover_active == {
+        "row_kind": "docflow_compliance",
+        "invariant": "cover-active",
+        "invariant_kind": "cover",
+        "status": "compliant",
+        "match_count": 1,
+    }
+
+    cover_proposed = next(row for row in compliance if row.get("invariant") == "cover-proposed")
+    assert cover_proposed == {
+        "row_kind": "docflow_compliance",
+        "invariant": "cover-proposed",
+        "invariant_kind": "cover",
+        "status": "proposed",
+        "match_count": 1,
+        "detail": None,
+    }
+
+    never_active = next(row for row in compliance if row.get("invariant") == "never-active")
+    assert never_active == {
+        "row_kind": "docflow_compliance",
+        "invariant": "never-active",
+        "invariant_kind": "never",
+        "status": "contradicts",
+        "match_count": 1,
+        "path": "README.md",
+        "qual": "README",
+        "source_row_kind": "doc_missing_frontmatter",
+    }
+
+    never_proposed = next(row for row in compliance if row.get("invariant") == "never-proposed")
+    assert never_proposed == {
+        "row_kind": "docflow_compliance",
+        "invariant": "never-proposed",
+        "invariant_kind": "never",
+        "status": "proposed",
+        "match_count": 1,
+        "would_violate": True,
+    }
+
+    require_active = next(row for row in compliance if row.get("invariant") == "require-active")
+    assert require_active == {
+        "row_kind": "docflow_compliance",
+        "invariant": "require-active",
+        "invariant_kind": "require",
+        "status": "compliant",
+        "match_count": 1,
+    }
+
+    require_proposed = next(row for row in compliance if row.get("invariant") == "require-proposed")
+    assert require_proposed == {
+        "row_kind": "docflow_compliance",
+        "invariant": "require-proposed",
+        "invariant_kind": "require",
+        "status": "proposed",
+        "match_count": 0,
+        "would_violate": True,
+        "detail": "requirement missing",
+    }
+
+    excess = [row for row in compliance if row.get("status") == "excess"]
+    assert excess == [
+        {
+            "row_kind": "docflow_compliance",
+            "status": "excess",
+            "evidence_id": "E:proposed",
+            "evidence_kind": "call_footprint",
+            "evidence_display": "proposed evidence",
+            "evidence_source": "proposed-source",
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Centralize and simplify per-kind compliance logic in `_docflow_compliance_rows` so `cover`/`never`/`require` behaviors are handled once via explicit strategy functions.
- Make unknown invariant kinds impossible-by-construction and reduce branch duplication while preserving existing compliance row shapes and evidence coverage semantics.

### Description
- Replaced the inline per-kind branching in `src/gabion_governance/governance_audit_impl.py::_docflow_compliance_rows` with typed handlers: `_handle_cover_invariant`, `_handle_never_invariant`, and `_handle_require_invariant` that accept `(invariant, matched, evidence_matched, active_flag, compliance, covered_evidence)`.
- Introduced a `handlers: dict[str, Handler]` dispatch keyed by `invariant.kind` and treat unknown kinds as impossible-by-construction via `never(...)`.
- In the main loop `matched` and `evidence_matched` are computed once and `active_flag = (invariant.status == "active")` is passed to the handler; all previously emitted fields (`status`, `detail`, `would_violate`, `match_count`, `path`, `qual`, `source_row_kind`, etc.) are preserved exactly.
- Added a regression test `tests/gabion/tooling/test_docflow_compliance_rows.py` that covers all three kinds in both `active` and `proposed` statuses and exercises evidence coverage/excess behavior, and refreshed `out/test_evidence.json` to include the new test mapping.

### Testing
- Ran the targeted unit test with `python -m pytest -o addopts='' tests/gabion/tooling/test_docflow_compliance_rows.py`, which passed (`1 passed`).
- Ran the repository policy checks via `scripts/policy_check.py --workflows` and `scripts/policy_check.py --ambiguity-contract` (invoked under the pinned runner wrapper), both completed successfully in this environment while emitting `mise` network-version warnings unrelated to the logic change.
- Regenerated test evidence with `python -m scripts.extract_test_evidence --root . --tests tests --out out/test_evidence.json`, which completed and produced the updated `out/test_evidence.json` mapping used by the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64093a9e08324a10531f0af120686)