### PR TITLE
Refactor governance audit into domain composition modules

### DIFF
--- a/src/gabion_governance/compliance_render/__init__.py
+++ b/src/gabion_governance/compliance_render/__init__.py
@@ -1,0 +1,4 @@
+from .contracts import ComplianceRenderResult, RenderedArtifact
+from .render import render_compliance, render_status_consistency_markdown
+
+__all__ = ["ComplianceRenderResult", "RenderedArtifact", "render_compliance", "render_status_consistency_markdown"]

--- a/src/gabion_governance/compliance_render/contracts.py
+++ b/src/gabion_governance/compliance_render/contracts.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RenderedArtifact:
+    markdown: str
+
+
+@dataclass(frozen=True)
+class ComplianceRenderResult:
+    status_consistency: RenderedArtifact

--- a/src/gabion_governance/compliance_render/decision_contracts.py
+++ b/src/gabion_governance/compliance_render/decision_contracts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DecisionSurface:
+    path: str
+    qual: str
+    params: tuple[str, ...]
+    meta: str
+
+    @property
+    def is_boundary(self) -> bool:
+        return "boundary" in self.meta
+
+
+@dataclass(frozen=True)
+class LintEntry:
+    path: str
+    line: int
+    col: int
+    code: str
+    message: str
+    param: str | None
+
+
+@dataclass(frozen=True)
+class ConsolidationConfig:
+    min_functions: int = 3
+    min_files: int = 2
+    max_examples: int = 5
+    require_forest: bool = True

--- a/src/gabion_governance/compliance_render/render.py
+++ b/src/gabion_governance/compliance_render/render.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from gabion_governance.sppf_audit.contracts import SppfStatusConsistencyResult
+
+from .contracts import ComplianceRenderResult, RenderedArtifact
+
+
+def render_status_consistency_markdown(result: SppfStatusConsistencyResult) -> RenderedArtifact:
+    lines = [
+        "# SPPF Status Consistency",
+        "",
+        f"- violations: {len(result.violations)}",
+        f"- warnings: {len(result.warnings)}",
+        "",
+    ]
+    if result.violations:
+        lines.extend(["## Violations", ""])
+        lines.extend(f"- {item}" for item in result.violations)
+        lines.append("")
+    if result.warnings:
+        lines.extend(["## Warnings", ""])
+        lines.extend(f"- {item}" for item in result.warnings)
+        lines.append("")
+    if not result.warnings and not result.violations:
+        lines.extend(["No issues detected.", ""])
+    return RenderedArtifact(markdown="\n".join(lines))
+
+
+def render_compliance(result: SppfStatusConsistencyResult) -> ComplianceRenderResult:
+    return ComplianceRenderResult(status_consistency=render_status_consistency_markdown(result))

--- a/src/gabion_governance/docflow_audit/__init__.py
+++ b/src/gabion_governance/docflow_audit/__init__.py
@@ -1,0 +1,12 @@
+from .contracts import AgentDirective, Doc, DocflowAuditContext, DocflowDomainResult, DocflowInvariant, DocflowObligationResult
+from .service import run_docflow_domain
+
+__all__ = [
+    "AgentDirective",
+    "Doc",
+    "DocflowAuditContext",
+    "DocflowDomainResult",
+    "DocflowInvariant",
+    "DocflowObligationResult",
+    "run_docflow_domain",
+]

--- a/src/gabion_governance/docflow_audit/contracts.py
+++ b/src/gabion_governance/docflow_audit/contracts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, TypeAlias
+
+if TYPE_CHECKING:
+    from gabion.analysis.projection.projection_spec import ProjectionSpec
+
+FrontmatterScalar: TypeAlias = str | int
+FrontmatterValue: TypeAlias = FrontmatterScalar | list[str] | dict[str, FrontmatterScalar]
+Frontmatter: TypeAlias = dict[str, FrontmatterValue]
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+
+@dataclass(frozen=True)
+class Doc:
+    frontmatter: Frontmatter
+    body: str
+
+
+@dataclass(frozen=True)
+class DocflowInvariant:
+    name: str
+    kind: str
+    spec: ProjectionSpec
+    status: str = "active"
+
+
+@dataclass(frozen=True)
+class DocflowAuditContext:
+    docs: dict[str, Doc]
+    revisions: dict[str, int]
+    invariant_rows: list[dict[str, object]]
+    invariants: list[DocflowInvariant]
+    warnings: list[str]
+    violations: list[str]
+
+
+@dataclass(frozen=True)
+class DocflowObligationResult:
+    entries: list[dict[str, JSONValue]]
+    summary: dict[str, int]
+    warnings: list[str]
+    violations: list[str]
+
+
+@dataclass(frozen=True)
+class AgentDirective:
+    source: str
+    scope_root: str
+    line: int
+    text: str
+    normalized: str
+    mandatory: bool
+    delta_marked: bool
+
+
+@dataclass(frozen=True)
+class DocflowDomainResult:
+    context: DocflowAuditContext
+    obligations: DocflowObligationResult
+    warnings: list[str]
+    violations: list[str]

