### PR TITLE
Refactor auxiliary mode kind resolution to ordered mapping

### DIFF
--- a/src/gabion/server_core/command_orchestrator.py
+++ b/src/gabion/server_core/command_orchestrator.py
@@ -444,16 +444,13 @@ def _auxiliary_mode_from_payload(
                 emit_delta=emit_delta,
                 write_baseline=write_baseline,
             )
-        if emit_report:
-            kind = "report"
-        elif emit_state:
-            kind = "state"
-        elif emit_delta:
-            kind = "delta"
-        elif write_baseline:
-            kind = "baseline-write"
-        else:
-            kind = "off"
+        ordered_modes = (
+            (emit_report, "report"),
+            (emit_state, "state"),
+            (emit_delta, "delta"),
+            (write_baseline, "baseline-write"),
+        )
+        kind = next((candidate_kind for flag, candidate_kind in ordered_modes if flag), "off")
     allowed = {"off", "state", "delta", "baseline-write"}
     if allow_report:
         allowed.add("report")

--- a/tests/gabion/server_core/command_orchestrator_coverage_cases.py
+++ b/tests/gabion/server_core/command_orchestrator_coverage_cases.py
@@ -126,6 +126,54 @@ def test_auxiliary_mode_from_payload_legacy_baseline_write_branch() -> None:
     assert mode.kind == "baseline-write"
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_kind"),
+    [
+        ({"emit_test_obsolescence": True}, "report"),
+        ({"emit_test_obsolescence_state": True}, "state"),
+        ({"emit_test_obsolescence_delta": True}, "delta"),
+        ({"write_test_obsolescence_baseline": True}, "baseline-write"),
+        ({}, "off"),
+    ],
+)
+def test_auxiliary_mode_from_payload_legacy_kind_resolution_order(
+    payload: dict[str, object],
+    expected_kind: str,
+) -> None:
+    _bind()
+    mode = orchestrator._auxiliary_mode_from_payload(
+        payload=payload,
+        mode_key="obsolescence_mode",
+        state_key="test_obsolescence_state",
+        emit_state_key="emit_test_obsolescence_state",
+        emit_delta_key="emit_test_obsolescence_delta",
+        write_baseline_key="write_test_obsolescence_baseline",
+        emit_report_key="emit_test_obsolescence",
+        domain="obsolescence",
+        allow_report=True,
+    )
+    assert mode.kind == expected_kind
+
+
+def test_auxiliary_mode_from_payload_legacy_kind_resolution_conflict_still_rejected() -> None:
+    _bind()
+    with pytest.raises(NeverThrown):
+        orchestrator._auxiliary_mode_from_payload(
+            payload={
+                "emit_test_obsolescence": True,
+                "emit_test_obsolescence_state": True,
+            },
+            mode_key="obsolescence_mode",
+            state_key="test_obsolescence_state",
+            emit_state_key="emit_test_obsolescence_state",
+            emit_delta_key="emit_test_obsolescence_delta",
+            write_baseline_key="write_test_obsolescence_baseline",
+            emit_report_key="emit_test_obsolescence",
+            domain="obsolescence",
+            allow_report=True,
+        )
+
+
 def test_auxiliary_mode_from_payload_rejects_invalid_mode_kind() -> None:
     _bind()
     with pytest.raises(NeverThrown):


### PR DESCRIPTION
### Motivation
- Simplify and centralize the legacy auxiliary `kind` resolution logic by replacing an `if/elif` chain with a single ordered selection data structure to improve maintainability and make the selection order explicit.
- Preserve existing semantics: conflicting-flag detection and downstream validation should remain unchanged.

### Description
- Reworked `_auxiliary_mode_from_payload` to build an ordered tuple `((emit_report, "report"), (emit_state, "state"), (emit_delta, "delta"), (write_baseline, "baseline-write"))` and select the first matching `kind` via `next(..., "off")` instead of an `if/elif` chain. (`src/gabion/server_core/command_orchestrator.py`)
- Kept the existing conflict detection (`enabled > 1`) and the `never(...)` validation paths (including `allow_report` and `allow_lifecycle`) intact.
- Added focused tests to prove parity with prior behavior and cover the legacy branches: `report`, `state`, `delta`, `baseline-write`, `off`, and an explicit conflict case. (`tests/gabion/server_core/command_orchestrator_coverage_cases.py`)

### Testing
- Ran the focused pytest selection with system Python using `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/server_core/command_orchestrator_coverage_cases.py -k auxiliary_mode_from_payload`, which executed the added/affected tests and reported `8 passed, 21 deselected` for the selected suite.
- Attempted to run pinned-toolchain invocation via `mise exec -- python -m pytest ...` but `mise` resolution failed in this environment; fallback to system Python was used as described above and succeeded for the focused tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64329ed4c8324b3f4d946ca44dbc4)