### PR TITLE
Stabilize governance audit ownership and API boundary

### DIFF
--- a/src/gabion/tooling/governance/governance_audit.py
+++ b/src/gabion/tooling/governance/governance_audit.py
@@ -3,9 +3,25 @@ from __future__ import annotations
 # gabion:decision_protocol_module
 # gabion:boundary_normalization_module
 
-from typing import Any
+from typing import Final
 
 from gabion_governance import governance_audit_impl as _impl
+
+# Temporary boundary adapter metadata for legacy direct module access.
+# This adapter exists only to provide a stable import surface while core
+# implementation remains in gabion_governance.governance_audit_impl.
+BOUNDARY_ADAPTER_METADATA: Final[dict[str, object]] = {
+    "actor": "codex",
+    "rationale": "Preserve stable governance-audit API boundary at gabion.tooling.governance.",
+    "scope": "module import surface gabion.tooling.governance.governance_audit",
+    "start": "2026-03-04",
+    "expiry": "2026-09-01",
+    "rollback_condition": "All in-repo and external imports target gabion_governance.governance_audit_impl directly or a newly ratified canonical package path.",
+    "evidence_links": [
+        "tests/gabion/tooling/governance/test_governance_audit_adapter.py",
+        "tests/gabion/tooling/docflow/test_docflow_violation_formatter.py",
+    ],
+}
 
 CORE_GOVERNANCE_DOCS = _impl.CORE_GOVERNANCE_DOCS
 DOCFLOW_AUDIT_INVARIANTS = _impl.DOCFLOW_AUDIT_INVARIANTS
@@ -15,69 +31,32 @@ _DEFAULT_AUDIT_GAS_LIMIT = _impl._DEFAULT_AUDIT_GAS_LIMIT
 
 Doc = _impl.Doc
 DocflowObligationResult = _impl.DocflowObligationResult
+DocflowInvariant = _impl.DocflowInvariant
 
+_audit_deadline_scope = _impl._audit_deadline_scope
+_parse_frontmatter = _impl._parse_frontmatter
+_agent_instruction_graph = _impl._agent_instruction_graph
+_docflow_invariant_rows = _impl._docflow_invariant_rows
+_evaluate_docflow_invariants = _impl._evaluate_docflow_invariants
+_docflow_compliance_rows = _impl._docflow_compliance_rows
+_sppf_sync_check = _impl._sppf_sync_check
+_sppf_status_triplet_violations = _impl._sppf_status_triplet_violations
+_emit_docflow_compliance = _impl._emit_docflow_compliance
+_format_docflow_violation = _impl._format_docflow_violation
+_make_invariant_spec = _impl._make_invariant_spec
+_audit_gas_limit = _impl._audit_gas_limit
 
-def _audit_deadline_scope(*args: Any, **kwargs: Any) -> Any:
-    return _impl._audit_deadline_scope(*args, **kwargs)
+run_docflow_cli = _impl.run_docflow_cli
+run_sppf_graph_cli = _impl.run_sppf_graph_cli
+run_status_consistency_cli = _impl.run_status_consistency_cli
+run_decision_tiers_cli = _impl.run_decision_tiers_cli
+run_consolidation_cli = _impl.run_consolidation_cli
+run_lint_summary_cli = _impl.run_lint_summary_cli
 
