### PR TITLE
Unify CLI output emission with canonical dataflow normalization

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -83,6 +83,7 @@ from gabion.tooling.docflow import (
     docflow_delta_emit as tooling_docflow_delta_emit)
 from gabion.tooling.governance import (
     governance_audit as tooling_governance_audit, ambiguity_contract_policy_check as tooling_ambiguity_contract_policy_check, normative_symdiff as tooling_normative_symdiff)
+from gabion.server_core import command_orchestrator_primitives
 from gabion.tooling.impact import (
     impact_select_tests as tooling_impact_select_tests)
 from gabion.json_types import JSONObject
@@ -866,6 +867,7 @@ def _emit_dataflow_result_outputs(result: JSONObject, opts: argparse.Namespace) 
         emit_result_json_to_stdout_fn=_emit_result_json_to_stdout,
         stdout_path=_STDOUT_PATH,
         check_deadline_fn=check_deadline,
+        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
     )
 
 

--- a/src/gabion/cli_support/shared/output_emitters.py
+++ b/src/gabion/cli_support/shared/output_emitters.py
@@ -10,7 +10,6 @@ from typing import Callable
 import typer
 
 from gabion.json_types import JSONObject
-from gabion.schema import LegacyDataflowMonolithResponseDTO
 
 DeadlineScopeFactory = Callable[[], AbstractContextManager[object]]
 EmitLintOutputsFn = Callable[..., None]
@@ -19,6 +18,7 @@ WriteTextToTargetFn = Callable[..., None]
 EmitResultJsonToStdoutFn = Callable[..., None]
 CheckDeadlineFn = Callable[[], None]
 SortOnceFn = Callable[..., list[str]]
