### PR TITLE
Extract server_core stage modules and deterministic stage contracts

### DIFF
--- a/src/gabion/server_core/analysis_stage.py
+++ b/src/gabion/server_core/analysis_stage.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from gabion.server_core.stage_contracts import AnalysisRunner, JSONObject, StageAnalysisResult
+
+
+def run_analysis_stage(
+    *,
+    context: object,
+    state: object,
+    collection_resume_payload: JSONObject | None,
+    run_analysis_with_progress: AnalysisRunner,
+) -> StageAnalysisResult:
+    outcome = run_analysis_with_progress(
+        context=context,
+        state=state,
+        collection_resume_payload=collection_resume_payload,
+    )
+    return StageAnalysisResult(
+        analysis_outcome=outcome,
+        semantic_progress_cumulative=outcome.semantic_progress_cumulative,
+        latest_collection_progress=outcome.latest_collection_progress,
+        last_collection_resume_payload=outcome.last_collection_resume_payload,
+    )

--- a/src/gabion/server_core/command_orchestrator.py
+++ b/src/gabion/server_core/command_orchestrator.py
@@ -151,6 +151,11 @@ from gabion.server_core.command_contract import CommandRuntimeInput, CommandRunt
 from gabion.server_core.command_effects import CommandEffects
 from gabion.server_core.command_reducers import (
     initial_collection_progress, initial_paths_count, normalize_paths, normalize_timeout_total_ticks)
+from gabion.server_core.analysis_stage import run_analysis_stage
+from gabion.server_core.timeout_stage import (
+    run_timeout_stage,
+    timeout_classification_decision,
+)
 
 _DURATION_TIMEOUT_CLOCK_MULTIPLIER = 16
 
