### PR TITLE
Extract shared forest signature metadata helper for dataflow IO callsites

### DIFF
--- a/docs/aspf_taint_isomorphism_no_change.yaml
+++ b/docs/aspf_taint_isomorphism_no_change.yaml
@@ -12,6 +12,7 @@ in_steps:
   - in-38
   - in-54
   - in-55
+  - in-56
   - in-36
   - in-59
   - in-57
@@ -22,6 +23,7 @@ justification: marker protocol generalization now classifies todo/deprecated mar
 # CU: ambiguity-boundary marker classification for dataflow_function_index_helpers is policy-surface only; ASPF taint crosswalk identities unchanged.
 # CU: canonical event algebra phase-2 adds foundation envelope/codec and adapter-only ASPF/dataflow mappings without modifying ASPF taint crosswalk identifiers or in-step obligations.
 # CU: identity shadow runtime + dataflow progress sidecar emission are additive telemetry carriers and do not change ASPF/taint identifier anchors or mapped in-step obligations.
+# CU: forest-signature metadata helper extraction in dataflow io centralizes existing key-projection logic without changing ASPF marker anchors, taint crosswalk IDs, or in-step obligations.
 # CU: canonical progress v2 dual-publish and bit-lowered integer-anchor tokenization are transport/identity-carrier refinements only and do not alter ASPF taint crosswalk identifiers or in-step obligations.
 # CU: legacy fast integer carrier removal and progress token alias-default cutover preserve ASPF taint crosswalk identifier anchors and mapped in-step obligations.
 # CU: IDR-001 stage-2 hard cut removes progress-v1 transport and parser ingress from src/gabion while preserving ASPF taint crosswalk identifiers and mapped in-step obligations.

--- a/src/gabion/analysis/dataflow/io/dataflow_snapshot_io.py
+++ b/src/gabion/analysis/dataflow/io/dataflow_snapshot_io.py
@@ -13,6 +13,9 @@ from gabion.analysis.aspf.aspf import Forest
 from gabion.analysis.foundation.baseline_io import load_json
 from gabion.analysis.dataflow.engine.dataflow_contracts import InvariantProposition
 from gabion.analysis.dataflow.io.dataflow_parse_helpers import _forbid_adhoc_bundle_discovery
+from gabion.analysis.dataflow.io.forest_signature_metadata import (
+    apply_forest_signature_metadata,
+)
 from gabion.analysis.dataflow.io.dataflow_snapshot_contracts import (
     DecisionSnapshotSurfaces, StructureSnapshotDiffRequest)
 from gabion.analysis.projection.decision_flow import (
@@ -147,27 +150,6 @@ def compute_structure_metrics(
     }
     metrics["forest_signature"] = build_forest_signature(forest)
     return metrics
-
-
-def _copy_forest_signature_metadata(
-    payload: JSONObject,
-    snapshot: JSONObject,
-    *,
-    prefix: str = "",
-) -> None:
-    signature = snapshot.get("forest_signature")
-    if signature is not None:
-        payload[f"{prefix}forest_signature"] = signature
-    partial = snapshot.get("forest_signature_partial")
-    if partial is not None:
-        payload[f"{prefix}forest_signature_partial"] = partial
-    basis = snapshot.get("forest_signature_basis")
-    if basis is not None:
-        payload[f"{prefix}forest_signature_basis"] = basis
-    if signature is None:
-        payload[f"{prefix}forest_signature_partial"] = True
-        if basis is None:
-            payload[f"{prefix}forest_signature_basis"] = "missing"
 
 
 def render_structure_snapshot(
@@ -356,8 +338,8 @@ def diff_decision_snapshots(
             ),
         },
     }
-    _copy_forest_signature_metadata(diff, baseline_snapshot, prefix="baseline_")
-    _copy_forest_signature_metadata(diff, current_snapshot, prefix="current_")
+    apply_forest_signature_metadata(diff, baseline_snapshot, prefix="baseline_")
+    apply_forest_signature_metadata(diff, current_snapshot, prefix="current_")
     return diff
 
 
@@ -434,8 +416,8 @@ def diff_structure_snapshots(
             "current_total": sum(current_counts.values()),
         },
     }
