### PR TITLE
Refactor CLI composition root to use shared runtime facades

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -22,6 +22,7 @@ from gabion.cli_support.check.check_commands import (
     register_check_delta_bundle_command as _register_check_delta_bundle_command, register_check_group_callback as _register_check_group_callback, register_check_run_command as _register_check_run_command)
 from gabion.cli_support.check.check_command_runtime import (
     check_raw_profile_args as _check_raw_profile_args_impl, run_check_aux_operation as _run_check_aux_operation_impl, run_check_command as _run_check_command_impl, run_check_raw_profile as _run_check_raw_profile_impl)
+from gabion.cli_support.check import check_runtime_facade
 from gabion.cli_support.check.check_execution_plan import (
     check_derived_artifacts as _check_derived_artifacts_impl, build_check_execution_plan_request as _build_check_execution_plan_request_impl)
 from gabion.cli_support.check.check_runtime import run_check as _run_check_impl
@@ -39,6 +40,16 @@ from gabion.cli_support.shared.output_emitters import (
     emit_dataflow_result_outputs as _emit_dataflow_result_outputs_impl, is_stdout_target as _is_stdout_target_impl,
     normalize_output_target as _normalize_output_target_impl, write_lint_sarif as _write_lint_sarif_impl,
     write_text_to_target as _write_text_to_target_impl)
+from gabion.cli_support.shared import result_emitters
+from gabion.cli_support.shared.runtime_deps import (
+    CliRuntimeDeps,
+    CliRunCiWatchFn,
+    CliRunCheckDeltaGatesFn,
+    CliRunCheckFn,
+    CliRunDataflowRawArgvFn,
+    CliRunSppfSyncFn,
+    context_cli_runtime_deps,
+)
 from gabion.cli_support.synth.synth_runtime import run_synth as _run_synth_impl
 from gabion.cli_support.synth.synth_commands import (
     register_synth_command as _register_synth_command)
@@ -63,7 +74,6 @@ from gabion.analysis.foundation.timeout_context import (
     check_deadline, deadline_loop_iter, render_deadline_profile_markdown)
 from gabion.commands import (
     boundary_order, check_contract, command_ids, progress_contract as progress_timeline, transport_policy)
-from gabion.commands.lint_parser import parse_lint_line
 from gabion.runtime import deadline_policy, env_policy, path_policy, policy_runtime
 
 DATAFLOW_COMMAND = command_ids.DATAFLOW_COMMAND
@@ -127,16 +137,6 @@ check_app.add_typer(check_taint_app, name="taint")
 Runner: TypeAlias = Callable[..., JSONObject]
 DEFAULT_RUNNER: Runner = run_command
 
-CliRunDataflowRawArgvFn: TypeAlias = Callable[[list[str]], None]
-CliRunCheckFn: TypeAlias = Callable[..., JSONObject]
-CliRunSppfSyncFn: TypeAlias = Callable[..., int]
-CliRunCheckDeltaGatesFn: TypeAlias = Callable[[], int]
-CliRunCiWatchFn: TypeAlias = Callable[
-    [tooling_ci_watch.StatusWatchOptions],
-    tooling_ci_watch.StatusWatchResult,
-]
-
-
 _DEFAULT_TIMEOUT_TICKS = 100
 _DEFAULT_TIMEOUT_TICK_NS = 1_000_000
 _DEFAULT_CHECK_REPORT_REL_PATH = path_policy.DEFAULT_CHECK_REPORT_REL_PATH
@@ -198,79 +198,15 @@ class SppfSyncCommitInfo:
     body: str
 
 
