### PR TITLE
Unify lint-line parsing across CLI and server

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -63,6 +63,7 @@ from gabion.analysis.foundation.timeout_context import (
     check_deadline, deadline_loop_iter, render_deadline_profile_markdown)
 from gabion.commands import (
     boundary_order, check_contract, command_ids, progress_contract as progress_timeline, transport_policy)
+from gabion.commands.lint_parser import parse_lint_line
 from gabion.runtime import deadline_policy, env_policy, path_policy, policy_runtime
 
 DATAFLOW_COMMAND = command_ids.DATAFLOW_COMMAND
@@ -135,7 +136,6 @@ CliRunCiWatchFn: TypeAlias = Callable[
     tooling_ci_watch.StatusWatchResult,
 ]
 
-_LINT_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$")
 
 _DEFAULT_TIMEOUT_TICKS = 100
 _DEFAULT_TIMEOUT_TICK_NS = 1_000_000
@@ -543,21 +543,11 @@ def _split_csv(value: str) -> list[str]:
 
 
 def _parse_lint_line(line: str) -> dict[str, object] | None:
-    match = _LINT_RE.match(line.strip())
-    if not match:
+    entry = parse_lint_line(line)
+    if entry is None:
         return None
-    line_no = int(match.group("line"))
-    col_no = int(match.group("col"))
-    rest = match.group("rest").strip()
-    if not rest:
-        return None
-    code, _, message = rest.partition(" ")
     return {
-        "path": match.group("path"),
-        "line": line_no,
-        "col": col_no,
-        "code": code,
-        "message": message,
+        **entry.model_dump(),
         "severity": "warning",
     }
 