--- a/src/gabion_governance/docflow_audit/service.py
+++ b/src/gabion_governance/docflow_audit/service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from .contracts import Doc, DocflowAuditContext, DocflowDomainResult, DocflowObligationResult
+
+
+def run_docflow_domain(
+    *,
+    root: Path,
+    extra_paths: list[str] | None,
+    extra_strict: list[str] | None,
+    sppf_gh_ref_mode: str,
+    baseline_write_emitted: bool,
+    delta_guard_checked: bool,
+    build_context: Callable[..., DocflowAuditContext],
+    load_docs: Callable[..., dict[str, Doc]],
+    evaluate_obligations: Callable[..., DocflowObligationResult],
+) -> tuple[DocflowDomainResult, dict[str, Doc]]:
+    context = build_context(
+        root,
+        extra_paths=extra_paths,
+        extra_strict=extra_strict,
+        sppf_gh_ref_mode=sppf_gh_ref_mode,
+    )
+    docs = load_docs(root=root, extra_paths=extra_paths)
+    obligations = evaluate_obligations(
+        root=root,
+        violations=context.violations,
+        baseline_write_emitted=baseline_write_emitted,
+        delta_guard_checked=delta_guard_checked,
+    )
+    warnings = [*context.warnings, *obligations.warnings]
+    violations = [*context.violations, *obligations.violations]
+    return (
+        DocflowDomainResult(
+            context=context,
+            obligations=obligations,
+            warnings=warnings,
+            violations=violations,
+        ),
+        docs,
+    )

--- a/src/gabion_governance/governance_audit_contracts.py
+++ b/src/gabion_governance/governance_audit_contracts.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion_governance.compliance_render.contracts import ComplianceRenderResult
+from gabion_governance.docflow_audit.contracts import DocflowDomainResult
+from gabion_governance.sppf_audit.contracts import SppfGraphResult, SppfStatusConsistencyResult
+
+
+@dataclass(frozen=True)
+class GovernanceAuditAggregateResult:
+    docflow: DocflowDomainResult | None = None
+    sppf_graph: SppfGraphResult | None = None
+    sppf_status: SppfStatusConsistencyResult | None = None
+    compliance_render: ComplianceRenderResult | None = None

--- a/src/gabion_governance/governance_audit_impl.py
+++ b/src/gabion_governance/governance_audit_impl.py
@@ -12,7 +12,6 @@ import tomllib
 import subprocess
 from datetime import datetime, timezone
 from collections import Counter, defaultdict
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable, List, Literal, Tuple, TypeAlias
 
