### PR TITLE
Unify shared CLI option schema for argparse and Typer surfaces

### DIFF
--- a/src/gabion/cli_support/shared/option_schema.py
+++ b/src/gabion/cli_support/shared/option_schema.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import typer
+
+
+class OptionType(str, Enum):
+    STRING = "string"
+    INT = "int"
+    FLOAT = "float"
+    PATH = "path"
+    BOOL = "bool"
+
+
+class OptionMultiplicity(str, Enum):
+    SINGLE = "single"
+    APPEND = "append"
+    FLAG = "flag"
+    BOOL_OPTIONAL = "bool_optional"
+
+
+@dataclass(frozen=True)
+class OptionSpec:
+    key: str
+    flag: str
+    option_type: OptionType
+    default: Any
+    multiplicity: OptionMultiplicity
+    help_text: str | None = None
+    choices: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OptionBindingOverride:
+    default: Any | None = None
+    multiplicity: OptionMultiplicity | None = None
+
+
+SHARED_OPTION_SPECS: dict[str, OptionSpec] = {
+    "root": OptionSpec(
+        key="root",
+        flag="--root",
+        option_type=OptionType.PATH,
+        default=Path("."),
+        multiplicity=OptionMultiplicity.SINGLE,
+    ),
+    "config": OptionSpec(
+        key="config",
+        flag="--config",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+    ),
+    "exclude": OptionSpec(
+        key="exclude",
+        flag="--exclude",
+        option_type=OptionType.STRING,
+        default=None,
+        multiplicity=OptionMultiplicity.APPEND,
+    ),
+    "ignore_params": OptionSpec(
+        key="ignore_params",
+        flag="--ignore-params",
+        option_type=OptionType.STRING,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+    ),
+    "transparent_decorators": OptionSpec(
+        key="transparent_decorators",
+        flag="--transparent-decorators",
+        option_type=OptionType.STRING,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Comma-separated decorator names treated as transparent.",
+    ),
+    "allow_external": OptionSpec(
+        key="allow_external",
+        flag="--allow-external",
+        option_type=OptionType.BOOL,
+        default=None,
+        multiplicity=OptionMultiplicity.BOOL_OPTIONAL,
+    ),
+    "strictness": OptionSpec(
+        key="strictness",
+        flag="--strictness",
+        option_type=OptionType.STRING,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        choices=("high", "low"),
+    ),
+    "no_recursive": OptionSpec(
+        key="no_recursive",
+        flag="--no-recursive",
+        option_type=OptionType.BOOL,
+        default=False,
+        multiplicity=OptionMultiplicity.FLAG,
+    ),
+    "aspf_trace_json": OptionSpec(
+        key="aspf_trace_json",
+        flag="--aspf-trace-json",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Write ASPF execution trace JSON to file or '-' for stdout.",
+    ),
+    "aspf_import_trace": OptionSpec(
+        key="aspf_import_trace",
+        flag="--aspf-import-trace",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.APPEND,
+        help_text="Import one or more prior ASPF trace JSON artifacts.",
+    ),
+    "aspf_equivalence_against": OptionSpec(
+        key="aspf_equivalence_against",
+        flag="--aspf-equivalence-against",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.APPEND,
+        help_text="One or more ASPF trace JSON artifacts used as equivalence baseline.",
+    ),
+    "aspf_opportunities_json": OptionSpec(
+        key="aspf_opportunities_json",
+        flag="--aspf-opportunities-json",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Write ASPF simplification/fungibility opportunities JSON to file or '-' for stdout.",
+    ),
+    "aspf_state_json": OptionSpec(
+        key="aspf_state_json",
+        flag="--aspf-state-json",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Write ASPF serialized state JSON to file or '-' for stdout.",
+    ),
+    "aspf_delta_jsonl": OptionSpec(
+        key="aspf_delta_jsonl",
+        flag="--aspf-delta-jsonl",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Write ASPF mutation delta ledger JSONL to file or '-' for stdout.",
+    ),
+    "aspf_import_state": OptionSpec(
+        key="aspf_import_state",
+        flag="--aspf-import-state",
+        option_type=OptionType.PATH,
+        default=None,
+        multiplicity=OptionMultiplicity.APPEND,
+        help_text="Import one or more prior ASPF serialized state JSON artifacts.",
+    ),
+    "aspf_semantic_surface": OptionSpec(
+        key="aspf_semantic_surface",
+        flag="--aspf-semantic-surface",
+        option_type=OptionType.STRING,
+        default=None,
+        multiplicity=OptionMultiplicity.APPEND,
+        help_text="Semantic surface keys to project into ASPF representatives.",
+    ),
+    "max_components": OptionSpec(
+        key="max_components",
+        flag="--max-components",
+        option_type=OptionType.INT,
+        default=10,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Max components in report.",
+    ),
+    "type_audit_max": OptionSpec(
+        key="type_audit_max",
+        flag="--type-audit-max",
+        option_type=OptionType.INT,
+        default=50,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Max type-tightening entries to print.",
+    ),
+    "type_audit_report": OptionSpec(
+        key="type_audit_report",
+        flag="--type-audit-report",
+        option_type=OptionType.BOOL,
+        default=False,
+        multiplicity=OptionMultiplicity.FLAG,
+        help_text="Include type-flow audit summary in the markdown report.",
+    ),
+    "fail_on_violations": OptionSpec(
+        key="fail_on_violations",
+        flag="--fail-on-violations",
+        option_type=OptionType.BOOL,
+        default=False,
+        multiplicity=OptionMultiplicity.FLAG,
+        help_text="Exit non-zero if undocumented/undeclared bundle violations are detected.",
+    ),
+    "synthesis_protocols_kind": OptionSpec(
+        key="synthesis_protocols_kind",
+        flag="--synthesis-protocols-kind",
+        option_type=OptionType.STRING,
+        default="dataclass",
+        multiplicity=OptionMultiplicity.SINGLE,
+        choices=("dataclass", "protocol", "contextvar"),
+        help_text="Emit dataclass, typing.Protocol, or ContextVar stubs (default: dataclass).",
+    ),
+    "synthesis_max_tier": OptionSpec(
+        key="synthesis_max_tier",
+        flag="--synthesis-max-tier",
+        option_type=OptionType.INT,
+        default=2,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Max tier to include in synthesis plan.",
+    ),
+    "synthesis_min_bundle_size": OptionSpec(
+        key="synthesis_min_bundle_size",
+        flag="--synthesis-min-bundle-size",
+        option_type=OptionType.INT,
+        default=2,
+        multiplicity=OptionMultiplicity.SINGLE,
+        help_text="Min bundle size to include in synthesis plan.",
+    ),
+    "synthesis_allow_singletons": OptionSpec(
+        key="synthesis_allow_singletons",
+        flag="--synthesis-allow-singletons",
+        option_type=OptionType.BOOL,
+        default=False,
+        multiplicity=OptionMultiplicity.FLAG,
+        help_text="Allow single-field bundles in synthesis plan.",
+    ),
+    "refactor_plan": OptionSpec(
+        key="refactor_plan",
+        flag="--refactor-plan",
+        option_type=OptionType.BOOL,
+        default=False,
+        multiplicity=OptionMultiplicity.FLAG,
+        help_text="Include refactoring plan summary in the markdown report.",
+    ),
+}
+
+# dataflow-bundle: cli.option-surface-intended-overlap
+INTENDED_OPTION_OVERLAP_KEYS: tuple[str, ...] = tuple(SHARED_OPTION_SPECS.keys())
+
+# dataflow-bundle: cli.option-surface-intentional-divergences
+OPTION_SURFACE_DIVERGENCES: dict[str, str] = {
+    "type_audit_report": (
+        "Raw argparse exposes --type-audit-report as one-way opt-in while the Typer synth "
+        "surface keeps explicit --type-audit-report/--no-type-audit-report toggles and defaults to enabled."
+    ),
+    "fail_on_violations": (
+        "Raw argparse exposes --fail-on-violations as one-way opt-in while the Typer synth "
+        "surface keeps explicit --fail-on-violations/--no-fail-on-violations toggles for scripted symmetry."
+    ),
+    "refactor_plan": (
+        "Raw argparse exposes --refactor-plan as one-way opt-in while the Typer synth "
+        "surface keeps explicit --refactor-plan/--no-refactor-plan toggles and defaults to enabled."
+    ),
+}
+
+
+def _resolved_multiplicity(
+    spec: OptionSpec,
+    override: OptionBindingOverride | None,
+) -> OptionMultiplicity:
+    return override.multiplicity if override and override.multiplicity is not None else spec.multiplicity
+
+
+def _resolved_default(spec: OptionSpec, override: OptionBindingOverride | None) -> Any:
+    return override.default if override and override.default is not None else spec.default
+
+
+def add_argparse_option(
+    parser: argparse.ArgumentParser,
+    spec: OptionSpec,
+    *,
+    override: OptionBindingOverride | None = None,
+) -> None:
+    kwargs: dict[str, Any] = {}
+    multiplicity = _resolved_multiplicity(spec, override)
+    if spec.help_text is not None:
+        kwargs["help"] = spec.help_text
+    if spec.option_type is OptionType.INT:
+        kwargs["type"] = int
+    elif spec.option_type is OptionType.FLOAT:
+        kwargs["type"] = float
+    elif spec.option_type is OptionType.PATH:
+        kwargs["type"] = str
+    if spec.choices:
+        kwargs["choices"] = spec.choices
+    if multiplicity is OptionMultiplicity.APPEND:
+        kwargs["action"] = "append"
+    elif multiplicity is OptionMultiplicity.FLAG:
+        kwargs["action"] = "store_true"
+    elif multiplicity is OptionMultiplicity.BOOL_OPTIONAL:
+        kwargs["action"] = argparse.BooleanOptionalAction
+
+    default = _resolved_default(spec, override)
+    if spec.option_type is OptionType.PATH and isinstance(default, Path):
+        default = str(default)
+    kwargs["default"] = default
+    parser.add_argument(spec.flag, **kwargs)
+
+
+def typer_option(
+    spec: OptionSpec,
+    *,
+    override: OptionBindingOverride | None = None,
+) -> Any:
+    multiplicity = _resolved_multiplicity(spec, override)
+    default = _resolved_default(spec, override)
+    if multiplicity is OptionMultiplicity.BOOL_OPTIONAL:
+        return typer.Option(
+            default,
+            f"{spec.flag}/--no-{spec.flag[2:]}",
+            help=spec.help_text,
+        )
+    return typer.Option(default, spec.flag, help=spec.help_text)