-
-def _parse_frontmatter(*args: Any, **kwargs: Any) -> Any:
-    return _impl._parse_frontmatter(*args, **kwargs)
-
-
-def _agent_instruction_graph(*args: Any, **kwargs: Any) -> Any:
-    return _impl._agent_instruction_graph(*args, **kwargs)
-
-
-def _docflow_invariant_rows(*args: Any, **kwargs: Any) -> Any:
-    return _impl._docflow_invariant_rows(*args, **kwargs)
-
-
-def _evaluate_docflow_invariants(*args: Any, **kwargs: Any) -> Any:
-    return _impl._evaluate_docflow_invariants(*args, **kwargs)
-
-
-def _sppf_sync_check(*args: Any, **kwargs: Any) -> Any:
-    return _impl._sppf_sync_check(*args, **kwargs)
-
-
-def _sppf_status_triplet_violations(*args: Any, **kwargs: Any) -> Any:
-    return _impl._sppf_status_triplet_violations(*args, **kwargs)
-
-
-def _emit_docflow_compliance(*args: Any, **kwargs: Any) -> Any:
-    return _impl._emit_docflow_compliance(*args, **kwargs)
-
-
-def _audit_gas_limit(*args: Any, **kwargs: Any) -> Any:
-    return _impl._audit_gas_limit(*args, **kwargs)
-
-
-def run_docflow_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_docflow_cli(argv)
-
-
-def run_sppf_graph_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_sppf_graph_cli(argv)
-
-
-def run_status_consistency_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_status_consistency_cli(argv)
-
-
-def run_decision_tiers_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_decision_tiers_cli(argv)
-
-
-def run_consolidation_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_consolidation_cli(argv)
-
-
-def run_lint_summary_cli(argv: list[str] | None = None) -> int:
-    return _impl.run_lint_summary_cli(argv)
-
+spec_from_dict = _impl.spec_from_dict
 
 __all__ = [
+    "BOUNDARY_ADAPTER_METADATA",
     "CORE_GOVERNANCE_DOCS",
     "DOCFLOW_AUDIT_INVARIANTS",
     "NORMATIVE_LOOP_DOMAINS",
@@ -85,12 +64,16 @@ __all__ = [
     "_DEFAULT_AUDIT_GAS_LIMIT",
     "Doc",
     "DocflowObligationResult",
+    "DocflowInvariant",
     "_agent_instruction_graph",
     "_audit_deadline_scope",
     "_audit_gas_limit",
+    "_docflow_compliance_rows",
     "_docflow_invariant_rows",
     "_emit_docflow_compliance",
     "_evaluate_docflow_invariants",
+    "_format_docflow_violation",
+    "_make_invariant_spec",
     "_parse_frontmatter",
     "_sppf_status_triplet_violations",
     "_sppf_sync_check",
@@ -100,4 +83,5 @@ __all__ = [
     "run_lint_summary_cli",
     "run_sppf_graph_cli",
     "run_status_consistency_cli",
+    "spec_from_dict",
 ]

--- a/src/gabion/tooling/governance/normative_symdiff.py
+++ b/src/gabion/tooling/governance/normative_symdiff.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from typing import Callable, Iterable, Mapping
 
 from gabion.order_contract import sort_once
-from gabion_governance import governance_audit_impl as governance_audit
+from gabion.tooling.governance import governance_audit
 
 from gabion import server
 from gabion.tooling.governance import ambiguity_contract_policy_check

--- a/tests/gabion/tooling/docflow/test_docflow_compliance_rows.py
+++ b/tests/gabion/tooling/docflow/test_docflow_compliance_rows.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from gabion_governance import governance_audit_impl as impl
+from gabion.tooling.governance import governance_audit as impl
 
 
 def _spec(name: str, predicate: str, **params: object):

--- a/tests/gabion/tooling/docflow/test_docflow_violation_formatter.py
+++ b/tests/gabion/tooling/docflow/test_docflow_violation_formatter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from gabion_governance import governance_audit_impl as audit_impl
+from gabion.tooling.governance import governance_audit as audit_impl
 
 
 def test_format_docflow_violation_known_kinds() -> None:

--- a/tests/gabion/tooling/governance/test_governance_audit_adapter.py
+++ b/tests/gabion/tooling/governance/test_governance_audit_adapter.py
@@ -1,24 +1,23 @@
 from __future__ import annotations
 
 from gabion.tooling.governance import governance_audit
+from gabion_governance import governance_audit_impl
 
 
-# gabion:evidence E:call_footprint::tests/test_governance_audit_adapter.py::test_adapter_wrappers_cover_parse_and_runner_paths::governance_audit.py::gabion.tooling.governance_audit._parse_frontmatter::governance_audit.py::gabion.tooling.governance_audit.run_decision_tiers_cli::governance_audit.py::gabion.tooling.governance_audit.run_lint_summary_cli
-def test_adapter_wrappers_cover_parse_and_runner_paths() -> None:
-    original_parse = governance_audit._impl._parse_frontmatter
-    original_tiers = governance_audit._impl.run_decision_tiers_cli
-    original_lint = governance_audit._impl.run_lint_summary_cli
-    try:
-        governance_audit._impl._parse_frontmatter = lambda text: ({"x": "y"}, text)
-        governance_audit._impl.run_decision_tiers_cli = lambda _argv=None: 11
-        governance_audit._impl.run_lint_summary_cli = lambda _argv=None: 17
+# gabion:evidence E:call_footprint::tests/test_governance_audit_adapter.py::test_adapter_reexports_impl_symbols_and_lifecycle_metadata::governance_audit.py::gabion.tooling.governance.governance_audit.BOUNDARY_ADAPTER_METADATA::governance_audit.py::gabion.tooling.governance.governance_audit._parse_frontmatter::governance_audit.py::gabion.tooling.governance.governance_audit.run_decision_tiers_cli
+def test_adapter_reexports_impl_symbols_and_lifecycle_metadata() -> None:
+    metadata = governance_audit.BOUNDARY_ADAPTER_METADATA
+    assert set(metadata) == {
+        "actor",
+        "rationale",
+        "scope",
+        "start",
+        "expiry",
+        "rollback_condition",
+        "evidence_links",
+    }
+    assert metadata["actor"] == "codex"
 
-        parsed, body = governance_audit._parse_frontmatter("---\n---\nbody")
-        assert parsed == {"x": "y"}
-        assert body == "---\n---\nbody"
-        assert governance_audit.run_decision_tiers_cli(["--help"]) == 11
-        assert governance_audit.run_lint_summary_cli(["--help"]) == 17
-    finally:
-        governance_audit._impl._parse_frontmatter = original_parse
-        governance_audit._impl.run_decision_tiers_cli = original_tiers
-        governance_audit._impl.run_lint_summary_cli = original_lint
+    assert governance_audit._parse_frontmatter is governance_audit_impl._parse_frontmatter
+    assert governance_audit.run_decision_tiers_cli is governance_audit_impl.run_decision_tiers_cli
+    assert governance_audit.run_lint_summary_cli is governance_audit_impl.run_lint_summary_cli


### PR DESCRIPTION
### Motivation

- Establish a single canonical ownership boundary for the governance-audit implementation while preserving a stable import surface for existing consumers.
- Eliminate per-function pass-through indirection to reduce coupling and make the implementation/re-export relationship explicit and auditable.

### Description

- Keep the core implementation in `gabion_governance.governance_audit_impl` and convert `gabion.tooling.governance.governance_audit` into an explicit boundary adapter exposing `BOUNDARY_ADAPTER_METADATA` with lifecycle fields `actor`, `rationale`, `scope`, `start`, `expiry`, `rollback_condition`, and `evidence_links`.
- Replace individual wrapper functions with direct symbol re-exports bound to `_impl` (CLI runners and helper symbols are now direct aliases to implementation symbols) to remove unnecessary call indirection.
- Update consumers to import the stable tooling surface by changing `from gabion_governance import governance_audit_impl` usages to `from gabion.tooling.governance import governance_audit` (applied in `normative_symdiff` and docflow tests).
- Update tests to assert the adapter lifecycle metadata and identity-based re-exports, and refresh the `out/test_evidence.json` evidence carrier to reflect the new test/evidence shape.

### Testing

- Ran the workflow policy check with `PYTHONPATH=src:. mise exec -- python -m scripts.policy.policy_check --workflows`, which completed successfully with a non-blocking `mise` network/version-list warning.
- Ran the ambiguity-contract policy check with `PYTHONPATH=src:. mise exec -- python -m scripts.policy.policy_check --ambiguity-contract`, which completed successfully with the same non-blocking `mise` warning.
- Ran targeted pytest for modified governance/docflow tests with `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/gabion/tooling/governance/test_governance_audit_adapter.py tests/gabion/tooling/docflow/test_docflow_compliance_rows.py tests/gabion/tooling/docflow/test_docflow_violation_formatter.py`, which resulted in `5 passed`.
- Ran the runtime policy integration test with `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/gabion/tooling/runtime_policy/test_integration.py`, which resulted in `1 passed`.
- Rebuilt test evidence with `PYTHONPATH=src:. mise exec -- python scripts/misc/extract_test_evidence.py --out out/test_evidence.json`, which completed and produced an updated `out/test_evidence.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a830459a2083249356b16a161f58e6)