@@ -30,6 +29,29 @@ from gabion.analysis.semantics.obligation_registry import (
 from gabion.invariants import never
 from gabion.order_contract import ordered_or_sorted
 from gabion.tooling.governance.governance_rules import load_governance_rules
+from gabion_governance.compliance_render import render_compliance
+from gabion_governance.compliance_render.decision_contracts import (
+    ConsolidationConfig,
+    DecisionSurface,
+    LintEntry,
+)
+from gabion_governance.docflow_audit import (
+    AgentDirective,
+    Doc,
+    DocflowAuditContext,
+    DocflowInvariant,
+    DocflowObligationResult,
+    run_docflow_domain,
+)
+from gabion_governance.docflow_audit.contracts import (
+    Frontmatter,
+    FrontmatterScalar,
+    FrontmatterValue,
+    JSONValue,
+)
+from gabion_governance.governance_audit_contracts import GovernanceAuditAggregateResult
+from gabion_governance.sppf_audit import build_sppf_graph, run_status_consistency
+from gabion_governance.sppf_audit.contracts import SppfStatusConsistencyResult
 
 _DEFAULT_AUDIT_TIMEOUT_TICKS = 120_000
 _DEFAULT_AUDIT_TIMEOUT_TICK_NS = 1_000_000
@@ -126,10 +148,6 @@ MAP_FIELDS = {
     "doc_section_reviews",
 }
 
-FrontmatterScalar: TypeAlias = str | int
-FrontmatterValue: TypeAlias = FrontmatterScalar | List[str] | dict[str, FrontmatterScalar]
-Frontmatter: TypeAlias = dict[str, FrontmatterValue]
-
 # --- Lint parsing helpers ---
 
 PARAM_RE = re.compile(r"param '([^']+)'\s*\(")
@@ -146,79 +164,6 @@ FOREST_FALLBACK_MARKER = "FOREST_FALLBACK_USED"
 FOREST_FALLBACK_WARNING_CLASS = "consolidation.forest_fallback"
 CONSOLIDATION_SOURCE_FOREST_NATIVE = "forest-native"
 CONSOLIDATION_SOURCE_FALLBACK_DERIVED = "fallback-derived"
-
-
-@dataclass(frozen=True)
-class Doc:
-    frontmatter: Frontmatter
-    body: str
-
-
-@dataclass(frozen=True)
-class DecisionSurface:
-    path: str
-    qual: str
-    params: tuple[str, ...]
-    meta: str
-
-    @property
-    def is_boundary(self) -> bool:
-        return "boundary" in self.meta
-
-
-@dataclass(frozen=True)
-class LintEntry:
-    path: str
-    line: int
-    col: int
-    code: str
-    message: str
-    param: str | None
-
-
-@dataclass(frozen=True)
-class ConsolidationConfig:
-    min_functions: int = 3
-    min_files: int = 2
-    max_examples: int = 5
-    require_forest: bool = True
-
-
-@dataclass(frozen=True)
-class DocflowInvariant:
-    name: str
-    kind: str
-    spec: ProjectionSpec
-    status: str = "active"
-
-
-@dataclass(frozen=True)
-class DocflowAuditContext:
-    docs: dict[str, Doc]
-    revisions: dict[str, int]
-    invariant_rows: list[dict[str, object]]
-    invariants: list[DocflowInvariant]
-    warnings: list[str]
-    violations: list[str]
-
-
-@dataclass(frozen=True)
-class DocflowObligationResult:
-    entries: list[dict[str, JSONValue]]
-    summary: dict[str, int]
-    warnings: list[str]
-    violations: list[str]
-
-
-@dataclass(frozen=True)
-class AgentDirective:
-    source: str
-    scope_root: str
-    line: int
-    text: str
-    normalized: str
-    mandatory: bool
-    delta_marked: bool
 
 
 def _coerce_argv(argv: list[str] | None) -> list[str]:
@@ -4565,23 +4510,22 @@ def _docflow_command(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 2
-    context = _docflow_audit_context(
-        root,
+    docflow_result, docs = run_docflow_domain(
+        root=root,
         extra_paths=args.extra_path,
         extra_strict=args.extra_strict,
         sppf_gh_ref_mode=sppf_gh_ref_mode,
-    )
-    docs = _load_docflow_docs(root=root, extra_paths=args.extra_path)
-    violations = context.violations
-    warnings = context.warnings
-    obligations = _evaluate_docflow_obligations(
-        root=root,
-        violations=violations,
         baseline_write_emitted=bool(args.baseline_write_emitted),
         delta_guard_checked=bool(args.delta_guard_checked),
+        build_context=_docflow_audit_context,
+        load_docs=_load_docflow_docs,
+        evaluate_obligations=_evaluate_docflow_obligations,
     )
-    warnings = warnings + obligations.warnings
-    violations = violations + obligations.violations
+    context = docflow_result.context
+    obligations = docflow_result.obligations
+    warnings = docflow_result.warnings
+    violations = docflow_result.violations
+    _aggregate = GovernanceAuditAggregateResult(docflow=docflow_result)
     _emit_docflow_suite_artifacts(
         root=root,
         extra_paths=args.extra_path,
@@ -4648,9 +4592,14 @@ def _docflow_command(args: argparse.Namespace) -> int:
 
 def _sppf_graph_command(args: argparse.Namespace) -> int:
     root = Path(args.root)
-    graph = _build_sppf_dependency_graph(root, issues_json=args.issues_json)
+    graph_result = build_sppf_graph(
+        root=root,
+        issues_json=args.issues_json,
+        build_graph=_build_sppf_dependency_graph,
+    )
+    _aggregate = GovernanceAuditAggregateResult(sppf_graph=graph_result)
     _write_sppf_graph_outputs(
-        graph,
+        graph_result.graph,
         json_output=args.json_output,
         dot_output=args.dot_output,
     )
@@ -4662,19 +4611,23 @@ def _sppf_graph_command(args: argparse.Namespace) -> int:
 
 def _status_consistency_command(args: argparse.Namespace) -> int:
     root = Path(args.root)
-    docs = _load_docflow_docs(root=root, extra_paths=args.extra_path)
-    violations, warnings = _sppf_axis_audit(root, docs)
-    sync_violations, sync_warnings = _sppf_sync_check(root, mode="required")
-    violations.extend(sync_violations)
-    warnings.extend(sync_warnings)
+    status_result = run_status_consistency(
+        root=root,
+        extra_paths=args.extra_path,
+        load_docs=_load_docflow_docs,
+        axis_audit=_sppf_axis_audit,
+        sync_check=_sppf_sync_check,
+    )
+    violations = status_result.violations
+    warnings = status_result.warnings
+    rendered = render_compliance(status_result)
+    _aggregate = GovernanceAuditAggregateResult(
+        sppf_status=status_result,
+        compliance_render=rendered,
+    )
     payload = {
         "root": str(root),
-        "violations": violations,
-        "warnings": warnings,
-        "summary": {
-            "violation_count": len(violations),
-            "warning_count": len(warnings),
-        },
+        **status_result.payload,
     }
     if args.json_output is not None:
         args.json_output.parent.mkdir(parents=True, exist_ok=True)
@@ -4685,24 +4638,7 @@ def _status_consistency_command(args: argparse.Namespace) -> int:
         print(f"SPPF status consistency JSON written to {args.json_output}")
     if args.md_output is not None:
         args.md_output.parent.mkdir(parents=True, exist_ok=True)
-        lines = [
-            "# SPPF Status Consistency",
-            "",
-            f"- violations: {len(violations)}",
-            f"- warnings: {len(warnings)}",
-            "",
-        ]
-        if violations:
-            lines.extend(["## Violations", ""])
-            lines.extend(f"- {item}" for item in violations)
-            lines.append("")
-        if warnings:
-            lines.extend(["## Warnings", ""])
-            lines.extend(f"- {item}" for item in warnings)
-            lines.append("")
-        if not warnings and not violations:
-            lines.extend(["No issues detected.", ""])
-        args.md_output.write_text("\n".join(lines), encoding="utf-8")
+        args.md_output.write_text(rendered.status_consistency.markdown, encoding="utf-8")
         print(f"SPPF status consistency markdown written to {args.md_output}")
     if violations and args.fail_on_violations:
         return 1

--- a/src/gabion_governance/sppf_audit/__init__.py
+++ b/src/gabion_governance/sppf_audit/__init__.py
@@ -1,0 +1,4 @@
+from .contracts import SppfGraphResult, SppfStatusConsistencyResult
+from .service import build_sppf_graph, run_status_consistency
+
+__all__ = ["SppfGraphResult", "SppfStatusConsistencyResult", "build_sppf_graph", "run_status_consistency"]

--- a/src/gabion_governance/sppf_audit/contracts.py
+++ b/src/gabion_governance/sppf_audit/contracts.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SppfGraphResult:
+    graph: dict[str, object]
+
+
+@dataclass(frozen=True)
+class SppfStatusConsistencyResult:
+    violations: list[str]
+    warnings: list[str]
+
+    @property
+    def payload(self) -> dict[str, object]:
+        return {
+            "violations": self.violations,
+            "warnings": self.warnings,
+            "summary": {
+                "violation_count": len(self.violations),
+                "warning_count": len(self.warnings),
+            },
+        }

--- a/src/gabion_governance/sppf_audit/service.py
+++ b/src/gabion_governance/sppf_audit/service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from gabion_governance.docflow_audit.contracts import Doc
+
+from .contracts import SppfGraphResult, SppfStatusConsistencyResult
+
+
+def build_sppf_graph(*, root: Path, issues_json: Path | None, build_graph: Callable[..., dict[str, object]]) -> SppfGraphResult:
+    return SppfGraphResult(graph=build_graph(root, issues_json=issues_json))
+
+
+def run_status_consistency(
+    *,
+    root: Path,
+    extra_paths: list[str] | None,
+    load_docs: Callable[..., dict[str, Doc]],
+    axis_audit: Callable[..., tuple[list[str], list[str]]],
+    sync_check: Callable[..., tuple[list[str], list[str]]],
+) -> SppfStatusConsistencyResult:
+    docs = load_docs(root=root, extra_paths=extra_paths)
+    violations, warnings = axis_audit(root, docs)
+    sync_violations, sync_warnings = sync_check(root, mode="required")
+    return SppfStatusConsistencyResult(
+        violations=[*violations, *sync_violations],
+        warnings=[*warnings, *sync_warnings],
+    )

--- a/tests/gabion/tooling/governance/test_compliance_render.py
+++ b/tests/gabion/tooling/governance/test_compliance_render.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from gabion_governance.compliance_render import render_status_consistency_markdown
+from gabion_governance.sppf_audit.contracts import SppfStatusConsistencyResult
+
+
+def test_render_status_consistency_markdown_includes_sections() -> None:
+    rendered = render_status_consistency_markdown(
+        SppfStatusConsistencyResult(violations=["v1"], warnings=["w1"])
+    )
+    assert "# SPPF Status Consistency" in rendered.markdown
+    assert "## Violations" in rendered.markdown
+    assert "- v1" in rendered.markdown
+    assert "## Warnings" in rendered.markdown
+    assert "- w1" in rendered.markdown

--- a/tests/gabion/tooling/governance/test_docflow_domain_service.py
+++ b/tests/gabion/tooling/governance/test_docflow_domain_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion_governance.docflow_audit import (
+    Doc,
+    DocflowAuditContext,
+    DocflowInvariant,
+    DocflowObligationResult,
+    run_docflow_domain,
+)
+from gabion_governance.governance_audit_impl import _make_invariant_spec
+
+
+def test_run_docflow_domain_combines_context_and_obligation_signals() -> None:
+    invariant = DocflowInvariant(
+        name="docflow:test",
+        kind="never",
+        spec=_make_invariant_spec("docflow:test", ["missing_frontmatter"]),
+    )
+
+    def _build_context(*_args, **_kwargs) -> DocflowAuditContext:
+        return DocflowAuditContext(
+            docs={"README.md": Doc(frontmatter={"doc_id": "readme"}, body="body")},
+            revisions={"README.md": 2},
+            invariant_rows=[],
+            invariants=[invariant],
+            warnings=["w1"],
+            violations=["v1"],
+        )
+
+    def _load_docs(*_args, **_kwargs) -> dict[str, Doc]:
+        return {"README.md": Doc(frontmatter={"doc_id": "readme"}, body="body")}
+
+    def _evaluate(*_args, **_kwargs) -> DocflowObligationResult:
+        return DocflowObligationResult(entries=[], summary={}, warnings=["w2"], violations=["v2"])
+
+    result, docs = run_docflow_domain(
+        root=Path("."),
+        extra_paths=None,
+        extra_strict=None,
+        sppf_gh_ref_mode="required",
+        baseline_write_emitted=False,
+        delta_guard_checked=False,
+        build_context=_build_context,
+        load_docs=_load_docs,
+        evaluate_obligations=_evaluate,
+    )
+
+    assert sorted(result.warnings) == ["w1", "w2"]
+    assert sorted(result.violations) == ["v1", "v2"]
+    assert list(docs) == ["README.md"]

--- a/tests/gabion/tooling/governance/test_governance_audit_composition_integration.py
+++ b/tests/gabion/tooling/governance/test_governance_audit_composition_integration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from gabion_governance import governance_audit_impl
+from gabion_governance.sppf_audit.contracts import SppfStatusConsistencyResult
+
+
+def test_status_consistency_command_preserves_markdown_json_shape(tmp_path: Path, monkeypatch) -> None:
+    json_output = tmp_path / "status.json"
+    md_output = tmp_path / "status.md"
+
+    monkeypatch.setattr(
+        governance_audit_impl,
+        "run_status_consistency",
+        lambda **_kwargs: SppfStatusConsistencyResult(violations=["v"], warnings=["w"]),
+    )
+
+    args = argparse.Namespace(
+        root=str(tmp_path),
+        extra_path=None,
+        json_output=json_output,
+        md_output=md_output,
+        fail_on_violations=False,
+    )
+
+    rc = governance_audit_impl._status_consistency_command(args)
+    assert rc == 0
+
+    payload = json.loads(json_output.read_text(encoding="utf-8"))
+    assert payload["summary"] == {"violation_count": 1, "warning_count": 1}
+    assert payload["violations"] == ["v"]
+    assert payload["warnings"] == ["w"]
+
+    markdown = md_output.read_text(encoding="utf-8")
+    assert "# SPPF Status Consistency" in markdown
+    assert "## Violations" in markdown
+    assert "## Warnings" in markdown

--- a/tests/gabion/tooling/governance/test_sppf_domain_service.py
+++ b/tests/gabion/tooling/governance/test_sppf_domain_service.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion_governance.sppf_audit import build_sppf_graph, run_status_consistency
+from gabion_governance.docflow_audit import Doc
+
+
+def test_build_sppf_graph_returns_typed_result() -> None:
+    result = build_sppf_graph(
+        root=Path("."),
+        issues_json=None,
+        build_graph=lambda *_args, **_kwargs: {"format_version": 1},
+    )
+    assert result.graph["format_version"] == 1
+
+
+def test_run_status_consistency_merges_axis_and_sync_findings() -> None:
+    result = run_status_consistency(
+        root=Path("."),
+        extra_paths=None,
+        load_docs=lambda **_kwargs: {"README.md": Doc(frontmatter={}, body="")},
+        axis_audit=lambda *_args, **_kwargs: (["axis-v"], ["axis-w"]),
+        sync_check=lambda *_args, **_kwargs: (["sync-v"], ["sync-w"]),
+    )
+    assert result.violations == ["axis-v", "sync-v"]
+    assert result.warnings == ["axis-w", "sync-w"]
+    assert result.payload["summary"]["violation_count"] == 2


### PR DESCRIPTION
### Motivation
- Reduce coupling and improve ownership by partitioning the large `governance_audit_impl.py` audit surface into focused domain modules for docflow, SPPF checks, and compliance rendering.
- Move domain dataclasses and typed contracts close to the logic that owns them to make boundaries explicit and simplify future refactors.
- Provide a single, typed aggregate result and preserve the existing CLI/compatibility import surface while delegating implementation to the new services.

### Description
- Introduce three new domain packages under `src/gabion_governance/`: `docflow_audit/` (contracts + `run_docflow_domain`), `sppf_audit/` (contracts + `build_sppf_graph` and `run_status_consistency`), and `compliance_render/` (rendering helpers and contracts).
- Extracted dataclasses and type aliases (e.g. `Doc`, `AgentDirective`, `DocflowInvariant`, `DocflowAuditContext`, `DocflowObligationResult`, `DecisionSurface`, `LintEntry`, `ConsolidationConfig`) into domain-local `contracts.py`/`decision_contracts.py` files.
- Added `GovernanceAuditAggregateResult` as a top-level aggregate envelope and updated `governance_audit_impl.py` to act as a compatibility facade that delegates `_docflow_command`, `_sppf_graph_command`, and `_status_consistency_command` to the new domain services.
- Added focused unit tests for the new domain services and one integration test validating the parity/shape of the composed status-consistency markdown/JSON output, and added `compliance_render` consumers for formatted outputs.

### Testing
- Ran targeted unit tests with `PYTHONPATH=src:. python -m pytest -q -o addopts='' tests/gabion/tooling/governance/test_docflow_domain_service.py tests/gabion/tooling/governance/test_sppf_domain_service.py tests/gabion/tooling/governance/test_compliance_render.py tests/gabion/tooling/governance/test_governance_audit_composition_integration.py`, which passed (`5 passed`).
- Ran additional governance tests with `PYTHONPATH=src:. python -m pytest -q -o addopts='' tests/gabion/tooling/governance/test_governance_audit_adapter.py tests/gabion/tooling/docflow/test_docflow_violation_formatter.py`, which passed.
- Executed policy checks `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` and `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract`, both of which completed successfully in this environment.
- Verified byte-compile for new modules with `python -m py_compile` and refreshed evidence with `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`, noting the evidence file was intentionally updated to include the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8912f7e388324a687a5f41cb755ae)