-    _copy_forest_signature_metadata(diff, baseline_snapshot, prefix="baseline_")
-    _copy_forest_signature_metadata(diff, current_snapshot, prefix="current_")
+    apply_forest_signature_metadata(diff, baseline_snapshot, prefix="baseline_")
+    apply_forest_signature_metadata(diff, current_snapshot, prefix="current_")
     return diff
 
 

--- a/src/gabion/analysis/dataflow/io/dataflow_structure_reuse.py
+++ b/src/gabion/analysis/dataflow/io/dataflow_structure_reuse.py
@@ -19,6 +19,7 @@ from gabion.analysis.dataflow.io.dataflow_synthesis_runtime_bridge import (
     _collect_dataclass_registry,
 )
 from gabion.analysis.foundation.json_types import JSONObject
+from gabion.analysis.dataflow.io.forest_signature_metadata import apply_forest_signature_metadata
 from gabion.analysis.foundation.resume_codec import mapping_or_empty, mapping_or_none, sequence_or_none
 from gabion.analysis.core.structure_reuse_classes import build_structure_class, structure_class_payload
 from gabion.analysis.foundation.timeout_context import check_deadline
@@ -396,7 +397,7 @@ def compute_structure_reuse(
         "replacement_map": replacement_map,
         "warnings": warnings,
     }
-    _copy_forest_signature_metadata(reuse_payload, snapshot)
+    apply_forest_signature_metadata(reuse_payload, snapshot)
     return reuse_payload
 
 
@@ -506,23 +507,3 @@ def _bundle_name_registry(root: Path) -> dict[tuple[str, ...], set[str]]:
         name_map[key].add(str(qual_name).split(".")[-1])
     return name_map
 
-
-def _copy_forest_signature_metadata(
-    payload: JSONObject,
-    snapshot: JSONObject,
-    *,
-    prefix: str = "",
-) -> None:
-    signature = snapshot.get("forest_signature")
-    if signature is not None:
-        payload[f"{prefix}forest_signature"] = signature
-    partial = snapshot.get("forest_signature_partial")
-    if partial is not None:
-        payload[f"{prefix}forest_signature_partial"] = partial
-    basis = snapshot.get("forest_signature_basis")
-    if basis is not None:
-        payload[f"{prefix}forest_signature_basis"] = basis
-    if signature is None:
-        payload[f"{prefix}forest_signature_partial"] = True
-        if basis is None:
-            payload[f"{prefix}forest_signature_basis"] = "missing"

--- a/src/gabion/analysis/dataflow/io/forest_signature_metadata.py
+++ b/src/gabion/analysis/dataflow/io/forest_signature_metadata.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from gabion.analysis.foundation.json_types import JSONObject
+
+
+def apply_forest_signature_metadata(
+    payload: JSONObject,
+    snapshot: JSONObject,
+    *,
+    prefix: str = "",
+) -> None:
+    signature = snapshot.get("forest_signature")
+    if signature is not None:
+        payload[f"{prefix}forest_signature"] = signature
+    partial = snapshot.get("forest_signature_partial")
+    if partial is not None:
+        payload[f"{prefix}forest_signature_partial"] = partial
+    basis = snapshot.get("forest_signature_basis")
+    if basis is not None:
+        payload[f"{prefix}forest_signature_basis"] = basis
+    if signature is None:
+        payload[f"{prefix}forest_signature_partial"] = True
+        if basis is None:
+            payload[f"{prefix}forest_signature_basis"] = "missing"

