### PR TITLE
Refactor server name normalization helper

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -2684,39 +2684,37 @@ def _uri_to_path(uri: str) -> Path:
     return Path(uri)
 
 
-def _normalize_transparent_decorators(value: object) -> set[str] | None:
+def _normalize_csv_or_iterable_names(value: object, *, strict: bool) -> list[str]:
     check_deadline()
     if value is None:
-        return None
-    items: list[str] = []
+        return []
     if isinstance(value, str):
-        items = [part.strip() for part in value.split(",") if part.strip()]
-    elif isinstance(value, (list, tuple, set)):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        items: list[str] = []
         for item in value:
             check_deadline()
             if isinstance(item, str):
                 items.extend([part.strip() for part in item.split(",") if part.strip()])
+            elif strict:
+                never("name set contains non-string entry", value_type=type(item).__name__)
+        return items
+    if strict:
+        never("invalid name set payload", value_type=type(value).__name__)
+    return []
+
+
+def _normalize_transparent_decorators(value: object) -> set[str] | None:
+    items = _normalize_csv_or_iterable_names(value, strict=False)
     if not items:
         return None
     return set(items)
 
 
 def _normalize_name_set(value: object) -> set[str] | None:
-    check_deadline()
     if value is None:
         return None
-    items: list[str] = []
-    if isinstance(value, str):
-        items = [part.strip() for part in value.split(",") if part.strip()]
-    elif isinstance(value, (list, tuple, set)):
-        for item in value:
-            check_deadline()
-            if isinstance(item, str):
-                items.extend([part.strip() for part in item.split(",") if part.strip()])
-            else:
-                never("name set contains non-string entry", value_type=type(item).__name__)
-    else:
-        never("invalid name set payload", value_type=type(value).__name__)
+    items = _normalize_csv_or_iterable_names(value, strict=True)
     return set(items)
 
 

--- a/tests/gabion/server/server_execute_command_edges_cases.py
+++ b/tests/gabion/server/server_execute_command_edges_cases.py
@@ -2796,12 +2796,24 @@ def test_server_deadline_overhead_and_name_set_edges() -> None:
     assert server._server_deadline_overhead_ns(total_ns=1, divisor=1) == 0
     with pytest.raises(NeverThrown):
         server._server_deadline_overhead_ns(total_ns=1, divisor=0)
+
+    assert server._normalize_name_set(None) is None
     assert server._normalize_name_set(" a, b ") == {"a", "b"}
     assert server._normalize_name_set([" a ", "b,c"]) == {"a", "b", "c"}
+    assert server._normalize_name_set((" a ", "b,c")) == {"a", "b", "c"}
+    assert server._normalize_name_set({" a ", "b,c"}) == {"a", "b", "c"}
     with pytest.raises(NeverThrown):
         server._normalize_name_set(["ok", 1])  # type: ignore[list-item]
     with pytest.raises(NeverThrown):
         server._normalize_name_set(1)  # type: ignore[arg-type]
+
+    assert server._normalize_transparent_decorators(None) is None
+    assert server._normalize_transparent_decorators(" a, b ") == {"a", "b"}
+    assert server._normalize_transparent_decorators([" a ", "b,c"]) == {"a", "b", "c"}
+    assert server._normalize_transparent_decorators((" a ", "b,c")) == {"a", "b", "c"}
+    assert server._normalize_transparent_decorators({" a ", "b,c"}) == {"a", "b", "c"}
+    assert server._normalize_transparent_decorators(["ok", 1]) == {"ok"}  # type: ignore[list-item]
+    assert server._normalize_transparent_decorators(1) is None  # type: ignore[arg-type]
 
 
 # gabion:evidence E:call_footprint::tests/test_server_execute_command_edges.py::test_execute_structure_reuse_total_edges::server.py::gabion.server._execute_structure_reuse_total::test_server_execute_command_edges.py::tests.test_server_execute_command_edges._with_timeout


### PR DESCRIPTION
### Motivation
- Consolidate duplicate CSV/list/set string-normalization logic into a single helper to reduce code duplication and centralize invariant checks.
- Preserve the existing strictness contract between transparent decorator normalization (permissive) and name-set normalization (strict) while improving maintainability.

### Description
- Added `_normalize_csv_or_iterable_names(value: object, *, strict: bool) -> list[str]` in `src/gabion/server.py` to normalize `None`, comma-delimited `str`, and iterable containers (`list`/`tuple`/`set`) into a flat list of trimmed strings.
- Implemented the helper to call `never(...)` for non-string iterable entries or invalid container payloads when `strict=True`, and to ignore non-strings / treat invalid containers as empty when `strict=False`.
- Reworked `_normalize_transparent_decorators` and `_normalize_name_set` to be thin wrappers over the new helper (`strict=False` for transparent decorators, `strict=True` for name sets) and retained exact prior behavior.
- Expanded unit coverage in `tests/gabion/server/server_execute_command_edges_cases.py` for both wrappers to exercise `None`, CSV strings, `list`/`tuple`/`set`, mixed-type iterables, and invalid container payloads, and refreshed `out/test_evidence.json` to reflect the updated test anchors.

### Testing
- Ran `PYTHONPATH=src mise exec -- python -m scripts.policy_check --workflows` and the workflow policy check completed successfully.
- Ran `PYTHONPATH=src mise exec -- python -m scripts.policy_check --ambiguity-contract` and the ambiguity-contract check completed successfully.
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/server/server_execute_command_edges_cases.py -k "name_set_edges"` and the selected test passed (`1 passed`).
- Ran `PYTHONPATH=src mise exec -- python -m scripts.extract_test_evidence --root . --tests tests --out out/test_evidence.json` to refresh evidence and the extraction completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a640bdeb608324a72019887e7b0e20)