### PR TITLE
Refactor phase primary-unit resolution to a shared mapping

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -222,6 +222,12 @@ _LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
 _LSP_PROGRESS_TOKEN = "gabion.dataflowAudit/progress-v1"
 _STDOUT_ALIAS = "-"
 _STDOUT_PATH = "/dev/stdout"
+_PHASE_PRIMARY_UNITS: Mapping[str, str] = {
+    "collection": "collection_files",
+    "forest": "forest_mutable_steps",
+    "edge": "edge_tasks",
+    "post": "post_tasks",
+}
 
 
 def _is_stdout_target(target: object) -> bool:
@@ -786,15 +792,10 @@ def _normalize_progress_work(
 
 
 def _phase_primary_unit_for_phase(phase: str) -> str:
-    if phase == "collection":
-        return "collection_files"
-    if phase == "forest":
-        return "forest_mutable_steps"
-    if phase == "edge":
-        return "edge_tasks"
-    if phase == "post":
-        return "post_tasks"
-    return "phase_work_units"
+    primary_unit = _PHASE_PRIMARY_UNITS.get(phase)
+    if primary_unit is not None:
+        return primary_unit
+    never("unknown phase for primary-unit lookup", phase=phase)
 
 
 def _build_phase_progress_v2(
@@ -829,14 +830,15 @@ def _build_phase_progress_v2(
     if normalized_work_total:
         normalized_work_done = min(normalized_work_done, normalized_work_total)
 
+    primary_unit_for_phase = _phase_primary_unit_for_phase(phase)
     normalized: JSONObject = {
         "format_version": 1,
         "schema": "gabion/phase_progress_v2",
-        "primary_unit": _phase_primary_unit_for_phase(phase),
+        "primary_unit": primary_unit_for_phase,
         "primary_done": normalized_work_done,
         "primary_total": normalized_work_total,
         "dimensions": {
-            _phase_primary_unit_for_phase(phase): {
+            primary_unit_for_phase: {
                 "done": normalized_work_done,
                 "total": normalized_work_total,
             }
@@ -849,7 +851,7 @@ def _build_phase_progress_v2(
                 normalized[key] = value
     primary_unit = str(normalized.get("primary_unit", "") or "").strip()
     if not primary_unit:
-        primary_unit = _phase_primary_unit_for_phase(phase)
+        primary_unit = primary_unit_for_phase
     raw_primary_done = normalized.get("primary_done")
     raw_primary_total = normalized.get("primary_total")
     primary_done = (

--- a/tests/gabion/server/server_helpers_cases.py
+++ b/tests/gabion/server/server_helpers_cases.py
@@ -154,7 +154,6 @@ def test_materialize_execution_plan_uses_request_payload(tmp_path: Path) -> None
 # gabion:evidence E:call_footprint::tests/test_server_helpers.py::test_phase_progress_helpers_normalize_and_clamp_payloads::server.py::gabion.server._build_phase_progress_v2::server.py::gabion.server._phase_primary_unit_for_phase
 def test_phase_progress_helpers_normalize_and_clamp_payloads() -> None:
     server = _load()
-    assert server._phase_primary_unit_for_phase("mystery") == "phase_work_units"
 
     normalized, primary_done, primary_total = server._build_phase_progress_v2(
         phase="collection",
@@ -194,6 +193,29 @@ def test_phase_progress_helpers_normalize_and_clamp_payloads() -> None:
     assert dimensions["hydrated_paths_delta"] == {"done": 3, "total": 4}
     assert dimensions["semantic_progress_points"] == {"done": 6, "total": 7}
     assert normalized["inventory"] == {"known": 1}
+
+
+# gabion:evidence E:function_site::server.py::gabion.server._phase_primary_unit_for_phase
+@pytest.mark.parametrize(
+    ("phase", "expected"),
+    [
+        ("collection", "collection_files"),
+        ("forest", "forest_mutable_steps"),
+        ("edge", "edge_tasks"),
+        ("post", "post_tasks"),
+    ],
+)
+def test_phase_primary_unit_for_phase_known_phases(phase: str, expected: str) -> None:
+    server = _load()
+    assert server._phase_primary_unit_for_phase(phase) == expected
+
+
+# gabion:evidence E:function_site::server.py::gabion.server._phase_primary_unit_for_phase
+def test_phase_primary_unit_for_phase_rejects_unknown_phase() -> None:
+    server = _load()
+
+    with pytest.raises(NeverThrown):
+        server._phase_primary_unit_for_phase("mystery")
 
 
 # gabion:evidence E:call_footprint::tests/test_server_helpers.py::test_progress_heartbeat_seconds_parsing_edges::server.py::gabion.server._progress_heartbeat_seconds


### PR DESCRIPTION
### Motivation

- Centralize the phase → primary-unit mapping to eliminate repeated equality checks and make the mapping explicit and auditable.
- Enforce a closed set of known phases for primary-unit resolution so unknown phases are caught as an invariant violation rather than silently falling back.

### Description

- Introduced a module constant `_PHASE_PRIMARY_UNITS: Mapping[str, str]` containing mappings for `collection`, `forest`, `edge`, and `post`.
- Rewrote `_phase_primary_unit_for_phase` to return the mapped value and call `never(...)` for unknown phases instead of returning a permissive fallback.
- Reused the resolved `primary_unit_for_phase` inside `_build_phase_progress_v2` so the primary unit is computed once and reused for `primary_unit`, default `dimensions`, and fallback restoration when the payload value is blank.
- Added tests covering all known phases (parametrized) and an explicit unknown-phase rejection test expecting `NeverThrown`, and refreshed `out/test_evidence.json` to reflect the updated tests.

### Testing

- Ran the targeted unit tests with `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/server/server_helpers_cases.py -q` which passed (`22 passed`).
- Executed policy checks via `PYTHONPATH=src mise exec -- python -m scripts.policy_check --workflows` and `--ambiguity-contract` (warnings about tool resolution were emitted by `mise` but the checks executed successfully in this environment).
- Regenerated test evidence with `PYTHONPATH=src python -m scripts.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and committed the updated `out/test_evidence.json` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a640a659488324b5dc070fbd39218f)