--- a/src/gabion/commands/lint_parser.py
+++ b/src/gabion/commands/lint_parser.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+
+from gabion.schema import LintEntryDTO
+
+_LINT_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$")
+
+
+def parse_lint_line(line: str) -> LintEntryDTO | None:
+    match = _LINT_RE.match(line.strip())
+    if not match:
+        return None
+    rest = match.group("rest").strip()
+    if not rest:
+        return None
+    code, _, message = rest.partition(" ")
+    return LintEntryDTO(
+        path=match.group("path"),
+        line=int(match.group("line")),
+        col=int(match.group("col")),
+        code=code,
+        message=message,
+    )

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -26,6 +26,7 @@ from lsprotocol.types import (
 from gabion.json_types import JSONObject, JSONValue
 from gabion.commands import (
     boundary_order, command_ids, payload_codec, progress_contract as progress_timeline)
+from gabion.commands.lint_parser import parse_lint_line
 from gabion.commands.check_contract import LintEntriesDecision
 from gabion.plan import (
     ExecutionPlan, ExecutionPlanObligations, ExecutionPlanPolicyMetadata, write_execution_plan_artifact)
@@ -107,7 +108,6 @@ _PROGRESS_DEADLINE_FLUSH_SECONDS = 5.0
 _PROGRESS_DEADLINE_WATCHDOG_SECONDS = 10.0
 _PROGRESS_HEARTBEAT_POLL_SECONDS = 0.05
 _PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = 0.5
-_LINT_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$")
 _LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
 _LSP_PROGRESS_TOKEN_V2 = "gabion.dataflowAudit/progress-v2"
 _LSP_PROGRESS_TOKEN = _LSP_PROGRESS_TOKEN_V2
@@ -1859,20 +1859,7 @@ def _ordered_command_response(
 
 
 def _parse_lint_line(line: str) -> LintEntryDTO | None:
-    match = _LINT_RE.match(line.strip())
-    if not match:
-        return None
-    rest = match.group("rest").strip()
-    if not rest:
-        return None
-    code, _, message = rest.partition(" ")
-    return LintEntryDTO(
-        path=match.group("path"),
-        line=int(match.group("line")),
-        col=int(match.group("col")),
-        code=code,
-        message=message,
-    )
+    return parse_lint_line(line)
 
 
 def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:

--- a/src/gabion/server_core/command_orchestrator_primitives.py
+++ b/src/gabion/server_core/command_orchestrator_primitives.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import threading
 import time
 from datetime import (datetime, timezone)
@@ -15,6 +14,7 @@ from pathlib import Path
 from typing import (Callable, Literal, Mapping, Sequence, cast)
 from gabion.json_types import (JSONObject, JSONValue)
 from gabion.commands import (boundary_order, command_ids, payload_codec, progress_contract as progress_timeline)
+from gabion.commands.lint_parser import parse_lint_line
 from gabion.commands.check_contract import LintEntriesDecision
 from gabion.plan import (ExecutionPlan, ExecutionPlanObligations, ExecutionPlanPolicyMetadata, write_execution_plan_artifact)
 from gabion.analysis import (AnalysisResult, AuditConfig, ReportCarrier, analyze_paths, apply_baseline, build_analysis_collection_resume_seed, compute_structure_metrics, compute_violations, build_refactor_plan, build_synthesis_plan, load_baseline, extract_report_sections, project_report_sections, report_projection_phase_rank, report_projection_spec_rows, render_dot, render_structure_snapshot, render_decision_snapshot, DecisionSnapshotSurfaces, render_protocol_stubs, render_refactor_plan, render_report, render_synthesis_section, resolve_baseline_path, write_baseline)
@@ -92,7 +92,6 @@ _PROGRESS_HEARTBEAT_POLL_SECONDS = 0.05
 
 _PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = 0.5
 
-_LINT_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$")
 
 _LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
 
@@ -1822,20 +1821,7 @@ def _latest_report_phase(phases: Mapping[str, JSONValue] | None) -> str | None:
     return best_phase
 
 def _parse_lint_line(line: str) -> LintEntryDTO | None:
-    match = _LINT_RE.match(line.strip())
-    if not match:
-        return None
-    rest = match.group("rest").strip()
-    if not rest:
-        return None
-    code, _, message = rest.partition(" ")
-    return LintEntryDTO(
-        path=match.group("path"),
-        line=int(match.group("line")),
-        col=int(match.group("col")),
-        code=code,
-        message=message,
-    )
+    return parse_lint_line(line)
 
 def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:
     entry = _parse_lint_line(line)

--- a/tests/gabion/commands/test_lint_parser.py
+++ b/tests/gabion/commands/test_lint_parser.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from gabion import cli, server
+from gabion.commands.lint_parser import parse_lint_line
+
+
+# gabion:evidence E:call_footprint::tests/test_lint_parser.py::test_shared_lint_parser_contract_for_valid_line::lint_parser.py::gabion.commands.lint_parser.parse_lint_line::cli.py::gabion.cli._parse_lint_line::server.py::gabion.server._parse_lint_line_as_payload
+def test_shared_lint_parser_contract_for_valid_line() -> None:
+    line = "pkg/mod.py:12:34: DF001 message body"
+
+    shared = parse_lint_line(line)
+    server_parsed = server._parse_lint_line_as_payload(line)
+    cli_parsed = cli._parse_lint_line(line)
+
+    assert shared is not None
+    expected = shared.model_dump()
+    assert server_parsed == expected
+    assert cli_parsed == {**expected, "severity": "warning"}
+
+
+# gabion:evidence E:call_footprint::tests/test_lint_parser.py::test_shared_lint_parser_contract_for_malformed_lines::lint_parser.py::gabion.commands.lint_parser.parse_lint_line::cli.py::gabion.cli._parse_lint_line::server.py::gabion.server._parse_lint_line_as_payload
+def test_shared_lint_parser_contract_for_malformed_lines() -> None:
+    malformed_lines = ["not a lint row", "pkg/mod.py:1:2:", "pkg/mod.py:1:2:   "]
+    for line in malformed_lines:
+        assert parse_lint_line(line) is None
+        assert server._parse_lint_line_as_payload(line) is None
+        assert cli._parse_lint_line(line) is None


### PR DESCRIPTION
### Motivation
- Reduce duplicated lint-line regex/parse logic by centralizing a single canonical parse contract so CLI, server, and orchestrator code share identical semantics.
- Keep transport-specific shaping at the caller boundary so the parser remains a pure DTO-producing primitive and presentation (e.g. `severity`) remains a CLI concern.

### Description
- Added `src/gabion/commands/lint_parser.py` which exposes `parse_lint_line(line) -> LintEntryDTO | None` and contains the canonical `_LINT_RE` and parse semantics.
- Replaced duplicated parsing logic in `src/gabion/cli.py`, `src/gabion/server.py`, and `src/gabion/server_core/command_orchestrator_primitives.py` to call `parse_lint_line` instead of repeating the regex logic.
- Preserved transport shaping at boundaries: the CLI adapter now enriches the shared DTO with `"severity": "warning"` while server paths serialize the DTO (`model_dump`) for payloads.
- Updated call sites that collected or serialized lint entries (`_collect_lint_entries`, `_parse_lint_line_as_payload`) to use the shared parser.
- Added unit tests `tests/gabion/commands/test_lint_parser.py` to assert parity between the shared parser, CLI adapter, and server payload serialization for both valid and malformed lint lines.
- Updated evidence output `out/test_evidence.json` to reflect new tests / call-footprint evidence.

### Testing
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/commands/test_lint_parser.py` which passed (`2 passed`).
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/cli/cli_helpers_cases.py -k lint_parsing_and_writers` which passed (`1 passed`).
- Ran `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/server/server_execute_command_edges_cases.py -k lint_normalization_helpers_cover_invalid_rows` which passed (`1 passed`).
- Executed policy checks `scripts/policy/policy_check.py --workflows` and `--ambiguity-contract`; the checks completed but the environment emitted `mise` warnings about resolving the pinned tool metadata (these are non-fatal in this run). All automated test runs listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88e5228288324a45f51aa0909cae3)