@@ -3419,10 +3424,7 @@ def _handle_timeout_cleanup(
 
 
 def _timeout_classification_decision(*, progress_payload: JSONObject) -> str:
-    timeout_classification = progress_payload.get("classification")
-    if isinstance(timeout_classification, str) and timeout_classification:
-        return timeout_classification
-    return "timed_out_no_progress"
+    return timeout_classification_decision(progress_payload=progress_payload)
 
 
 def _checkpoint_projection_decision(*, report_output_path: Path | None) -> bool:
@@ -4476,7 +4478,12 @@ def _stage_finalize_success(*, stage: _ExecuteCommandFinalizeSuccessStage) -> _S
 
 
 def _stage_finalize_timeout(*, exc: TimeoutExceeded, context: _TimeoutCleanupContext) -> dict:
-    return _handle_timeout_cleanup(exc=exc, context=context)
+    timeout_stage = run_timeout_stage(
+        exc=exc,
+        context=context,
+        cleanup_handler=_handle_timeout_cleanup,
+    )
+    return timeout_stage.response
 
 
 def _stage_runtime_bootstrap(
@@ -4522,16 +4529,17 @@ def _stage_execute_analysis(
     state: _AnalysisExecutionMutableState,
     collection_resume_payload: JSONObject | None,
 ) -> _ExecuteCommandAnalysisStage:
-    analysis_outcome = _run_analysis_with_progress(
+    stage = run_analysis_stage(
         context=context,
         state=state,
         collection_resume_payload=collection_resume_payload,
+        run_analysis_with_progress=_run_analysis_with_progress,
     )
     return _ExecuteCommandAnalysisStage(
-        analysis_outcome=analysis_outcome,
-        last_collection_resume_payload=analysis_outcome.last_collection_resume_payload,
-        semantic_progress_cumulative=analysis_outcome.semantic_progress_cumulative,
-        latest_collection_progress=analysis_outcome.latest_collection_progress,
+        analysis_outcome=stage.analysis_outcome,
+        last_collection_resume_payload=stage.last_collection_resume_payload,
+        semantic_progress_cumulative=stage.semantic_progress_cumulative,
+        latest_collection_progress=stage.latest_collection_progress,
     )
 
 

--- a/src/gabion/server_core/ingress_stage.py
+++ b/src/gabion/server_core/ingress_stage.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from gabion.server_core.stage_contracts import (
+    IngressModeSelector,
+    PayloadNormalizer,
+    PayloadOptionsParser,
+    StageIngressResult,
+)
+
+
+def run_ingress_stage(
+    *,
+    payload: dict[str, object],
+    root: Path,
+    normalize_payload: PayloadNormalizer,
+    parse_options: PayloadOptionsParser,
+    select_mode: IngressModeSelector,
+) -> StageIngressResult:
+    normalized_payload = normalize_payload(payload=payload)
+    options = parse_options(payload=normalized_payload, root=root)
+    mode = select_mode(payload=normalized_payload, options=options)
+    return StageIngressResult(payload=normalized_payload, options=options, mode=mode)
+
+
+def default_mode_selector(*, payload: Mapping[str, object], options: object) -> str:
+    if payload.get("aux_operation") is not None:
+        return "aux_operation"
+    return "analysis"

--- a/src/gabion/server_core/output_stage.py
+++ b/src/gabion/server_core/output_stage.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from gabion.server_core.stage_contracts import (
+    AuxiliaryOutputEmitter,
+    PrimaryOutputEmitter,
+    StageOutputResult,
+)
+
+
+def run_output_stage(
+    *,
+    primary_output_emitter: PrimaryOutputEmitter,
+    auxiliary_output_emitter: AuxiliaryOutputEmitter,
+    primary_args: tuple[object, ...] = (),
+    primary_kwargs: dict[str, object] | None = None,
+    auxiliary_args: tuple[object, ...] = (),
+    auxiliary_kwargs: dict[str, object] | None = None,
+) -> StageOutputResult:
+    rendered = primary_output_emitter(
+        *primary_args,
+        **(primary_kwargs or {}),
+    )
+    auxiliary_output_emitter(
+        *auxiliary_args,
+        **(auxiliary_kwargs or {}),
+    )
+    checkpoint_state = rendered.get("phase_checkpoint_state", {})
+    return StageOutputResult(response=rendered, phase_checkpoint_state=checkpoint_state)

--- a/src/gabion/server_core/stage_contracts.py
+++ b/src/gabion/server_core/stage_contracts.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol
+
+
+JSONValue = object
+JSONObject = dict[str, JSONValue]
+
+
+@dataclass(frozen=True)
+class StageIngressResult:
+    payload: dict[str, object]
+    options: Any
+    mode: str
+
+
+@dataclass(frozen=True)
+class StageAnalysisResult:
+    analysis_outcome: Any
+    semantic_progress_cumulative: JSONObject | None
+    latest_collection_progress: JSONObject
+    last_collection_resume_payload: JSONObject | None
+
+
+@dataclass(frozen=True)
+class StageOutputResult:
+    response: dict[str, object]
+    phase_checkpoint_state: JSONObject
+
+
+@dataclass(frozen=True)
+class StageTimeoutResult:
+    response: dict[str, object]
+
+
+class PayloadNormalizer(Protocol):
+    def __call__(self, *, payload: dict[str, object]) -> dict[str, object]: ...
+
+
+class PayloadOptionsParser(Protocol):
+    def __call__(self, *, payload: Mapping[str, object], root: Path) -> Any: ...
+
+
+class IngressModeSelector(Protocol):
+    def __call__(self, *, payload: Mapping[str, object], options: Any) -> str: ...
+
+
+class AnalysisRunner(Protocol):
+    def __call__(self, *, context: Any, state: Any, collection_resume_payload: JSONObject | None) -> Any: ...
+
+
+class PrimaryOutputEmitter(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> dict[str, object]: ...
+
+
+class AuxiliaryOutputEmitter(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+class TimeoutCleanupHandler(Protocol):
+    def __call__(self, *, exc: BaseException, context: Any) -> dict[str, object]: ...
+
+
+@dataclass(frozen=True)
+class _ExecutionPayloadOptions:
+    """Shared execution options contract extracted for stage boundaries."""
+
+    emit_phase_timeline: bool
+    progress_heartbeat_seconds: float
+
+
+@dataclass(frozen=True)
+class _AnalysisInclusionFlags:
+    """Shared analysis inclusion contract extracted for stage boundaries."""
+
+    type_audit: bool
+    include_decisions: bool
+    include_rewrite_plans: bool
+    include_exception_obligations: bool
+    include_handledness_witnesses: bool
+    include_never_invariants: bool
+    include_wl_refinement: bool
+    include_ambiguities: bool
+    include_coherence: bool
+    needs_analysis: bool

--- a/src/gabion/server_core/timeout_stage.py
+++ b/src/gabion/server_core/timeout_stage.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+from gabion.server_core.stage_contracts import JSONObject, StageTimeoutResult, TimeoutCleanupHandler
+
+
+def timeout_classification_decision(*, progress_payload: JSONObject) -> str:
+    timeout_classification = progress_payload.get("classification")
+    if isinstance(timeout_classification, str) and timeout_classification:
+        return timeout_classification
+    return "timed_out_no_progress"
+
+
+def run_timeout_stage(
+    *,
+    exc: BaseException,
+    context: object,
+    cleanup_handler: TimeoutCleanupHandler,
+) -> StageTimeoutResult:
+    return StageTimeoutResult(response=cleanup_handler(exc=exc, context=context))
+
+
+def render_timeout_payload(*, base_payload: Mapping[str, object], classification: str) -> dict[str, object]:
+    rendered = dict(base_payload)
+    rendered["classification"] = classification
+    return rendered

--- a/tests/gabion/server_core/command_orchestrator_coverage_cases.py
+++ b/tests/gabion/server_core/command_orchestrator_coverage_cases.py
@@ -825,3 +825,48 @@ def test_build_success_response_emits_analysis_resume_block_when_resume_source_p
     assert isinstance(resume_payload, dict)
     assert resume_payload["source"] == "resume_manifest"
     assert resume_payload["cache_verdict"] in {"seeded", "warm"}
+
+
+def test_execute_command_total_uses_analysis_stage_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind()
+    module_path = tmp_path / "sample.py"
+    module_path.write_text("def f(x):\n    return x\n")
+
+    class _Workspace:
+        def __init__(self, root_path: str) -> None:
+            self.root_path = root_path
+
+    class _DummyServer:
+        def __init__(self, root_path: str) -> None:
+            self.workspace = _Workspace(root_path)
+
+    called = {"analysis_stage": False}
+
+    original = orchestrator.run_analysis_stage
+
+    def _wrapped_run_analysis_stage(**kwargs: object):
+        called["analysis_stage"] = True
+        return original(**kwargs)
+
+    monkeypatch.setattr(orchestrator, "run_analysis_stage", _wrapped_run_analysis_stage)
+
+    deps = server._default_execute_command_deps().with_overrides(
+        analyze_paths_fn=lambda *_args, **_kwargs: _empty_analysis_result(),
+    )
+    response = orchestrator.execute_command_total(
+        _DummyServer(str(tmp_path)),
+        {
+            "root": str(tmp_path),
+            "paths": [str(module_path)],
+            "report": "-",
+            "analysis_timeout_ticks": 5_000,
+            "analysis_timeout_tick_ns": 1_000_000,
+        },
+        deps=deps,
+    )
+
+    assert called["analysis_stage"] is True
+    assert response["analysis_state"] == "succeeded"

--- a/tests/gabion/server_core/test_stage_modules.py
+++ b/tests/gabion/server_core/test_stage_modules.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion.server_core.analysis_stage import run_analysis_stage
+from gabion.server_core.ingress_stage import default_mode_selector, run_ingress_stage
+from gabion.server_core.output_stage import run_output_stage
+from gabion.server_core.timeout_stage import (
+    render_timeout_payload,
+    run_timeout_stage,
+    timeout_classification_decision,
+)
+
+
+class _Outcome:
+    def __init__(self) -> None:
+        self.semantic_progress_cumulative = {"done": 1}
+        self.latest_collection_progress = {"done": 1, "total": 1}
+        self.last_collection_resume_payload = {"cursor": "next"}
+
+
+def test_ingress_stage_normalizes_options_and_mode() -> None:
+    stage = run_ingress_stage(
+        payload={"raw": True, "aux_operation": {"domain": "x"}},
+        root=Path("."),
+        normalize_payload=lambda *, payload: {"normalized": True, **payload},
+        parse_options=lambda *, payload, root: {"root": str(root), "keys": sorted(payload)},
+        select_mode=default_mode_selector,
+    )
+
+    assert stage.payload["normalized"] is True
+    assert stage.mode == "aux_operation"
+    assert stage.options["root"] == "."
+
+
+def test_analysis_stage_returns_structured_contract() -> None:
+    stage = run_analysis_stage(
+        context=object(),
+        state=object(),
+        collection_resume_payload={"resume": True},
+        run_analysis_with_progress=lambda **_kwargs: _Outcome(),
+    )
+
+    assert stage.semantic_progress_cumulative == {"done": 1}
+    assert stage.latest_collection_progress["total"] == 1
+
+
+def test_output_stage_calls_primary_and_auxiliary_emitters() -> None:
+    called: list[str] = []
+
+    def _primary(*_args: object, **_kwargs: object) -> dict[str, object]:
+        called.append("primary")
+        return {"analysis_state": "succeeded", "phase_checkpoint_state": {"phase": "emit"}}
+
+    def _aux(*_args: object, **_kwargs: object) -> None:
+        called.append("aux")
+
+    stage = run_output_stage(primary_output_emitter=_primary, auxiliary_output_emitter=_aux)
+
+    assert called == ["primary", "aux"]
+    assert stage.phase_checkpoint_state == {"phase": "emit"}
+
+
+def test_timeout_stage_contracts() -> None:
+    classification = timeout_classification_decision(progress_payload={})
+    assert classification == "timed_out_no_progress"
+
+    payload = render_timeout_payload(base_payload={"timeout": True}, classification=classification)
+    assert payload["classification"] == "timed_out_no_progress"
+
+    stage = run_timeout_stage(
+        exc=TimeoutError("timed out"),
+        context=object(),
+        cleanup_handler=lambda **_kwargs: {"timeout": True},
+    )
+    assert stage.response == {"timeout": True}


### PR DESCRIPTION
### Motivation
- Refactor the monolithic `execute_command_total` flow into clear, testable stages to enforce boundary normalization and make execution phases (ingress, analysis, output, timeout) deterministic and unit-testable.
- Reify recurring execution dataclasses and inclusion flags into a shared stage contract so stage inputs/outputs are explicit and composable.

### Description
- Added stage boundary contracts in `src/gabion/server_core/stage_contracts.py` including dataclass result carriers and Protocol-style callables (`PayloadNormalizer`, `AnalysisRunner`, `PrimaryOutputEmitter`, `TimeoutCleanupHandler`, etc.).
- Introduced four stage modules under `src/gabion/server_core/`: `ingress_stage.py` (payload normalization / mode selection), `analysis_stage.py` (analysis-run orchestration), `output_stage.py` (primary + auxiliary artifact emission), and `timeout_stage.py` (timeout classification / cleanup helpers), each exposing a single deterministic `run_..._stage` function and small helpers such as `render_timeout_payload` and `default_mode_selector`.
- Kept `command_orchestrator.py` as a thin composition root by wiring analysis and timeout flows through the new stage functions (`run_analysis_stage`, `run_timeout_stage`) and delegating timeout classification to the extracted helper.
- Added focused unit tests in `tests/gabion/server_core/test_stage_modules.py` for stage contracts and a small integration assertion in `tests/gabion/server_core/command_orchestrator_coverage_cases.py` to verify `execute_command_total` exercises the analysis-stage composition path.

### Testing
- Ran targeted pytest for the new and adapted tests with `PYTHONPATH=.:src` and pytest options; outcome: `5 passed, 31 deselected` for the selected test subset.
- Ran repo policy checks `scripts/policy/policy_check.py --workflows` and `--ambiguity-contract` with `PYTHONPATH` adjustments; both completed successfully while `mise` emitted environment/tool-resolution warnings in this environment.
- Executed `scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` to refresh evidence artifacts; the extraction completed and the updated `out/test_evidence.json` was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a890f6fe1c8324a696763a05389461)