--- a/src/gabion/cli_support/shared/parser_builder.py
+++ b/src/gabion/cli_support/shared/parser_builder.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 
+from gabion.cli_support.shared.option_schema import SHARED_OPTION_SPECS, add_argparse_option
+
 
 def dataflow_cli_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -9,27 +11,19 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("paths", nargs="+")
-    parser.add_argument("--root", default=".")
-    parser.add_argument("--config", default=None)
+    add_argparse_option(parser, SHARED_OPTION_SPECS["root"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["config"])
     parser.add_argument("--baseline", default=None, help="Baseline file for violations.")
     parser.add_argument(
         "--baseline-write",
         action="store_true",
         help="Write current violations to baseline file.",
     )
-    parser.add_argument("--exclude", action="append", default=None)
-    parser.add_argument("--ignore-params", default=None)
-    parser.add_argument(
-        "--transparent-decorators",
-        default=None,
-        help="Comma-separated decorator names treated as transparent.",
-    )
-    parser.add_argument(
-        "--allow-external",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-    )
-    parser.add_argument("--strictness", choices=["high", "low"], default=None)
+    add_argparse_option(parser, SHARED_OPTION_SPECS["exclude"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["ignore_params"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["transparent_decorators"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["allow_external"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["strictness"])
     parser.add_argument(
         "--language",
         default=None,
@@ -40,51 +34,15 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional ingest profile used by the selected language adapter.",
     )
-    parser.add_argument(
-        "--aspf-trace-json",
-        default=None,
-        help="Write ASPF execution trace JSON to file or '-' for stdout.",
-    )
-    parser.add_argument(
-        "--aspf-import-trace",
-        action="append",
-        default=None,
-        help="Import one or more prior ASPF trace JSON artifacts.",
-    )
-    parser.add_argument(
-        "--aspf-equivalence-against",
-        action="append",
-        default=None,
-        help="One or more ASPF trace JSON artifacts used as equivalence baseline.",
-    )
-    parser.add_argument(
-        "--aspf-opportunities-json",
-        default=None,
-        help="Write ASPF simplification/fungibility opportunities JSON to file or '-' for stdout.",
-    )
-    parser.add_argument(
-        "--aspf-state-json",
-        default=None,
-        help="Write ASPF serialized state JSON to file or '-' for stdout.",
-    )
-    parser.add_argument(
-        "--aspf-delta-jsonl",
-        default=None,
-        help="Write ASPF mutation delta ledger JSONL to file or '-' for stdout.",
-    )
-    parser.add_argument(
-        "--aspf-import-state",
-        action="append",
-        default=None,
-        help="Import one or more prior ASPF serialized state JSON artifacts.",
-    )
-    parser.add_argument(
-        "--aspf-semantic-surface",
-        action="append",
-        default=None,
-        help="Semantic surface keys to project into ASPF representatives.",
-    )
-    parser.add_argument("--no-recursive", action="store_true")
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_trace_json"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_import_trace"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_equivalence_against"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_opportunities_json"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_state_json"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_delta_jsonl"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_import_state"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["aspf_semantic_surface"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["no_recursive"])
     parser.add_argument("--dot", default=None, help="Write DOT graph to file or '-' for stdout.")
     parser.add_argument(
         "--emit-structure-tree",
@@ -152,33 +110,20 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
         default=None,
         help="Write lint SARIF to file or '-' for stdout.",
     )
-    parser.add_argument("--max-components", type=int, default=10, help="Max components in report.")
+    add_argparse_option(parser, SHARED_OPTION_SPECS["max_components"])
     parser.add_argument(
         "--type-audit",
         action="store_true",
         help="Emit type-tightening suggestions based on downstream annotations.",
     )
-    parser.add_argument(
-        "--type-audit-max",
-        type=int,
-        default=50,
-        help="Max type-tightening entries to print.",
-    )
-    parser.add_argument(
-        "--type-audit-report",
-        action="store_true",
-        help="Include type-flow audit summary in the markdown report.",
-    )
+    add_argparse_option(parser, SHARED_OPTION_SPECS["type_audit_max"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["type_audit_report"])
     parser.add_argument(
         "--fail-on-type-ambiguities",
         action="store_true",
         help="Exit non-zero if type ambiguities are detected.",
     )
-    parser.add_argument(
-        "--fail-on-violations",
-        action="store_true",
-        help="Exit non-zero if undocumented/undeclared bundle violations are detected.",
-    )
+    add_argparse_option(parser, SHARED_OPTION_SPECS["fail_on_violations"])
     parser.add_argument(
         "--synthesis-plan",
         default=None,
@@ -194,40 +139,17 @@ def dataflow_cli_parser() -> argparse.ArgumentParser:
         default=None,
         help="Write protocol/dataclass stubs to file or '-' for stdout.",
     )
-    parser.add_argument(
-        "--synthesis-protocols-kind",
-        choices=["dataclass", "protocol", "contextvar"],
-        default="dataclass",
-        help="Emit dataclass, typing.Protocol, or ContextVar stubs (default: dataclass).",
-    )
-    parser.add_argument(
-        "--synthesis-max-tier",
-        type=int,
-        default=2,
-        help="Max tier to include in synthesis plan.",
-    )
-    parser.add_argument(
-        "--synthesis-min-bundle-size",
-        type=int,
-        default=2,
-        help="Min bundle size to include in synthesis plan.",
-    )
-    parser.add_argument(
-        "--synthesis-allow-singletons",
-        action="store_true",
-        help="Allow single-field bundles in synthesis plan.",
-    )
+    add_argparse_option(parser, SHARED_OPTION_SPECS["synthesis_protocols_kind"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["synthesis_max_tier"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["synthesis_min_bundle_size"])
+    add_argparse_option(parser, SHARED_OPTION_SPECS["synthesis_allow_singletons"])
     parser.add_argument(
         "--synthesis-merge-overlap",
         type=float,
         default=None,
         help="Jaccard overlap threshold for merging bundles (0.0-1.0).",
     )
-    parser.add_argument(
-        "--refactor-plan",
-        action="store_true",
-        help="Include refactoring plan summary in the markdown report.",
-    )
+    add_argparse_option(parser, SHARED_OPTION_SPECS["refactor_plan"])
     parser.add_argument(
         "--refactor-plan-json",
         default=None,

--- a/src/gabion/cli_support/synth/synth_commands.py
+++ b/src/gabion/cli_support/synth/synth_commands.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
 import typer
 
+from gabion.cli_support.shared.option_schema import SHARED_OPTION_SPECS, typer_option
 from gabion.json_types import JSONObject
 
 DataflowFilterBundleCtor = Callable[..., object]
@@ -27,71 +28,52 @@ def register_synth_command(
     @app.command("synth")
     def synth(
         paths: list[Path] = typer.Argument(None),
-        root: Path = typer.Option(Path("."), "--root"),
+        root: Path = typer_option(SHARED_OPTION_SPECS["root"]),
         out_dir: Path = typer.Option(Path("artifacts/synthesis"), "--out-dir"),
         no_timestamp: bool = typer.Option(False, "--no-timestamp"),
-        config: Path | None = typer.Option(None, "--config"),
-        exclude: list[str] | None = typer.Option(None, "--exclude"),
-        ignore_params_csv: str | None = typer.Option(None, "--ignore-params"),
-        transparent_decorators_csv: str | None = typer.Option(
-            None,
-            "--transparent-decorators",
+        config: Path | None = typer_option(SHARED_OPTION_SPECS["config"]),
+        exclude: list[str] | None = typer_option(SHARED_OPTION_SPECS["exclude"]),
+        ignore_params_csv: str | None = typer_option(SHARED_OPTION_SPECS["ignore_params"]),
+        transparent_decorators_csv: str | None = typer_option(
+            SHARED_OPTION_SPECS["transparent_decorators"]
         ),
-        allow_external: bool | None = typer.Option(
-            None,
-            "--allow-external/--no-allow-external",
-        ),
-        strictness: str | None = typer.Option(None, "--strictness"),
-        no_recursive: bool = typer.Option(False, "--no-recursive"),
-        max_components: int = typer.Option(10, "--max-components"),
+        allow_external: bool | None = typer_option(SHARED_OPTION_SPECS["allow_external"]),
+        strictness: Literal["high", "low"] | None = typer_option(SHARED_OPTION_SPECS["strictness"]),
+        no_recursive: bool = typer_option(SHARED_OPTION_SPECS["no_recursive"]),
+        max_components: int = typer_option(SHARED_OPTION_SPECS["max_components"]),
         type_audit_report: bool = typer.Option(
             True,
             "--type-audit-report/--no-type-audit-report",
         ),
-        type_audit_max: int = typer.Option(50, "--type-audit-max"),
-        synthesis_max_tier: int = typer.Option(2, "--synthesis-max-tier"),
-        synthesis_min_bundle_size: int = typer.Option(2, "--synthesis-min-bundle-size"),
-        synthesis_allow_singletons: bool = typer.Option(
-            False,
-            "--synthesis-allow-singletons",
+        type_audit_max: int = typer_option(SHARED_OPTION_SPECS["type_audit_max"]),
+        synthesis_max_tier: int = typer_option(SHARED_OPTION_SPECS["synthesis_max_tier"]),
+        synthesis_min_bundle_size: int = typer_option(
+            SHARED_OPTION_SPECS["synthesis_min_bundle_size"]
         ),
-        synthesis_protocols_kind: str = typer.Option(
-            "dataclass",
-            "--synthesis-protocols-kind",
+        synthesis_allow_singletons: bool = typer_option(
+            SHARED_OPTION_SPECS["synthesis_allow_singletons"]
+        ),
+        synthesis_protocols_kind: Literal["dataclass", "protocol", "contextvar"] = typer_option(
+            SHARED_OPTION_SPECS["synthesis_protocols_kind"]
         ),
         refactor_plan: bool = typer.Option(True, "--refactor-plan/--no-refactor-plan"),
         fail_on_violations: bool = typer.Option(
             False,
             "--fail-on-violations/--no-fail-on-violations",
         ),
-        aspf_trace_json: Path | None = typer.Option(None, "--aspf-trace-json"),
-        aspf_import_trace: list[Path] | None = typer.Option(
-            None,
-            "--aspf-import-trace",
+        aspf_trace_json: Path | None = typer_option(SHARED_OPTION_SPECS["aspf_trace_json"]),
+        aspf_import_trace: list[Path] | None = typer_option(SHARED_OPTION_SPECS["aspf_import_trace"]),
+        aspf_equivalence_against: list[Path] | None = typer_option(
+            SHARED_OPTION_SPECS["aspf_equivalence_against"]
         ),
-        aspf_equivalence_against: list[Path] | None = typer.Option(
-            None,
-            "--aspf-equivalence-against",
+        aspf_opportunities_json: Path | None = typer_option(
+            SHARED_OPTION_SPECS["aspf_opportunities_json"]
         ),
-        aspf_opportunities_json: Path | None = typer.Option(
-            None,
-            "--aspf-opportunities-json",
-        ),
-        aspf_state_json: Path | None = typer.Option(
-            None,
-            "--aspf-state-json",
-        ),
-        aspf_delta_jsonl: Path | None = typer.Option(
-            None,
-            "--aspf-delta-jsonl",
-        ),
-        aspf_import_state: list[Path] | None = typer.Option(
-            None,
-            "--aspf-import-state",
-        ),
-        aspf_semantic_surface: list[str] | None = typer.Option(
-            None,
-            "--aspf-semantic-surface",
+        aspf_state_json: Path | None = typer_option(SHARED_OPTION_SPECS["aspf_state_json"]),
+        aspf_delta_jsonl: Path | None = typer_option(SHARED_OPTION_SPECS["aspf_delta_jsonl"]),
+        aspf_import_state: list[Path] | None = typer_option(SHARED_OPTION_SPECS["aspf_import_state"]),
+        aspf_semantic_surface: list[str] | None = typer_option(
+            SHARED_OPTION_SPECS["aspf_semantic_surface"]
         ),
     ) -> None:
         """Run the dataflow audit and emit synthesis outputs (prototype)."""

--- a/tests/gabion/cli/cli_option_surface_contract_cases.py
+++ b/tests/gabion/cli/cli_option_surface_contract_cases.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from typer.main import get_command
+
+from gabion import cli
+from gabion.cli_support.shared.option_schema import (
+    INTENDED_OPTION_OVERLAP_KEYS,
+    OPTION_SURFACE_DIVERGENCES,
+    SHARED_OPTION_SPECS,
+    OptionMultiplicity,
+)
+from gabion.cli_support.shared.parser_builder import dataflow_cli_parser
+
+
+@dataclass(frozen=True)
+class OptionFingerprint:
+    multiplicity: str
+    default: str
+    has_negative_flag: bool
+    choices: tuple[str, ...]
+
+
+def _normalize_default(value: Any) -> str:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    return repr(value)
+
+
+def _normalize_argparse_inventory() -> Mapping[str, OptionFingerprint]:
+    parser = dataflow_cli_parser()
+    inventory: dict[str, OptionFingerprint] = {}
+    for key in INTENDED_OPTION_OVERLAP_KEYS:
+        spec = SHARED_OPTION_SPECS[key]
+        action = parser._option_string_actions[spec.flag]
+        if isinstance(action, argparse._AppendAction):
+            multiplicity = OptionMultiplicity.APPEND.value
+        elif isinstance(action, argparse.BooleanOptionalAction):
+            multiplicity = OptionMultiplicity.BOOL_OPTIONAL.value
+        elif isinstance(action, argparse._StoreTrueAction):
+            multiplicity = OptionMultiplicity.FLAG.value
+        else:
+            multiplicity = OptionMultiplicity.SINGLE.value
+        inventory[key] = OptionFingerprint(
+            multiplicity=multiplicity,
+            default=_normalize_default(action.default),
+            has_negative_flag=f"--no-{spec.flag[2:]}" in parser._option_string_actions,
+            choices=tuple(action.choices or ()),
+        )
+    return inventory
+
+
+def _normalize_typer_inventory() -> Mapping[str, OptionFingerprint]:
+    app = get_command(cli.app)
+    synth = app.commands["synth"]
+    by_flag: dict[str, Any] = {}
+    for param in synth.params:
+        for flag in param.opts:
+            by_flag[flag] = param
+
+    inventory: dict[str, OptionFingerprint] = {}
+    for key in INTENDED_OPTION_OVERLAP_KEYS:
+        spec = SHARED_OPTION_SPECS[key]
+        param = by_flag[spec.flag]
+        if param.secondary_opts:
+            multiplicity = OptionMultiplicity.BOOL_OPTIONAL.value
+        elif param.multiple:
+            multiplicity = OptionMultiplicity.APPEND.value
+        elif param.is_flag:
+            multiplicity = OptionMultiplicity.FLAG.value
+        else:
+            multiplicity = OptionMultiplicity.SINGLE.value
+        choices: tuple[str, ...] = ()
+        choice_values = getattr(param.type, "choices", None)
+        if choice_values is not None:
+            choices = tuple(choice_values)
+        inventory[key] = OptionFingerprint(
+            multiplicity=multiplicity,
+            default=_normalize_default(param.default),
+            has_negative_flag=bool(param.secondary_opts),
+            choices=choices,
+        )
+    return inventory
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_option_surface_contract.py::test_raw_and_typer_option_overlap_contract::parser_builder.py::gabion.cli_support.shared.parser_builder.dataflow_cli_parser::synth_commands.py::gabion.cli_support.synth.synth_commands.register_synth_command
+
+def test_raw_and_typer_option_overlap_contract() -> None:
+    raw_inventory = _normalize_argparse_inventory()
+    typer_inventory = _normalize_typer_inventory()
+
+    observed_divergences: set[str] = set()
+    for key in INTENDED_OPTION_OVERLAP_KEYS:
+        assert raw_inventory[key].choices == typer_inventory[key].choices
+        if raw_inventory[key] == typer_inventory[key]:
+            continue
+        observed_divergences.add(key)
+        assert key in OPTION_SURFACE_DIVERGENCES
+
+    assert observed_divergences == set(OPTION_SURFACE_DIVERGENCES)


### PR DESCRIPTION
### Motivation
- Reduce duplicated flag literals across the raw `argparse` parser and the `Typer` synth command by centralizing option metadata in a typed schema so both surfaces can be kept in sync.
- Make surface differences explicit and auditable by moving parser-specific binding details into small adapter functions and documenting intentional divergences in one place.
- Provide a machine-checkable contract so tests can detect accidental drift between raw and Typer option surfaces.

### Description
- Add a shared option schema module `src/gabion/cli_support/shared/option_schema.py` introducing `OptionSpec`, `OptionType`, `OptionMultiplicity`, `add_argparse_option(...)`, and `typer_option(...)`, plus `INTENDED_OPTION_OVERLAP_KEYS` and `OPTION_SURFACE_DIVERGENCES` to record intentional differences.
- Refactor `dataflow_cli_parser()` in `src/gabion/cli_support/shared/parser_builder.py` to call `add_argparse_option(...)` for the intended-overlap flags, preserving parser-local-only flags inline.
- Refactor `register_synth_command()` in `src/gabion/cli_support/synth/synth_commands.py` to consume the same shared specs via `typer_option(...)`, keeping Typer-specific toggles at the binding layer.
- Add a contract test `tests/gabion/cli/cli_option_surface_contract_cases.py` that normalizes option inventories from the raw-profile parser and the Typer `synth` command and asserts any differences are documented in `OPTION_SURFACE_DIVERGENCES`.
- Minor binding detail: convert `Path` defaults to strings for `argparse` defaults inside the adapter so defaults render consistently for the raw parser.

### Testing
- Ran the focused contract test with `PYTHONPATH=src pytest -q -o addopts='' tests/gabion/cli/cli_option_surface_contract_cases.py` and it passed (`1 passed`).
- Exercised synth-related CLI tests with `PYTHONPATH=src pytest -q -o addopts='' tests/gabion/cli/cli_commands_cases.py -k 'synth_invalid_strictness or synth_invalid_protocols_kind'` and the selected checks passed (`2 passed, 23 deselected`).
- Ran policy checks `PYTHONPATH=src:. python scripts/policy/policy_check.py --workflows` and `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` and both completed successfully in this environment.
- Ran linter checks with `python -m ruff check ...` over the modified files and they passed; and ran `python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` to refresh `out/test_evidence.json` which updated the new test evidence mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8305301f48324aa81355f119be3bf)