### PR TITLE
Unify stdout target normalization/checking in shared runtime policy

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -574,7 +574,7 @@ def _collect_lint_entries(lines: list[str]) -> list[dict[str, object]]:
 
 
 def _normalize_output_target(target: str | Path) -> str:
-    return dataflow_runtime_common.normalize_output_target(
+    return path_policy.normalize_output_target(
         target,
         stdout_alias=_STDOUT_ALIAS,
         stdout_path=_STDOUT_PATH,
@@ -582,9 +582,11 @@ def _normalize_output_target(target: str | Path) -> str:
 
 
 def _is_stdout_target(target: object) -> bool:
-    if target is None:
-        return False
-    return _normalize_output_target(str(target)) == _STDOUT_PATH
+    return path_policy.is_stdout_target(
+        target,
+        stdout_alias=_STDOUT_ALIAS,
+        stdout_path=_STDOUT_PATH,
+    )
 
 
 class _TargetStreamRouter:

--- a/src/gabion/cli_support/shared/dataflow_runtime_common.py
+++ b/src/gabion/cli_support/shared/dataflow_runtime_common.py
@@ -38,10 +38,11 @@ def normalize_output_target(
     stdout_alias: str = STDOUT_ALIAS,
     stdout_path: str = STDOUT_PATH,
 ) -> str:
-    target_str = str(target)
-    if target_str == stdout_alias:
-        return stdout_path
-    return target_str
+    return path_policy.normalize_output_target(
+        target,
+        stdout_alias=stdout_alias,
+        stdout_path=stdout_path,
+    )
 
 
 def normalize_optional_output_target(

--- a/src/gabion/runtime/path_policy.py
+++ b/src/gabion/runtime/path_policy.py
@@ -6,9 +6,38 @@ from pathlib import Path
 DEFAULT_CHECK_REPORT_REL_PATH = Path("artifacts/audit_reports/dataflow_report.md")
 DEFAULT_PHASE_TIMELINE_MD_REL_PATH = Path("artifacts/audit_reports/dataflow_phase_timeline.md")
 DEFAULT_PHASE_TIMELINE_JSONL_REL_PATH = Path("artifacts/audit_reports/dataflow_phase_timeline.jsonl")
+STDOUT_ALIAS = "-"
+STDOUT_PATH = "/dev/stdout"
 
 
 def resolve_report_path(path: Path | None, *, root: Path) -> Path:
     if path is not None:
         return path
     return root / DEFAULT_CHECK_REPORT_REL_PATH
+
+
+def normalize_output_target(
+    target: str | Path,
+    *,
+    stdout_alias: str = STDOUT_ALIAS,
+    stdout_path: str = STDOUT_PATH,
+) -> str:
+    text = str(target).strip()
+    if text == stdout_alias:
+        return stdout_path
+    return text
+
+
+def is_stdout_target(
+    target: object,
+    *,
+    stdout_alias: str = STDOUT_ALIAS,
+    stdout_path: str = STDOUT_PATH,
+) -> bool:
+    if not isinstance(target, (str, Path)):
+        return False
+    return normalize_output_target(
+        target,
+        stdout_alias=stdout_alias,
+        stdout_path=stdout_path,
+    ) == stdout_path

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -66,6 +66,7 @@ from gabion.schema import (
 from gabion.server_core import command_orchestrator_primitives as orchestrator_primitives
 from gabion.synthesis import NamingContext, SynthesisConfig, Synthesizer
 from gabion.tooling.governance.governance_rules import GovernanceRules, load_governance_rules
+from gabion.runtime import path_policy
 
 server = LanguageServer("gabion", "0.1.0")
 CHECK_COMMAND = command_ids.CHECK_COMMAND
@@ -122,10 +123,11 @@ _PHASE_PRIMARY_UNITS: Mapping[str, str] = {
 
 
 def _is_stdout_target(target: object) -> bool:
-    if not isinstance(target, (str, Path)):
-        return False
-    text = str(target).strip()
-    return text in {_STDOUT_ALIAS, _STDOUT_PATH}
+    return path_policy.is_stdout_target(
+        target,
+        stdout_alias=_STDOUT_ALIAS,
+        stdout_path=_STDOUT_PATH,
+    )
 
 
 def _analysis_resume_cache_verdict(

--- a/tests/gabion/cli/cli_server_parity_cases.py
+++ b/tests/gabion/cli/cli_server_parity_cases.py
@@ -351,3 +351,25 @@ def test_dataflow_run_check_matches_server_fields(tmp_path: Path) -> None:
     assert {key: cli_result.get(key) for key in keys} == {
         key: server_result.get(key) for key in keys
     }
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_server_parity.py::test_stdout_target_normalization_parity_between_cli_and_server::cli.py::gabion.cli._is_stdout_target::cli.py::gabion.cli._normalize_output_target::server.py::gabion.server._is_stdout_target
+@pytest.mark.parametrize(
+    ("target", "normalized", "is_stdout"),
+    [
+        ("-", "/dev/stdout", True),
+        (" /dev/stdout ", "/dev/stdout", True),
+        ("  -  ", "/dev/stdout", True),
+        ("report.json", "report.json", False),
+        (" report.json ", "report.json", False),
+    ],
+)
+def test_stdout_target_normalization_parity_between_cli_and_server(
+    target: str,
+    normalized: str,
+    is_stdout: bool,
+) -> None:
+    assert cli._normalize_output_target(target) == normalized
+    assert cli._is_stdout_target(target) is is_stdout
+
+    assert server._is_stdout_target(target) is is_stdout


### PR DESCRIPTION
### Motivation
- Ensure CLI and server use identical logic for output-target canonicalization and stdout detection to avoid subtle differences in alias/whitespace handling.

### Description
- Added shared helpers in `src/gabion/runtime/path_policy.py`: `normalize_output_target(...)` and `is_stdout_target(...)` that trim whitespace and canonicalize `-` to `/dev/stdout`.
- Replaced CLI-local logic in `src/gabion/cli.py` with calls to `path_policy.normalize_output_target` and `path_policy.is_stdout_target` so the CLI honors the same aliases and normalization rules.
- Updated the server `src/gabion/server.py` to call `path_policy.is_stdout_target` for stdout detection so server and CLI behavior is unified.
- Routed the `cli_support` utility `normalize_output_target` through `path_policy` for consistency at the support layer.
- Added a regression parity test in `tests/gabion/cli/cli_server_parity_cases.py` that parametrizes several targets (including `-`, `/dev/stdout` with surrounding whitespace, and normal filenames) and asserts identical normalization and stdout-detection behavior for both CLI and server adapters.
- Updated test evidence mapping `out/test_evidence.json` to include the new parity test footprint.

### Testing
- Ran the parity pytest for the new test: `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/gabion/cli/cli_server_parity_cases.py -k stdout_target_normalization_parity_between_cli_and_server`, and the selected tests passed (`5 passed, 7 deselected`).
- Executed policy checks `scripts/policy/policy_check.py --workflows` and `--ambiguity-contract` (run via `mise` with `PYTHONPATH` set); the checks completed (note: `mise` emitted tool-resolution warnings during the run environment bootstrap).
- Ran the evidence extractor `scripts.misc.extract_test_evidence` to refresh `out/test_evidence.json`, and the updated evidence file was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88e5765a48324bc77fc28e7638cf4)