-@dataclass(frozen=True)
-class CliDeps:
-    run_dataflow_raw_argv_fn: CliRunDataflowRawArgvFn
-    run_check_fn: CliRunCheckFn
-    run_sppf_sync_fn: CliRunSppfSyncFn
-    run_check_delta_gates_fn: CliRunCheckDeltaGatesFn
-    run_ci_watch_fn: CliRunCiWatchFn
-
-
-def _context_callable_dep(
-    *,
-    ctx: typer.Context,
-    key: str,
-    default: Callable[..., object],
-) -> Callable[..., object]:
-    obj = ctx.obj
-    if not isinstance(obj, Mapping):
-        return default
-    candidate = obj.get(key)
-    if candidate is None:
-        return default
-    if callable(candidate):
-        return candidate
-    never(
-        "invalid cli dependency override",
-        dependency=key,
-        value_type=type(candidate).__name__,
-    )
-    return default  # pragma: no cover - never() raises
-
-
-def _context_cli_deps(ctx: typer.Context) -> CliDeps:
-    return CliDeps(
-        run_dataflow_raw_argv_fn=cast(
-            CliRunDataflowRawArgvFn,
-            _context_callable_dep(
-                ctx=ctx,
-                key="run_dataflow_raw_argv",
-                default=_run_dataflow_raw_argv,
-            ),
-        ),
-        run_check_fn=cast(
-            CliRunCheckFn,
-            _context_callable_dep(
-                ctx=ctx,
-                key="run_check",
-                default=run_check,
-            ),
-        ),
-        run_sppf_sync_fn=cast(
-            CliRunSppfSyncFn,
-            _context_callable_dep(
-                ctx=ctx,
-                key="run_sppf_sync",
-                default=_run_sppf_sync,
-            ),
-        ),
-        run_check_delta_gates_fn=cast(
-            CliRunCheckDeltaGatesFn,
-            _context_callable_dep(
-                ctx=ctx,
-                key="run_check_delta_gates",
-                default=_run_check_delta_gates,
-            ),
-        ),
-        run_ci_watch_fn=cast(
-            CliRunCiWatchFn,
-            _context_callable_dep(
-                ctx=ctx,
-                key="run_ci_watch",
-                default=_run_ci_watch,
-            ),
-        ),
+def _context_cli_deps(ctx: typer.Context) -> CliRuntimeDeps:
+    return context_cli_runtime_deps(
+        ctx=ctx,
+        default_run_dataflow_raw_argv_fn=_run_dataflow_raw_argv,
+        default_run_check_fn=run_check,
+        default_run_sppf_sync_fn=_run_sppf_sync,
+        default_run_check_delta_gates_fn=_run_check_delta_gates,
+        default_run_ci_watch_fn=_run_ci_watch,
+        never_fn=never,
     )
 
 
@@ -543,24 +479,11 @@ def _split_csv(value: str) -> list[str]:
 
 
 def _parse_lint_line(line: str) -> dict[str, object] | None:
-    entry = parse_lint_line(line)
-    if entry is None:
-        return None
-    return {
-        **entry.model_dump(),
-        "severity": "warning",
-    }
+    return result_emitters.parse_lint_line_entry(line)
 
 
 def _collect_lint_entries(lines: list[str]) -> list[dict[str, object]]:
-    check_deadline()
-    entries: list[dict[str, object]] = []
-    for line in lines:
-        check_deadline()
-        parsed = _parse_lint_line(line)
-        if parsed is not None:
-            entries.append(parsed)
-    return entries
+    return result_emitters.collect_lint_entries(lines, check_deadline_fn=check_deadline)
 
 
 def _is_stdout_target(target: object) -> bool:
@@ -609,13 +532,14 @@ def _normalize_optional_output_target(target: object) -> str | None:
 
 
 def _write_lint_jsonl(target: str, entries: list[dict[str, object]]) -> None:
-    payload = "\n".join(json.dumps(entry, sort_keys=False) for entry in entries)
-    _write_text_to_target(
+    result_emitters.write_lint_jsonl(
         target,
-        payload,
-        ensure_trailing_newline=bool(payload),
+        entries,
+        write_text_to_target_fn=_write_text_to_target,
     )
 
+
+_TargetStreamRouter = result_emitters.TargetStreamRouter
 
 _write_lint_sarif = cast(
     Callable[[str, list[dict[str, object]]], None],
@@ -636,17 +560,16 @@ def _emit_lint_outputs(
     lint_sarif: Optional[Path],
     lint_entries: list[dict[str, object]] | None = None,
 ) -> None:
-    check_deadline()
-    if lint:
-        for line in lint_lines:
-            check_deadline()
-            typer.echo(line)
-    if lint_jsonl or lint_sarif:
-        entries = lint_entries if lint_entries is not None else _collect_lint_entries(lint_lines)
-        if lint_jsonl is not None:
-            _write_lint_jsonl(str(lint_jsonl), entries)
-        if lint_sarif is not None:
-            _write_lint_sarif(str(lint_sarif), entries)
+    result_emitters.emit_lint_outputs(
+        lint_lines,
+        lint=lint,
+        lint_jsonl=lint_jsonl,
+        lint_sarif=lint_sarif,
+        lint_entries=lint_entries,
+        check_deadline_fn=check_deadline,
+        write_lint_jsonl_fn=_write_lint_jsonl,
+        write_lint_sarif_fn=_write_lint_sarif,
+    )
 
 
 def _emit_timeout_profile_artifacts(
@@ -654,23 +577,11 @@ def _emit_timeout_profile_artifacts(
     *,
     root: Path,
 ) -> None:
-    timeout_context = result.get("timeout_context")
-    if not isinstance(timeout_context, Mapping):
-        return
-    profile = timeout_context.get("deadline_profile")
-    if not isinstance(profile, Mapping):
-        return
-    artifact_dir = root / "artifacts" / "out"
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    profile_json_path = artifact_dir / "deadline_profile.json"
-    profile_md_path = artifact_dir / "deadline_profile.md"
-    profile_json_path.write_text(json.dumps(profile, indent=2, sort_keys=False) + "\n")
-    profile_md_path.write_text(
-        render_deadline_profile_markdown(profile) + "\n",
-        encoding="utf-8",
+    result_emitters.emit_timeout_profile_artifacts(
+        result,
+        root=root,
+        render_deadline_profile_markdown_fn=render_deadline_profile_markdown,
     )
-    typer.echo(f"Wrote deadline profile JSON: {profile_json_path}")
-    typer.echo(f"Wrote deadline profile markdown: {profile_md_path}")
 
 
 _render_timeout_progress_markdown = _render_timeout_progress_markdown_impl
@@ -858,38 +769,11 @@ _run_check_raw_profile = cast(
 
 
 def _nonzero_exit_causes(result: JSONObject) -> list[str]:
-    causes: list[str] = []
-    if bool(result.get("timeout", False)):
-        analysis_state = str(result.get("analysis_state") or "unknown")
-        causes.append(f"timeout (analysis_state={analysis_state})")
-    violations = int(result.get("violations", 0) or 0)
-    if violations > 0:
-        causes.append(f"policy violations={violations}")
-    type_ambiguities_raw = result.get("type_ambiguities")
-    if isinstance(type_ambiguities_raw, list) and type_ambiguities_raw:
-        causes.append(f"type ambiguities={len(type_ambiguities_raw)}")
-    errors_raw = result.get("errors")
-    if isinstance(errors_raw, list) and errors_raw:
-        first_error = str(errors_raw[0])
-        if len(errors_raw) > 1:
-            causes.append(f"errors={len(errors_raw)} (first: {first_error})")
-        else:
-            causes.append(f"error: {first_error}")
-    if not causes:
-        analysis_state = str(result.get("analysis_state") or "unknown")
-        causes.append(
-            "no explicit violations/type ambiguities/errors were returned; "
-            f"analysis_state={analysis_state}"
-        )
-    return causes
+    return result_emitters.nonzero_exit_causes(result)
 
 
 def _emit_nonzero_exit_causes(result: JSONObject) -> None:
-    exit_code = int(result.get("exit_code", 0) or 0)
-    if exit_code == 0:
-        return
-    causes = "; ".join(_nonzero_exit_causes(result))
-    typer.echo(f"Non-zero exit ({exit_code}) cause(s): {causes}", err=True)
+    result_emitters.emit_nonzero_exit_causes(result)
 
 
 def _emit_resume_state_startup_line(
@@ -983,22 +867,7 @@ def _emit_phase_timeline_progress(*, header: str | None, row: str) -> None:
 
 
 def _emit_analysis_resume_summary(result: JSONObject) -> None:
-    resume = result.get("analysis_resume")
-    if not isinstance(resume, Mapping):
-        return
-    path = str(resume.get("state_path", "") or "")
-    status = str(resume.get("status", "") or "")
-    reused_files = int(resume.get("reused_files", 0) or 0)
-    total_files = int(resume.get("total_files", 0) or 0)
-    remaining_files = int(resume.get("remaining_files", 0) or 0)
-    cache_verdict = str(resume.get("cache_verdict", "") or "")
-    status_suffix = f" status={status}" if status else ""
-    verdict_suffix = f" cache_verdict={cache_verdict}" if cache_verdict else ""
-    typer.echo(
-        "Resume state: "
-        f"path={path or '<none>'} reused_files={reused_files}/{total_files} "
-        f"remaining_files={remaining_files}{status_suffix}{verdict_suffix}"
-    )
+    result_emitters.emit_analysis_resume_summary(result)
 
 
 def _context_run_dataflow_raw_argv(ctx: typer.Context) -> Callable[[list[str]], None]:
@@ -1074,42 +943,19 @@ def _run_dataflow_raw_argv(
 
 
 def _default_check_artifact_flags() -> CheckArtifactFlags:
-    return CheckArtifactFlags(
-        emit_test_obsolescence=False,
-        emit_test_evidence_suggestions=False,
-        emit_call_clusters=False,
-        emit_call_cluster_consolidation=False,
-        emit_test_annotation_drift=False,
-        emit_semantic_coverage_map=False,
-    )
+    return check_runtime_facade.default_check_artifact_flags()
 
 
 def _default_check_delta_options() -> CheckDeltaOptions:
-    return CheckDeltaOptions(
-        obsolescence_mode=check_contract.CheckAuxMode(kind="off"),
-        annotation_drift_mode=check_contract.CheckAuxMode(kind="off"),
-        ambiguity_mode=check_contract.CheckAuxMode(kind="off"),
-        semantic_coverage_mapping=None,
-    )
+    return check_runtime_facade.default_check_delta_options()
 
 
 def _check_help_or_exit(ctx: typer.Context) -> None:
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.get_help())
-        raise typer.Exit(code=2)
+    check_runtime_facade.check_help_or_exit(ctx)
 
 
 def _check_gate_policy(gate: CheckGateMode) -> tuple[bool, bool]:
-    if gate is CheckGateMode.all:
-        return True, True
-    if gate is CheckGateMode.none:
-        return False, False
-    if gate is CheckGateMode.violations:
-        return True, False
-    if gate is CheckGateMode.type_ambiguities:
-        return False, True
-    never("invalid check gate mode", gate=str(gate))
-    return False, False  # pragma: no cover
+    return check_runtime_facade.check_gate_policy(gate, never_fn=never)
 
 
 def _check_lint_mode(
@@ -1118,42 +964,11 @@ def _check_lint_mode(
     lint_jsonl_out: Path | None,
     lint_sarif_out: Path | None,
 ) -> tuple[bool, bool]:
-    line_enabled = lint_mode in {
-        CheckLintMode.line,
-        CheckLintMode.line_jsonl,
-        CheckLintMode.line_sarif,
-        CheckLintMode.all,
-    }
-    jsonl_enabled = lint_mode in {
-        CheckLintMode.jsonl,
-        CheckLintMode.line_jsonl,
-        CheckLintMode.jsonl_sarif,
-        CheckLintMode.all,
-    }
-    sarif_enabled = lint_mode in {
-        CheckLintMode.sarif,
-        CheckLintMode.line_sarif,
-        CheckLintMode.jsonl_sarif,
-        CheckLintMode.all,
-    }
-    if jsonl_enabled and lint_jsonl_out is None:
-        raise typer.BadParameter(
-            "--lint-jsonl-out is required when --lint includes jsonl output."
-        )
-    if sarif_enabled and lint_sarif_out is None:
-        raise typer.BadParameter(
-            "--lint-sarif-out is required when --lint includes sarif output."
-        )
-    if not jsonl_enabled and lint_jsonl_out is not None:
-        raise typer.BadParameter(
-            "--lint-jsonl-out is only valid when --lint includes jsonl."
-        )
-    if not sarif_enabled and lint_sarif_out is not None:
-        raise typer.BadParameter(
-            "--lint-sarif-out is only valid when --lint includes sarif."
-        )
-    lint_enabled = lint_mode is not CheckLintMode.none
-    return lint_enabled, line_enabled
+    return check_runtime_facade.check_lint_mode(
+        lint_mode=lint_mode,
+        lint_jsonl_out=lint_jsonl_out,
+        lint_sarif_out=lint_sarif_out,
+    )
 
 
 _build_status_watch_options = cast(

--- a/src/gabion/cli_support/check/check_command_runtime.py
+++ b/src/gabion/cli_support/check/check_command_runtime.py
@@ -9,13 +9,14 @@ from typing import Callable, Mapping
 import typer
 
 from gabion.commands import check_contract
+from gabion.cli_support.shared.runtime_deps import CliRuntimeDeps
 from gabion.json_types import JSONObject
 
 CheckArtifactFlags = check_contract.CheckArtifactFlags
 DataflowFilterBundle = check_contract.DataflowFilterBundle
 CheckAuxOperation = check_contract.CheckAuxOperation
 
-ContextCliDepsFn = Callable[[typer.Context], object]
+ContextCliDepsFn = Callable[[typer.Context], CliRuntimeDeps]
 RunWithTimeoutRetriesFn = Callable[..., JSONObject]
 PhaseProgressFromNotificationFn = Callable[[Mapping[str, object]], dict[str, object] | None]
 PhaseProgressSignatureFn = Callable[[Mapping[str, object]], tuple[object, ...]]

--- a/src/gabion/cli_support/check/check_runtime_facade.py
+++ b/src/gabion/cli_support/check/check_runtime_facade.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import typer
+
+from gabion.commands import check_contract
+
+CheckArtifactFlags = check_contract.CheckArtifactFlags
+CheckDeltaOptions = check_contract.CheckDeltaOptions
+
+
+def default_check_artifact_flags() -> CheckArtifactFlags:
+    return CheckArtifactFlags(
+        emit_test_obsolescence=False,
+        emit_test_evidence_suggestions=False,
+        emit_call_clusters=False,
+        emit_call_cluster_consolidation=False,
+        emit_test_annotation_drift=False,
+        emit_semantic_coverage_map=False,
+    )
+
+
+def default_check_delta_options() -> CheckDeltaOptions:
+    return CheckDeltaOptions(
+        obsolescence_mode=check_contract.CheckAuxMode(kind="off"),
+        annotation_drift_mode=check_contract.CheckAuxMode(kind="off"),
+        ambiguity_mode=check_contract.CheckAuxMode(kind="off"),
+        semantic_coverage_mapping=None,
+    )
+
+
+def check_help_or_exit(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(code=2)
+
+
+def check_gate_policy(gate: object, *, never_fn: Callable[..., object]) -> tuple[bool, bool]:
+    gate_value = str(getattr(gate, "value", gate))
+    if gate_value == "all":
+        return True, True
+    if gate_value == "none":
+        return False, False
+    if gate_value == "violations":
+        return True, False
+    if gate_value == "type-ambiguities":
+        return False, True
+    never_fn("invalid check gate mode", gate=gate_value)
+    return False, False  # pragma: no cover
+
+
+def check_lint_mode(
+    *,
+    lint_mode: object,
+    lint_jsonl_out: Path | None,
+    lint_sarif_out: Path | None,
+) -> tuple[bool, bool]:
+    lint_value = str(getattr(lint_mode, "value", lint_mode))
+    line_enabled = lint_value in {"line", "line+jsonl", "line+sarif", "all"}
+    jsonl_enabled = lint_value in {"jsonl", "line+jsonl", "jsonl+sarif", "all"}
+    sarif_enabled = lint_value in {"sarif", "line+sarif", "jsonl+sarif", "all"}
+    if jsonl_enabled and lint_jsonl_out is None:
+        raise typer.BadParameter(
+            "--lint-jsonl-out is required when --lint includes jsonl output."
+        )
+    if sarif_enabled and lint_sarif_out is None:
+        raise typer.BadParameter(
+            "--lint-sarif-out is required when --lint includes sarif output."
+        )
+    if not jsonl_enabled and lint_jsonl_out is not None:
+        raise typer.BadParameter(
+            "--lint-jsonl-out is only valid when --lint includes jsonl."
+        )
+    if not sarif_enabled and lint_sarif_out is not None:
+        raise typer.BadParameter(
+            "--lint-sarif-out is only valid when --lint includes sarif."
+        )
+    lint_enabled = lint_value != "none"
+    return lint_enabled, line_enabled

--- a/src/gabion/cli_support/shared/result_emitters.py
+++ b/src/gabion/cli_support/shared/result_emitters.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Mapping
+
+import typer
+
+from gabion.commands.lint_parser import parse_lint_line
+from gabion.json_types import JSONObject
+
+CheckDeadlineFn = Callable[[], None]
+WriteTextToTargetFn = Callable[..., None]
+WriteLintSarifFn = Callable[[str, list[dict[str, object]]], None]
+RenderDeadlineProfileMarkdownFn = Callable[[Mapping[str, object]], str]
+
+
+
+
+class TargetStreamRouter:
+    def __init__(self, *, max_open_streams: int = 8) -> None:
+        self._max_open_streams = max(1, int(max_open_streams))
+        self._streams: dict[str, tuple[object, str]] = {}
+
+    def _stream_for_target(self, *, target: str, encoding: str):
+        existing = self._streams.get(target)
+        if existing is not None:
+            stream, current_encoding = existing
+            if current_encoding == encoding:
+                return stream
+            stream.close()
+            self._streams.pop(target, None)
+        if len(self._streams) >= self._max_open_streams:
+            oldest_target = next(iter(self._streams))
+            oldest_stream, _ = self._streams.pop(oldest_target)
+            oldest_stream.close()
+        stream = Path(target).open("w", encoding=encoding)
+        self._streams[target] = (stream, encoding)
+        return stream
+
+    def write(self, *, target: str, payload: str, encoding: str = "utf-8") -> None:
+        stream = self._stream_for_target(target=target, encoding=encoding)
+        stream.seek(0)
+        stream.truncate(0)
+        stream.write(payload)
+        stream.flush()
+
+    def close(self) -> None:
+        for target in list(self._streams):
+            stream, _ = self._streams.pop(target)
+            stream.close()
+
+
+def parse_lint_line_entry(line: str) -> dict[str, object] | None:
+    entry = parse_lint_line(line)
+    if entry is None:
+        return None
+    return {
+        **entry.model_dump(),
+        "severity": "warning",
+    }
+
+
+def collect_lint_entries(
+    lines: list[str],
+    *,
+    check_deadline_fn: CheckDeadlineFn,
+) -> list[dict[str, object]]:
+    check_deadline_fn()
+    entries: list[dict[str, object]] = []
+    for line in lines:
+        check_deadline_fn()
+        parsed = parse_lint_line_entry(line)
+        if parsed is not None:
+            entries.append(parsed)
+    return entries
+
+
+def write_lint_jsonl(
+    target: str,
+    entries: list[dict[str, object]],
+    *,
+    write_text_to_target_fn: WriteTextToTargetFn,
+) -> None:
+    payload = "\n".join(json.dumps(entry, sort_keys=False) for entry in entries)
+    write_text_to_target_fn(
+        target,
+        payload,
+        ensure_trailing_newline=bool(payload),
+    )
+
+
+def emit_lint_outputs(
+    lint_lines: list[str],
+    *,
+    lint: bool,
+    lint_jsonl: Path | None,
+    lint_sarif: Path | None,
+    check_deadline_fn: CheckDeadlineFn,
+    write_lint_jsonl_fn: Callable[[str, list[dict[str, object]]], None],
+    write_lint_sarif_fn: WriteLintSarifFn,
+    lint_entries: list[dict[str, object]] | None = None,
+) -> None:
+    check_deadline_fn()
+    if lint:
+        for line in lint_lines:
+            check_deadline_fn()
+            typer.echo(line)
+    if lint_jsonl or lint_sarif:
+        entries = (
+            lint_entries
+            if lint_entries is not None
+            else collect_lint_entries(lint_lines, check_deadline_fn=check_deadline_fn)
+        )
+        if lint_jsonl is not None:
+            write_lint_jsonl_fn(str(lint_jsonl), entries)
+        if lint_sarif is not None:
+            write_lint_sarif_fn(str(lint_sarif), entries)
+
+
+def emit_timeout_profile_artifacts(
+    result: Mapping[str, object],
+    *,
+    root: Path,
+    render_deadline_profile_markdown_fn: RenderDeadlineProfileMarkdownFn,
+) -> None:
+    timeout_context = result.get("timeout_context")
+    if not isinstance(timeout_context, Mapping):
+        return
+    profile = timeout_context.get("deadline_profile")
+    if not isinstance(profile, Mapping):
+        return
+    artifact_dir = root / "artifacts" / "out"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    profile_json_path = artifact_dir / "deadline_profile.json"
+    profile_md_path = artifact_dir / "deadline_profile.md"
+    profile_json_path.write_text(json.dumps(profile, indent=2, sort_keys=False) + "\n")
+    profile_md_path.write_text(
+        render_deadline_profile_markdown_fn(profile) + "\n",
+        encoding="utf-8",
+    )
+    typer.echo(f"Wrote deadline profile JSON: {profile_json_path}")
+    typer.echo(f"Wrote deadline profile markdown: {profile_md_path}")
+
+
+def nonzero_exit_causes(result: JSONObject) -> list[str]:
+    causes: list[str] = []
+    if bool(result.get("timeout", False)):
+        analysis_state = str(result.get("analysis_state") or "unknown")
+        causes.append(f"timeout (analysis_state={analysis_state})")
+    violations = int(result.get("violations", 0) or 0)
+    if violations > 0:
+        causes.append(f"policy violations={violations}")
+    type_ambiguities_raw = result.get("type_ambiguities")
+    if isinstance(type_ambiguities_raw, list) and type_ambiguities_raw:
+        causes.append(f"type ambiguities={len(type_ambiguities_raw)}")
+    errors_raw = result.get("errors")
+    if isinstance(errors_raw, list) and errors_raw:
+        first_error = str(errors_raw[0])
+        if len(errors_raw) > 1:
+            causes.append(f"errors={len(errors_raw)} (first: {first_error})")
+        else:
+            causes.append(f"error: {first_error}")
+    if not causes:
+        analysis_state = str(result.get("analysis_state") or "unknown")
+        causes.append(
+            "no explicit violations/type ambiguities/errors were returned; "
+            f"analysis_state={analysis_state}"
+        )
+    return causes
+
+
+def emit_nonzero_exit_causes(result: JSONObject) -> None:
+    exit_code = int(result.get("exit_code", 0) or 0)
+    if exit_code == 0:
+        return
+    causes = "; ".join(nonzero_exit_causes(result))
+    typer.echo(f"Non-zero exit ({exit_code}) cause(s): {causes}", err=True)
+
+
+def emit_analysis_resume_summary(result: JSONObject) -> None:
+    resume = result.get("analysis_resume")
+    if not isinstance(resume, Mapping):
+        return
+    path = str(resume.get("state_path", "") or "")
+    status = str(resume.get("status", "") or "")
+    reused_files = int(resume.get("reused_files", 0) or 0)
+    total_files = int(resume.get("total_files", 0) or 0)
+    remaining_files = int(resume.get("remaining_files", 0) or 0)
+    cache_verdict = str(resume.get("cache_verdict", "") or "")
+    status_suffix = f" status={status}" if status else ""
+    verdict_suffix = f" cache_verdict={cache_verdict}" if cache_verdict else ""
+    typer.echo(
+        "Resume state: "
+        f"path={path or '<none>'} reused_files={reused_files}/{total_files} "
+        f"remaining_files={remaining_files}{status_suffix}{verdict_suffix}"
+    )

--- a/src/gabion/cli_support/shared/runtime_deps.py
+++ b/src/gabion/cli_support/shared/runtime_deps.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Protocol, TypeAlias, cast
+
+import typer
+
+from gabion.json_types import JSONObject
+from gabion.tooling.runtime import ci_watch as tooling_ci_watch
+
+CliRunDataflowRawArgvFn: TypeAlias = Callable[[list[str]], None]
+CliRunCheckFn: TypeAlias = Callable[..., JSONObject]
+CliRunSppfSyncFn: TypeAlias = Callable[..., int]
+CliRunCheckDeltaGatesFn: TypeAlias = Callable[[], int]
+CliRunCiWatchFn: TypeAlias = Callable[
+    [tooling_ci_watch.StatusWatchOptions],
+    tooling_ci_watch.StatusWatchResult,
+]
+
+
+class CliRuntimeDeps(Protocol):
+    run_dataflow_raw_argv_fn: CliRunDataflowRawArgvFn
+    run_check_fn: CliRunCheckFn
+    run_sppf_sync_fn: CliRunSppfSyncFn
+    run_check_delta_gates_fn: CliRunCheckDeltaGatesFn
+    run_ci_watch_fn: CliRunCiWatchFn
+
+
+@dataclass(frozen=True)
+class CliRuntimeDepsBundle:
+    run_dataflow_raw_argv_fn: CliRunDataflowRawArgvFn
+    run_check_fn: CliRunCheckFn
+    run_sppf_sync_fn: CliRunSppfSyncFn
+    run_check_delta_gates_fn: CliRunCheckDeltaGatesFn
+    run_ci_watch_fn: CliRunCiWatchFn
+
+
+def context_callable_dep(
+    *,
+    ctx: typer.Context,
+    key: str,
+    default: Callable[..., object],
+    never_fn: Callable[..., object],
+) -> Callable[..., object]:
+    obj = ctx.obj
+    if not isinstance(obj, Mapping):
+        return default
+    candidate = obj.get(key)
+    if candidate is None:
+        return default
+    if callable(candidate):
+        return candidate
+    never_fn(
+        "invalid cli dependency override",
+        dependency=key,
+        value_type=type(candidate).__name__,
+    )
+    return default  # pragma: no cover - never() raises
+
+
+def context_cli_runtime_deps(
+    *,
+    ctx: typer.Context,
+    default_run_dataflow_raw_argv_fn: CliRunDataflowRawArgvFn,
+    default_run_check_fn: CliRunCheckFn,
+    default_run_sppf_sync_fn: CliRunSppfSyncFn,
+    default_run_check_delta_gates_fn: CliRunCheckDeltaGatesFn,
+    default_run_ci_watch_fn: CliRunCiWatchFn,
+    never_fn: Callable[..., object],
+) -> CliRuntimeDepsBundle:
+    return CliRuntimeDepsBundle(
+        run_dataflow_raw_argv_fn=cast(
+            CliRunDataflowRawArgvFn,
+            context_callable_dep(
+                ctx=ctx,
+                key="run_dataflow_raw_argv",
+                default=default_run_dataflow_raw_argv_fn,
+                never_fn=never_fn,
+            ),
+        ),
+        run_check_fn=cast(
+            CliRunCheckFn,
+            context_callable_dep(
+                ctx=ctx,
+                key="run_check",
+                default=default_run_check_fn,
+                never_fn=never_fn,
+            ),
+        ),
+        run_sppf_sync_fn=cast(
+            CliRunSppfSyncFn,
+            context_callable_dep(
+                ctx=ctx,
+                key="run_sppf_sync",
+                default=default_run_sppf_sync_fn,
+                never_fn=never_fn,
+            ),
+        ),
+        run_check_delta_gates_fn=cast(
+            CliRunCheckDeltaGatesFn,
+            context_callable_dep(
+                ctx=ctx,
+                key="run_check_delta_gates",
+                default=default_run_check_delta_gates_fn,
+                never_fn=never_fn,
+            ),
+        ),
+        run_ci_watch_fn=cast(
+            CliRunCiWatchFn,
+            context_callable_dep(
+                ctx=ctx,
+                key="run_ci_watch",
+                default=default_run_ci_watch_fn,
+                never_fn=never_fn,
+            ),
+        ),
+    )

--- a/tests/gabion/cli/test_cli_architecture_entrypoint.py
+++ b/tests/gabion/cli/test_cli_architecture_entrypoint.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+CLI_PATH = Path("src/gabion/cli.py")
+
+
+def _function_nodes() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(CLI_PATH.read_text(encoding="utf-8"), filename=str(CLI_PATH))
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+
+
+# gabion:evidence E:function_site::cli.py::gabion.cli._emit_lint_outputs E:function_site::cli.py::gabion.cli._check_gate_policy
+def test_cli_runtime_helpers_are_thin_facades() -> None:
+    functions = _function_nodes()
+    facade_names = {
+        "_parse_lint_line",
+        "_collect_lint_entries",
+        "_write_lint_jsonl",
+        "_emit_lint_outputs",
+        "_emit_timeout_profile_artifacts",
+        "_default_check_artifact_flags",
+        "_default_check_delta_options",
+        "_check_help_or_exit",
+        "_check_gate_policy",
+        "_check_lint_mode",
+        "_nonzero_exit_causes",
+        "_emit_nonzero_exit_causes",
+        "_emit_analysis_resume_summary",
+    }
+    missing = facade_names - functions.keys()
+    assert not missing
+
+    for name in sorted(facade_names):
+        body = functions[name].body
+        assert len(body) <= 2, f"{name} should stay a thin facade"
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_architecture_entrypoint.py::test_cli_runtime_logic_resides_in_support_modules::cli.py::gabion.cli._context_cli_deps
+def test_cli_runtime_logic_resides_in_support_modules() -> None:
+    source = CLI_PATH.read_text(encoding="utf-8")
+    assert "result_emitters." in source
+    assert "check_runtime_facade." in source
+    assert "context_cli_runtime_deps(" in source


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc dependency wiring and move runtime behavior out of `src/gabion/cli.py` so the file acts strictly as a composition root (argument registration, dependency injection, exit plumbing).
- Centralize common CLI runtime helpers (lint/output/timeout/non-zero exit emission) and provide a single injection surface so command families share a predictable runtime dependency contract.

### Description
- Introduce `CliRuntimeDeps` protocol and `context_cli_runtime_deps` resolver in `src/gabion/cli_support/shared/runtime_deps.py` and switch `cli.py` to use this unified injection surface for all runtime callbacks.
- Extract result emission helpers (lint parsing/collection, jsonl/sarif writers, timeout profile artifact emission, non-zero-exit/resume summary emitters) into `src/gabion/cli_support/shared/result_emitters.py` and delegate from `cli.py` via small thin facades.
- Add `src/gabion/cli_support/check/check_runtime_facade.py` housing check-specific small helpers (default artifact/delta option builders, lint/gate policy evaluation, help/exit behavior) and route `cli.py` through those facades.
- Tighten typing in `src/gabion/cli_support/check/check_command_runtime.py` to consume the new `CliRuntimeDeps` protocol instead of ad-hoc untyped context returns.
- Add an architecture test `tests/gabion/cli/test_cli_architecture_entrypoint.py` that enforces `cli.py` helper symbols remain thin facades and checks that `cli.py` delegates logic into the new support modules.
- Refresh `out/test_evidence.json` to include evidence for the new architecture tests.

### Testing
- Ran `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` and it completed successfully (policy-workflow checks passed).
- Ran `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which reported pre-existing ACP-004 violations in unrelated dataflow engine modules (failure unrelated to this CLI refactor).
- Ran unit tests: `PYTHONPATH=src:. pytest -o addopts='' tests/gabion/cli/test_cli_architecture_entrypoint.py -q` — passed.
- Ran targeted CLI tests: `PYTHONPATH=src:. pytest -o addopts='' tests/gabion/cli/test_cli.py -k "target_stream_router or emit_lint_outputs_writes_artifacts" -q` — passed.
- Extracted and refreshed test evidence with `python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and committed the updated `out/test_evidence.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a899bb9b708324a37064365c603c36)