--- a/tests/gabion/analysis/dataflow_s2/test_forest_signature_metadata.py
+++ b/tests/gabion/analysis/dataflow_s2/test_forest_signature_metadata.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from gabion.analysis.dataflow.io import dataflow_snapshot_io, dataflow_structure_reuse
+from gabion.analysis.dataflow.io.forest_signature_metadata import (
+    apply_forest_signature_metadata,
+)
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "prefix", "expected"),
+    [
+        (
+            {
+                "forest_signature": "sig",
+                "forest_signature_partial": False,
+                "forest_signature_basis": "exact",
+            },
+            "",
+            {
+                "forest_signature": "sig",
+                "forest_signature_partial": False,
+                "forest_signature_basis": "exact",
+            },
+        ),
+        (
+            {
+                "forest_signature_partial": False,
+                "forest_signature_basis": "fallback",
+            },
+            "",
+            {
+                "forest_signature_partial": True,
+                "forest_signature_basis": "fallback",
+            },
+        ),
+        (
+            {},
+            "",
+            {
+                "forest_signature_partial": True,
+                "forest_signature_basis": "missing",
+            },
+        ),
+        (
+            {"forest_signature": "sig", "forest_signature_basis": "exact"},
+            "baseline_",
+            {
+                "baseline_forest_signature": "sig",
+                "baseline_forest_signature_basis": "exact",
+            },
+        ),
+    ],
+)
+def test_apply_forest_signature_metadata_cases(
+    snapshot: dict[str, object],
+    prefix: str,
+    expected: dict[str, object],
+) -> None:
+    payload: dict[str, object] = {}
+    apply_forest_signature_metadata(payload, snapshot, prefix=prefix)
+    assert payload == expected
+
+
+def test_snapshot_and_reuse_modules_share_helper_behavior() -> None:
+    snapshot = {"forest_signature_basis": "observed"}
+
+    from_snapshot_module: dict[str, object] = {}
+    dataflow_snapshot_io.apply_forest_signature_metadata(
+        from_snapshot_module,
+        snapshot,
+        prefix="current_",
+    )
+
+    from_reuse_module: dict[str, object] = {}
+    dataflow_structure_reuse.apply_forest_signature_metadata(
+        from_reuse_module,
+        snapshot,
+        prefix="current_",
+    )
+
+    expected = {
+        "current_forest_signature_partial": True,
+        "current_forest_signature_basis": "observed",
+    }
+    assert from_snapshot_module == expected
+    assert from_reuse_module == expected


### PR DESCRIPTION
### Motivation
- Consolidate duplicated projection logic for `forest_signature`, `forest_signature_partial`, and `forest_signature_basis` into a single boundary helper to ensure consistent behavior across dataflow IO callsites. 
- Reduce code duplication in snapshot and reuse paths and make the prefixed key projection and fallback semantics explicit and reusable.

### Description
- Added `apply_forest_signature_metadata` in `src/gabion/analysis/dataflow/io/forest_signature_metadata.py` to project `forest_signature`, `forest_signature_partial`, and `forest_signature_basis` and to enforce the existing fallback rule (when signature is missing set `partial=True` and `basis="missing"`).
- Updated `src/gabion/analysis/dataflow/io/dataflow_snapshot_io.py` to import and use `apply_forest_signature_metadata` at both diff callsites (baseline/current) in place of duplicated logic.
- Updated `src/gabion/analysis/dataflow/io/dataflow_structure_reuse.py` to import and use `apply_forest_signature_metadata` for reuse payload projection and removed the local duplicate implementation.
- Added unit tests in `tests/gabion/analysis/dataflow_s2/test_forest_signature_metadata.py` that cover: signature present, signature missing + basis present, signature missing + basis missing (forces partial + "missing" basis), prefixed key projection, and behavioral equivalence when invoked via both modules.
- Updated repository policy/evidence artifacts to reflect the change surface required by policy checks (`docs/aspf_taint_isomorphism_no_change.yaml` and `out/test_evidence.json`).

### Testing
- Ran the repository policy workflows with `python -m scripts.policy.policy_check --workflows` and the ambiguity contract with `python -m scripts.policy.policy_check --ambiguity-contract`, both completed successfully.
- Executed the targeted pytest run with `pytest -o addopts='' tests/gabion/analysis/structure/test_structure_diff.py tests/gabion/analysis/dataflow_s2/dataflow_structure_reuse_cases.py tests/gabion/analysis/dataflow_s2/test_forest_signature_metadata.py`, and all tests passed (15 passed).
- Ran the test-evidence extraction with `python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`; the extraction completed and produced updated evidence entries for the new tests (artifact intentionally updated to reflect added tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8863c85fc8324920ba1a5c5fa7c4c)