### PR TITLE
Refactor delta gate wrappers to use shared adapter factory

### DIFF
--- a/src/gabion/tooling/delta/ambiguity_delta_gate.py
+++ b/src/gabion/tooling/delta/ambiguity_delta_gate.py
@@ -5,20 +5,21 @@ from typing import Mapping
 
 from gabion.tooling.delta import delta_gate
 
-ENV_FLAG = delta_gate.AMBIGUITY_DELTA_ENV_FLAG
+_GATE_ADAPTER = delta_gate.make_standard_gate_adapter(gate_id="ambiguity")
+ENV_FLAG = _GATE_ADAPTER.spec.env_flag
 
 
 def _enabled(value: str | None = None) -> bool:
-    return delta_gate.ambiguity_enabled(value)
+    return _GATE_ADAPTER.enabled(value)
 
 
 def _delta_value(payload: Mapping[str, object]) -> int:
-    return delta_gate.ambiguity_delta_value(payload)
+    return _GATE_ADAPTER.delta_value(payload)
 
 
 def check_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return delta_gate.check_ambiguity_gate(path, enabled=enabled)
+    return _GATE_ADAPTER.check_gate(path, enabled=enabled)
 
 
 def main() -> int:
-    return delta_gate.ambiguity_main()
+    return _GATE_ADAPTER.main()

--- a/src/gabion/tooling/delta/delta_gate.py
+++ b/src/gabion/tooling/delta/delta_gate.py
@@ -34,6 +34,33 @@ class StandardGateSpec:
     ok_prefix: str
 
 