+NormalizeDataflowResponseFn = Callable[[JSONObject], dict[str, object]]
 
 
 def emit_dataflow_result_outputs(
@@ -32,19 +32,10 @@ def emit_dataflow_result_outputs(
     emit_result_json_to_stdout_fn: EmitResultJsonToStdoutFn,
     stdout_path: str,
     check_deadline_fn: CheckDeadlineFn,
+    normalize_dataflow_response_fn: NormalizeDataflowResponseFn,
 ) -> None:
     with cli_deadline_scope_factory():
-        normalized_result = LegacyDataflowMonolithResponseDTO.model_validate(
-            {
-                "exit_code": int(result.get("exit_code", 0) or 0),
-                "timeout": bool(result.get("timeout", False)),
-                "analysis_state": result.get("analysis_state"),
-                "errors": result.get("errors") or [],
-                "lint_lines": result.get("lint_lines") or [],
-                "lint_entries": result.get("lint_entries") or [],
-                "payload": result,
-            }
-        ).model_dump()
+        normalized_result = normalize_dataflow_response_fn(result)
         lint_lines = normalized_result.get("lint_lines", []) or []
         lint_entries_raw = normalized_result.get("lint_entries")
         lint_entries = lint_entries_raw if isinstance(lint_entries_raw, list) else None
@@ -56,8 +47,8 @@ def emit_dataflow_result_outputs(
             lint_entries=lint_entries,
         )
         if opts.type_audit:
-            suggestions = result.get("type_suggestions", [])
-            ambiguities = result.get("type_ambiguities", [])
+            suggestions = normalized_result.get("type_suggestions", [])
+            ambiguities = normalized_result.get("type_ambiguities", [])
             if suggestions:
                 typer.echo("Type tightening candidates:")
                 for line in suggestions[: opts.type_audit_max]:
@@ -68,77 +59,77 @@ def emit_dataflow_result_outputs(
                 for line in ambiguities[: opts.type_audit_max]:
                     check_deadline_fn()
                     typer.echo(f"- {line}")
-        if is_stdout_target_fn(opts.dot) and "dot" in result:
+        if is_stdout_target_fn(opts.dot) and "dot" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                str(result["dot"]),
+                str(normalized_result["dot"]),
                 ensure_trailing_newline=True,
             )
-        if is_stdout_target_fn(opts.synthesis_plan) and "synthesis_plan" in result:
+        if is_stdout_target_fn(opts.synthesis_plan) and "synthesis_plan" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["synthesis_plan"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["synthesis_plan"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
-        if is_stdout_target_fn(opts.synthesis_protocols) and "synthesis_protocols" in result:
+        if is_stdout_target_fn(opts.synthesis_protocols) and "synthesis_protocols" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                str(result["synthesis_protocols"]),
+                str(normalized_result["synthesis_protocols"]),
                 ensure_trailing_newline=True,
             )
-        if is_stdout_target_fn(opts.refactor_plan_json) and "refactor_plan" in result:
+        if is_stdout_target_fn(opts.refactor_plan_json) and "refactor_plan" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["refactor_plan"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["refactor_plan"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
         if (
             is_stdout_target_fn(opts.fingerprint_synth_json)
-            and "fingerprint_synth_registry" in result
+            and "fingerprint_synth_registry" in normalized_result
         ):
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_synth_registry"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_synth_registry"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
         if (
             is_stdout_target_fn(opts.fingerprint_provenance_json)
-            and "fingerprint_provenance" in result
+            and "fingerprint_provenance" in normalized_result
         ):
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_provenance"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_provenance"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
-        if is_stdout_target_fn(opts.fingerprint_deadness_json) and "fingerprint_deadness" in result:
+        if is_stdout_target_fn(opts.fingerprint_deadness_json) and "fingerprint_deadness" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_deadness"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_deadness"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
-        if is_stdout_target_fn(opts.fingerprint_coherence_json) and "fingerprint_coherence" in result:
+        if is_stdout_target_fn(opts.fingerprint_coherence_json) and "fingerprint_coherence" in normalized_result:
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_coherence"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_coherence"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
         if (
             is_stdout_target_fn(opts.fingerprint_rewrite_plans_json)
-            and "fingerprint_rewrite_plans" in result
+            and "fingerprint_rewrite_plans" in normalized_result
         ):
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_rewrite_plans"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_rewrite_plans"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
         if (
             is_stdout_target_fn(opts.fingerprint_exception_obligations_json)
-            and "fingerprint_exception_obligations" in result
+            and "fingerprint_exception_obligations" in normalized_result
         ):
             write_text_to_target_fn(
                 stdout_path,
                 json.dumps(
-                    result["fingerprint_exception_obligations"],
+                    normalized_result["fingerprint_exception_obligations"],
                     indent=2,
                     sort_keys=False,
                 ),
@@ -146,11 +137,11 @@ def emit_dataflow_result_outputs(
             )
         if (
             is_stdout_target_fn(opts.fingerprint_handledness_json)
-            and "fingerprint_handledness" in result
+            and "fingerprint_handledness" in normalized_result
         ):
             write_text_to_target_fn(
                 stdout_path,
-                json.dumps(result["fingerprint_handledness"], indent=2, sort_keys=False),
+                json.dumps(normalized_result["fingerprint_handledness"], indent=2, sort_keys=False),
                 ensure_trailing_newline=True,
             )
         stdout_json_targets = (
@@ -163,8 +154,8 @@ def emit_dataflow_result_outputs(
             (opts.aspf_state_json, "aspf_state"),
         )
         for output_target, result_key in stdout_json_targets:
-            if result_key in result and is_stdout_target_fn(output_target):
-                emit_result_json_to_stdout_fn(payload=result[result_key])
+            if result_key in normalized_result and is_stdout_target_fn(output_target):
+                emit_result_json_to_stdout_fn(payload=normalized_result[result_key])
 
 
 def write_lint_sarif(

--- a/tests/gabion/cli/cli_output_emitters_cases.py
+++ b/tests/gabion/cli/cli_output_emitters_cases.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from typing import Any
+
+from gabion.cli_support.shared.output_emitters import emit_dataflow_result_outputs
+from gabion.server_core import command_orchestrator_primitives
+
+
+def _opts(**overrides: Any) -> argparse.Namespace:
+    defaults: dict[str, Any] = {
+        "lint": None,
+        "lint_jsonl": None,
+        "lint_sarif": None,
+        "type_audit": False,
+        "type_audit_max": 10,
+        "dot": None,
+        "synthesis_plan": None,
+        "synthesis_protocols": None,
+        "refactor_plan_json": None,
+        "fingerprint_synth_json": None,
+        "fingerprint_provenance_json": None,
+        "fingerprint_deadness_json": None,
+        "fingerprint_coherence_json": None,
+        "fingerprint_rewrite_plans_json": None,
+        "fingerprint_exception_obligations_json": None,
+        "fingerprint_handledness_json": None,
+        "emit_structure_tree": None,
+        "emit_structure_metrics": None,
+        "emit_decision_snapshot": None,
+        "aspf_trace_json": None,
+        "aspf_opportunities_json": None,
+        "aspf_state_json": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_emit_dataflow_outputs_uses_canonical_lint_entry_normalization() -> None:
+    captured: dict[str, object] = {}
+
+    def _capture_lint(
+        _lint_lines: list[str], *, lint: object, lint_jsonl: object, lint_sarif: object, lint_entries: object
+    ) -> None:
+        captured["lint_entries"] = lint_entries
+
+    emit_dataflow_result_outputs(
+        {
+            "exit_code": 0,
+            "lint_lines": ["pkg/mod.py:1:2: DF001 bad"],
+            "lint_entries": "malformed",
+        },
+        _opts(),
+        cli_deadline_scope_factory=lambda: nullcontext(),
+        emit_lint_outputs_fn=_capture_lint,
+        is_stdout_target_fn=lambda _target: False,
+        write_text_to_target_fn=lambda *_args, **_kwargs: None,
+        emit_result_json_to_stdout_fn=lambda **_kwargs: None,
+        stdout_path="-",
+        check_deadline_fn=lambda: None,
+        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
+    )
+
+    lint_entries = captured["lint_entries"]
+    assert isinstance(lint_entries, list)
+    assert lint_entries[0]["code"] == "DF001"
+
+
+def test_emit_dataflow_outputs_respects_canonical_aspf_presence_rules() -> None:
+    emitted: list[object] = []
+
+    emit_dataflow_result_outputs(
+        {
+            "exit_code": 0,
+            "aspf_trace": {
+                "format_version": 2,
+                "trace_id": "aspf-trace:abc123",
+                "started_at_utc": "2026-02-25T00:00:00+00:00",
+                "controls": {},
+                "one_cells": [],
+                "two_cell_witnesses": [],
+                "cofibration_witnesses": [],
+                "surface_representatives": {},
+                "imported_trace_count": 0,
+            },
+            "aspf_opportunities": "malformed",
+        },
+        _opts(aspf_trace_json="-", aspf_opportunities_json="-", aspf_state_json="-"),
+        cli_deadline_scope_factory=lambda: nullcontext(),
+        emit_lint_outputs_fn=lambda *_args, **_kwargs: None,
+        is_stdout_target_fn=lambda target: target == "-",
+        write_text_to_target_fn=lambda *_args, **_kwargs: None,
+        emit_result_json_to_stdout_fn=lambda *, payload: emitted.append(payload),
+        stdout_path="-",
+        check_deadline_fn=lambda: None,
+        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
+    )
+
+    assert any(isinstance(payload, dict) and payload.get("trace_id") == "aspf-trace:abc123" for payload in emitted)
+    assert "malformed" in emitted
+    assert all(not (isinstance(payload, dict) and "aspf_state" in payload) for payload in emitted)
+
+
+def test_emit_dataflow_outputs_uses_canonical_capability_field_normalization() -> None:
+    captured: dict[str, object] = {}
+
+    def _normalize(response: dict[str, object]) -> dict[str, object]:
+        normalized = command_orchestrator_primitives._normalize_dataflow_response(response)
+        captured["normalized"] = normalized
+        return normalized
+
+    emit_dataflow_result_outputs(
+        {
+            "exit_code": 0,
+            "selected_adapter": 7,
+            "supported_analysis_surfaces": "malformed",
+            "disabled_surface_reasons": ["malformed"],
+        },
+        _opts(),
+        cli_deadline_scope_factory=lambda: nullcontext(),
+        emit_lint_outputs_fn=lambda *_args, **_kwargs: None,
+        is_stdout_target_fn=lambda _target: False,
+        write_text_to_target_fn=lambda *_args, **_kwargs: None,
+        emit_result_json_to_stdout_fn=lambda **_kwargs: None,
+        stdout_path="-",
+        check_deadline_fn=lambda: None,
+        normalize_dataflow_response_fn=_normalize,
+    )
+
+    normalized = captured["normalized"]
+    assert normalized["selected_adapter"] == "7"
+    assert normalized["supported_analysis_surfaces"] == []
+    assert normalized["disabled_surface_reasons"] == {}


### PR DESCRIPTION
### Motivation
- Ensure the CLI emits dataflow outputs using the same canonical normalization semantics used by the server to avoid parity bugs and duplicate normalization logic.  
- Reduce subtle inconsistencies caused by mixing raw `result` reads with ad-hoc normalization in the CLI emitter.  
- Make the normalization boundary explicit and injectable so the emitter can be reused and tested deterministically.

### Description
- Injected a normalization callable dependency `normalize_dataflow_response_fn` into `emit_dataflow_result_outputs` and switched all downstream reads to the single normalized mapping.  
- Wired the CLI to pass the server canonical normalizer `command_orchestrator_primitives._normalize_dataflow_response` into the shared emitter by default (`src/gabion/cli.py`).  
- Added regression tests in `tests/gabion/cli/cli_output_emitters_cases.py` that validate lint entry normalization, ASPF artifact emission rules, and capability-field normalization parity; refreshed `out/test_evidence.json` to reflect the new tests.

### Testing
- Ran the ambiguity/workflows policy checks with `scripts/policy/policy_check.py --workflows` and `--ambiguity-contract`, and both checks completed successfully.  
- Ran the new targeted pytest file with `python -m pytest -o addopts='' tests/gabion/cli/cli_output_emitters_cases.py` and the suite passed (`3 passed`).  
- Refreshed evidence with `python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to include the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88641ed148324a0a2c6286bd58b30)