### PR TITLE
Unify server command dispatch registry across transports

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -2931,36 +2931,103 @@ def _impact_overlap(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
     return not (a_end < b_start or b_end < a_start)
 
 
+@dataclass(frozen=True)
+class CommandDispatchRegistration:
+    executor_name: str
+    transport_lsp: bool
+    transport_direct: bool
+
+
+_COMMAND_DISPATCH_REGISTRY: dict[str, CommandDispatchRegistration] = {
+    CHECK_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_command",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    DATAFLOW_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_command",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    STRUCTURE_DIFF_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_structure_diff",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    STRUCTURE_REUSE_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_structure_reuse",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    DECISION_DIFF_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_decision_diff",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    SYNTHESIS_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_synthesis",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    REFACTOR_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_refactor",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    IMPACT_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_impact",
+        transport_lsp=True,
+        transport_direct=True,
+    ),
+    LSP_PARITY_GATE_COMMAND: CommandDispatchRegistration(
+        executor_name="execute_lsp_parity_gate",
+        transport_lsp=False,
+        transport_direct=True,
+    ),
+}
+
+
+def _validate_command_dispatch_registry_coverage() -> None:
+    registered = set(_COMMAND_DISPATCH_REGISTRY)
+    semantic = set(command_ids.SEMANTIC_COMMAND_IDS)
+    missing = tuple(
+        sort_once(
+            semantic - registered,
+            source="server.command_dispatch_registry.missing",
+        )
+    )
+    if missing:
+        never(
+            "command dispatch registry missing semantic command ids",
+            missing=missing,
+        )
+
+
+_validate_command_dispatch_registry_coverage()
+
+def _command_executor_from_registration(
+    registration: CommandDispatchRegistration,
+) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
+    candidate = globals().get(registration.executor_name)
+    if not callable(candidate):
+        return None
+    return cast(Callable[[LanguageServer, dict[str, object] | None], dict], candidate)
+
 
 def _lsp_command_executor(command: str) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
-    mapping: dict[str, Callable[[LanguageServer, dict[str, object] | None], dict]] = {
-        CHECK_COMMAND: execute_command,
-        DATAFLOW_COMMAND: execute_command,
-        STRUCTURE_DIFF_COMMAND: execute_structure_diff,
-        STRUCTURE_REUSE_COMMAND: execute_structure_reuse,
-        DECISION_DIFF_COMMAND: execute_decision_diff,
-        SYNTHESIS_COMMAND: execute_synthesis,
-        REFACTOR_COMMAND: execute_refactor,
-        IMPACT_COMMAND: execute_impact,
-    }
-    return mapping.get(command)
+    registration = _COMMAND_DISPATCH_REGISTRY.get(command)
+    if registration is None or not registration.transport_lsp:
+        return None
+    return _command_executor_from_registration(registration)
 
 
 def _direct_command_executor(
     command: str,
 ) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
-    mapping: dict[str, Callable[[LanguageServer, dict[str, object] | None], dict]] = {
-        CHECK_COMMAND: execute_command,
-        DATAFLOW_COMMAND: execute_command,
-        STRUCTURE_DIFF_COMMAND: execute_structure_diff,
-        STRUCTURE_REUSE_COMMAND: execute_structure_reuse,
-        DECISION_DIFF_COMMAND: execute_decision_diff,
-        SYNTHESIS_COMMAND: execute_synthesis,
-        REFACTOR_COMMAND: execute_refactor,
-        IMPACT_COMMAND: execute_impact,
-        LSP_PARITY_GATE_COMMAND: execute_lsp_parity_gate,
-    }
-    return mapping.get(command)
+    registration = _COMMAND_DISPATCH_REGISTRY.get(command)
+    if registration is None or not registration.transport_direct:
+        return None
+    return _command_executor_from_registration(registration)
 
 
 def _strip_parity_ignored_keys(

--- a/tests/gabion/lsp_client/lsp_parity_gate_cases.py
+++ b/tests/gabion/lsp_client/lsp_parity_gate_cases.py
@@ -86,11 +86,22 @@ def test_parity_gate_normalizes_payload_and_is_deterministic() -> None:
     assert first["checked_commands"][0]["parity_ok"] is True
 
 
-# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_lsp_command_executor_map_covers_known_and_unknown::server.py::gabion.server._lsp_command_executor
-def test_lsp_command_executor_map_covers_known_and_unknown() -> None:
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_command_executor_transport_filtering_is_stable::server.py::gabion.server._lsp_command_executor
+def test_command_executor_transport_filtering_is_stable() -> None:
     assert server._lsp_command_executor(server.CHECK_COMMAND) is server.execute_command
     assert server._lsp_command_executor(server.IMPACT_COMMAND) is server.execute_impact
+    assert server._lsp_command_executor(server.LSP_PARITY_GATE_COMMAND) is None
+    assert (
+        server._direct_command_executor(server.LSP_PARITY_GATE_COMMAND)
+        is server.execute_lsp_parity_gate
+    )
     assert server._lsp_command_executor("gabion.unknown") is None
+    assert server._direct_command_executor("gabion.unknown") is None
+
+
+# gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_command_dispatch_registry_covers_semantic_command_ids::server.py::gabion.server._validate_command_dispatch_registry_coverage
+def test_command_dispatch_registry_covers_semantic_command_ids() -> None:
+    assert set(server._COMMAND_DISPATCH_REGISTRY) == set(server.command_ids.SEMANTIC_COMMAND_IDS)
 
 
 # gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_strip_parity_ignored_keys_filters_requested_fields::server.py::gabion.server._strip_parity_ignored_keys


### PR DESCRIPTION
### Motivation
- Remove duplicated LSP vs direct executor maps and centralize command dispatch to reduce drift and make transport eligibility explicit. 
- Make transport filtering (e.g., parity-gate being direct-only) an explicit, testable property rather than an incidental difference in two maps.
- Ensure coverage: all canonical `command_ids.SEMANTIC_COMMAND_IDS` must be represented in a single registry to avoid silent omissions.

### Description
- Introduced a frozen dataclass `CommandDispatchRegistration` and a single `_COMMAND_DISPATCH_REGISTRY` keyed by command id, storing executor identity and transport flags (`transport_lsp`, `transport_direct`).
- Replaced the duplicate inline maps by reimplementing `_lsp_command_executor` and `_direct_command_executor` as thin filters over the shared registry and added `_command_executor_from_registration` to resolve the executor by name.
- Added `_validate_command_dispatch_registry_coverage()` which asserts (via `never(...)`) that every `command_ids.SEMANTIC_COMMAND_IDS` entry appears in the central registry and invoked it at module load.
- Updated parity-gate tests to assert transport-filtering behavior and added a test asserting the registry covers all semantic command ids; refreshed `out/test_evidence.json` to reflect test evidence changes.

### Testing
- Ran targeted pytest: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/lsp_client/lsp_parity_gate_cases.py tests/gabion/commands/test_command_dispatch_registry.py` and all tests in those files passed (`18 passed`).
- Ran the repository policy checks with `mise exec -- python -m scripts.policy.policy_check --workflows` and `PYTHONPATH=src mise exec -- python -m scripts.policy.policy_check --ambiguity-contract` (warnings about local `mise` tool resolution were emitted but checks completed in this environment).
- Regenerated test evidence with `PYTHONPATH=src mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and committed the refreshed `out/test_evidence.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88e7063988324ba23f13f99c6a88b)