+@dataclass(frozen=True)
+class StandardGateAdapter:
+    gate_id: str
+    spec: StandardGateSpec
+    default_path: Path
+
+    def enabled(self, value: str | None = None) -> bool:
+        return _enabled_default_true(self.spec.env_flag, value)
+
+    def delta_value(self, payload: Mapping[str, object]) -> int:
+        return _nested_int(payload, self.spec.delta_keys)
+
+    def check_gate(self, path: Path, *, enabled: bool | None = None) -> int:
+        return _check_standard_gate(self.spec, path, enabled=enabled)
+
+    def main(self) -> int:
+        return self.check_gate(self.default_path)
+
+
+_STANDARD_GATE_DEFAULT_PATHS: dict[str, Path] = {
+    "obsolescence_opaque": Path("artifacts/out/test_obsolescence_delta.json"),
+    "obsolescence_unmapped": Path("artifacts/out/test_obsolescence_delta.json"),
+    "annotation_orphaned": Path("artifacts/out/test_annotation_drift_delta.json"),
+    "ambiguity": Path("artifacts/out/ambiguity_delta.json"),
+}
+
+
 def _standard_spec_from_policy(policy: GatePolicy) -> StandardGateSpec:
     return StandardGateSpec(
         env_flag=policy.env_flag,
@@ -109,6 +136,25 @@ def _gate_id_for_env_flag(env_flag: str) -> str:
     if gate_id is None:
         raise ValueError(f"unsupported env flag for governance mapping: {env_flag}")
     return gate_id
+
+
+def make_standard_gate_adapter(
+    *,
+    gate_id: str | None = None,
+    env_flag: str | None = None,
+    default_path: Path | None = None,
+) -> StandardGateAdapter:
+    if (gate_id is None) == (env_flag is None):
+        raise ValueError("provide exactly one of gate_id or env_flag")
+    resolved_gate_id = gate_id if gate_id is not None else _gate_id_for_env_flag(env_flag or "")
+    if resolved_gate_id not in _STANDARD_GATE_DEFAULT_PATHS:
+        raise ValueError(f"unsupported standard gate adapter id: {resolved_gate_id}")
+    spec = _policy_spec(resolved_gate_id)
+    return StandardGateAdapter(
+        gate_id=resolved_gate_id,
+        spec=spec,
+        default_path=default_path or _STANDARD_GATE_DEFAULT_PATHS[resolved_gate_id],
+    )
 
 
 def _check_standard_gate(

--- a/src/gabion/tooling/delta/obsolescence_delta_gate.py
+++ b/src/gabion/tooling/delta/obsolescence_delta_gate.py
@@ -5,20 +5,21 @@ from typing import Mapping
 
 from gabion.tooling.delta import delta_gate
 
-ENV_FLAG = delta_gate.OBSOLESCENCE_OPAQUE_ENV_FLAG
+_GATE_ADAPTER = delta_gate.make_standard_gate_adapter(gate_id="obsolescence_opaque")
+ENV_FLAG = _GATE_ADAPTER.spec.env_flag
 
 
 def _enabled(value: str | None = None) -> bool:
-    return delta_gate.obsolescence_opaque_enabled(value)
+    return _GATE_ADAPTER.enabled(value)
 
 
 def _delta_value(payload: Mapping[str, object]) -> int:
-    return delta_gate.obsolescence_opaque_delta_value(payload)
+    return _GATE_ADAPTER.delta_value(payload)
 
 
 def check_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return delta_gate.check_obsolescence_opaque_gate(path, enabled=enabled)
+    return _GATE_ADAPTER.check_gate(path, enabled=enabled)
 
 
 def main() -> int:
-    return delta_gate.obsolescence_opaque_main()
+    return _GATE_ADAPTER.main()

--- a/src/gabion/tooling/delta/obsolescence_delta_unmapped_gate.py
+++ b/src/gabion/tooling/delta/obsolescence_delta_unmapped_gate.py
@@ -5,20 +5,21 @@ from typing import Mapping
 
 from gabion.tooling.delta import delta_gate
 
-ENV_FLAG = delta_gate.OBSOLESCENCE_UNMAPPED_ENV_FLAG
+_GATE_ADAPTER = delta_gate.make_standard_gate_adapter(gate_id="obsolescence_unmapped")
+ENV_FLAG = _GATE_ADAPTER.spec.env_flag
 
 
 def _enabled(value: str | None = None) -> bool:
-    return delta_gate.obsolescence_unmapped_enabled(value)
+    return _GATE_ADAPTER.enabled(value)
 
 
 def _delta_value(payload: Mapping[str, object]) -> int:
-    return delta_gate.obsolescence_unmapped_delta_value(payload)
+    return _GATE_ADAPTER.delta_value(payload)
 
 
 def check_gate(path: Path, *, enabled: bool | None = None) -> int:
-    return delta_gate.check_obsolescence_unmapped_gate(path, enabled=enabled)
+    return _GATE_ADAPTER.check_gate(path, enabled=enabled)
 
 
 def main() -> int:
-    return delta_gate.obsolescence_unmapped_main()
+    return _GATE_ADAPTER.main()

--- a/tests/gabion/tooling/delta/test_delta_gates.py
+++ b/tests/gabion/tooling/delta/test_delta_gates.py
@@ -7,6 +7,7 @@ from typing import Callable
 import pytest
 
 from gabion.tooling.delta import ambiguity_delta_gate
+from gabion.tooling.delta import delta_gate
 from gabion.tooling.runtime import annotation_drift_orphaned_gate
 from gabion.tooling.delta import obsolescence_delta_gate
 from gabion.tooling.delta import obsolescence_delta_unmapped_gate
@@ -139,3 +140,49 @@ def test_gate_delta_value_handles_invalid_shapes(
     else:
         assert delta_value({"summary": {"delta": []}}) == 0
         assert delta_value({"summary": {"delta": {key_path[-1]: "bad"}}}) == 0
+
+
+@pytest.mark.parametrize(
+    ("gate_id", "env_flag", "payload", "expected_delta"),
+    [
+        (
+            "ambiguity",
+            delta_gate.AMBIGUITY_DELTA_ENV_FLAG,
+            {"summary": {"total": {"delta": 4}}},
+            4,
+        ),
+        (
+            "obsolescence_opaque",
+            delta_gate.OBSOLESCENCE_OPAQUE_ENV_FLAG,
+            {"summary": {"opaque_evidence": {"delta": 5}}},
+            5,
+        ),
+        (
+            "obsolescence_unmapped",
+            delta_gate.OBSOLESCENCE_UNMAPPED_ENV_FLAG,
+            {"summary": {"counts": {"delta": {"unmapped": 6}}}},
+            6,
+        ),
+    ],
+)
+def test_standard_gate_adapter_resolves_enablement_and_delta_value(
+    gate_id: str,
+    env_flag: str,
+    payload: dict[str, object],
+    expected_delta: int,
+) -> None:
+    adapter = delta_gate.make_standard_gate_adapter(gate_id=gate_id)
+    assert adapter.spec.env_flag == env_flag
+    assert adapter.delta_value(payload) == expected_delta
+    with env_scope({env_flag: "off"}):
+        assert adapter.enabled() is False
+    with env_scope({env_flag: "true"}):
+        assert adapter.enabled() is True
+
+
+def test_standard_gate_adapter_resolves_by_env_flag() -> None:
+    adapter = delta_gate.make_standard_gate_adapter(
+        env_flag=delta_gate.OBSOLESCENCE_UNMAPPED_ENV_FLAG
+    )
+    assert adapter.gate_id == "obsolescence_unmapped"
+    assert adapter.spec.env_flag == delta_gate.OBSOLESCENCE_UNMAPPED_ENV_FLAG


### PR DESCRIPTION
### Motivation
- Reduce duplication in delta gate wrapper modules by centralizing common gate behavior into a declarative adapter. 
- Make gate construction resolvable by `gate_id` or environment flag so new gates can be added with minimal per-file boilerplate. 
- Preserve existing public/CLI-compatible symbols while easing future maintenance and policy-driven defaults.

### Description
- Added `StandardGateAdapter` and `make_standard_gate_adapter(...)` to `src/gabion/tooling/delta/delta_gate.py` to encapsulate spec resolution, enablement checks, delta extraction, `check_gate` and `main` behavior. 
- Consolidated default artifact paths for standard gates into a single `_STANDARD_GATE_DEFAULT_PATHS` mapping and a policy-backed `StandardGateSpec`. 
- Replaced the per-file duplicated logic in `src/gabion/tooling/delta/ambiguity_delta_gate.py`, `src/gabion/tooling/delta/obsolescence_delta_gate.py`, and `src/gabion/tooling/delta/obsolescence_delta_unmapped_gate.py` with thin compatibility stubs that delegate to `make_standard_gate_adapter(...)` while keeping exported names (`ENV_FLAG`, `_enabled`, `_delta_value`, `check_gate`, `main`). 
- Added tests in `tests/gabion/tooling/delta/test_delta_gates.py` that assert adapter construction by `gate_id` and `env_flag`, verify `env_flag` resolution, enablement semantics, and delta-value extraction. 
- Updated `out/test_evidence.json` to reflect newly added test evidence entries after the test changes.

### Testing
- Ran targeted pytest for the delta gate tests with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/tooling/delta/test_delta_gates.py` and observed `28 passed` (all tests in that file passed). 
- Executed policy checks with `PYTHONPATH=src mise exec -- python -m scripts.policy.policy_check --ambiguity-contract` after adjusting `PYTHONPATH`, which completed successfully for the ambiguity contract run. 
- Ran the workflow policy check `mise exec -- python -m scripts.policy.policy_check --workflows` (required initial environment/tool trust bootstrapping and was exercised as part of validation). 
- Ran `PYTHONPATH=src mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` to refresh evidence, which produced an intentional diff in `out/test_evidence.json` to include the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88e8ff9548324820178c1b8f768ed)