### PR TITLE
Refactor server-core orchestrator dependencies into concern carriers

### DIFF
--- a/scripts/policy/policy_scanner_suite.py
+++ b/scripts/policy/policy_scanner_suite.py
@@ -13,7 +13,7 @@ def run(*, root: Path, out: Path) -> int:
     print(f"policy-suite scan: cached={result.cached} total_violations={total} out={out}")
     if total == 0:
         return 0
-    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import"):
+    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel"):
         items = policy_scanner_suite.violations_for_rule(result, rule=rule)
         if not items:
             continue

--- a/src/gabion/server_core/analysis_primitives.py
+++ b/src/gabion/server_core/analysis_primitives.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.server_core import command_orchestrator_primitives as legacy
+
+
+@dataclass(frozen=True)
+class AnalysisPrimitives:
+    analysis_index_resume_hydrated_count = staticmethod(legacy._analysis_index_resume_hydrated_count)
+    analysis_index_resume_signature = staticmethod(legacy._analysis_index_resume_signature)
+    analysis_resume_cache_verdict = staticmethod(legacy._analysis_resume_cache_verdict)
+    analysis_resume_progress = staticmethod(legacy._analysis_resume_progress)
+    groups_by_path_from_collection_resume = staticmethod(legacy._groups_by_path_from_collection_resume)
+    latest_report_phase = staticmethod(legacy._latest_report_phase)
+    normalize_dataflow_response = staticmethod(legacy._normalize_dataflow_response)
+    report_witness_digest = staticmethod(legacy._report_witness_digest)
+    render_incremental_report = staticmethod(legacy._render_incremental_report)
+
+
+def default_analysis_primitives() -> AnalysisPrimitives:
+    return AnalysisPrimitives()

--- a/src/gabion/server_core/command_orchestrator.py
+++ b/src/gabion/server_core/command_orchestrator.py
@@ -167,7 +167,7 @@ def _bind_server_symbols() -> None:
 
 def _record_trace_1cell(
     *,
-    execute_deps: CommandEffects,
+    execute_deps: ExecuteCommandDeps,
     state: object | None,
     kind: str,
     source_label: str,
@@ -179,7 +179,7 @@ def _record_trace_1cell(
 ) -> None:
     if state is None:
         return
-    execute_deps.record_1cell_fn(
+    execute_deps.progress.record_1cell_fn(
         state,
         kind=kind,
         source_label=source_label,
@@ -1371,7 +1371,7 @@ class _TimeoutCleanupContext:
     analysis_resume_state_path: Path | None
     analysis_resume_input_manifest_digest: str | None
     last_collection_resume_payload: JSONObject | None
-    execute_deps: CommandEffects
+    execute_deps: ExecuteCommandDeps
     analysis_resume_input_witness: JSONObject | None
     emit_phase_timeline: bool
     phase_timeline_path: Path
@@ -1424,7 +1424,7 @@ class _ProgressEmitter:
 
 @dataclass(frozen=True)
 class _AnalysisExecutionContext:
-    execute_deps: CommandEffects
+    execute_deps: ExecuteCommandDeps
     aspf_trace_state: object | None
     runtime_state: CommandRuntimeState
     forest: Forest
@@ -1526,7 +1526,7 @@ def _aspf_import_state_paths(
 
 def _prepare_analysis_resume_state(
     *,
-    execute_deps: CommandEffects,
+    execute_deps: ExecuteCommandDeps,
     aspf_trace_state: object | None,
     needs_analysis: bool,
     normalized_ingest: NormalizedIngestBundle,
@@ -1550,7 +1550,7 @@ def _prepare_analysis_resume_state(
         # Legacy checkpoint payload ingress is hard-rejected; ASPF import-state is the
         # only supported continuation path for active orchestration.
         state.analysis_resume_state_path = None
-        input_manifest = execute_deps.analysis_input_manifest_fn(
+        input_manifest = execute_deps.analysis.analysis_input_manifest_fn(
             root=resolved_root,
             file_paths=file_paths_for_run,
             recursive=not no_recursive,
@@ -1559,7 +1559,7 @@ def _prepare_analysis_resume_state(
             config=config,
         )
         state.analysis_resume_input_manifest_digest = (
-            execute_deps.analysis_input_manifest_digest_fn(input_manifest)
+            execute_deps.analysis.analysis_input_manifest_digest_fn(input_manifest)
         )
         import_state_paths = _aspf_import_state_paths(
             aspf_import_state,
@@ -1568,7 +1568,7 @@ def _prepare_analysis_resume_state(
         if import_state_paths:
             aspf_resume_payload = cast(
                 Mapping[str, object],
-                execute_deps.load_aspf_resume_state_fn(
+                execute_deps.analysis.load_aspf_resume_state_fn(
                     import_state_paths=import_state_paths
                 )
                 or {},
@@ -1732,7 +1732,7 @@ def _run_analysis_with_progress(
         nonlocal last_collection_report_flush_ns
         nonlocal last_collection_report_flush_completed
         context.profiling_counters["server.collection_resume_persist_calls"] += 1
-        semantic_progress = context.execute_deps.collection_semantic_progress_fn(
+        semantic_progress = context.execute_deps.analysis.collection_semantic_progress_fn(
             previous_collection_resume=state.last_collection_resume_payload,
             collection_resume=progress_payload,
             total_files=context.analysis_resume_total_files,
@@ -1785,7 +1785,7 @@ def _run_analysis_with_progress(
             else False
         )
         now_ns = time.monotonic_ns()
-        if intro_changed and context.execute_deps.collection_checkpoint_flush_due_fn(
+        if intro_changed and context.execute_deps.output.collection_checkpoint_flush_due_fn(
             intro_changed=True,
             remaining_files=collection_progress["remaining_files"],
             semantic_substantive_progress=semantic_substantive_progress,
@@ -1824,7 +1824,7 @@ def _run_analysis_with_progress(
                 forest=context.forest,
                 parse_failure_witnesses=[],
             )
-            preview_sections = context.execute_deps.project_report_sections_fn(
+            preview_sections = context.execute_deps.analysis.project_report_sections_fn(
                 preview_groups_by_path,
                 preview_report,
                 max_phase="post",
@@ -1960,7 +1960,7 @@ def _run_analysis_with_progress(
         ):
             return
         phase_progress_last_flush_ns[phase] = now_ns
-        available_sections = context.execute_deps.project_report_sections_fn(
+        available_sections = context.execute_deps.analysis.project_report_sections_fn(
             groups_by_path,
             report_carrier,
             max_phase="post",
@@ -2037,7 +2037,7 @@ def _run_analysis_with_progress(
         if bootstrap_collection_resume is None:
             seed_paths = context.file_paths_for_run[:1] if context.file_paths_for_run else []
             bootstrap_collection_resume = (
-                context.execute_deps.build_analysis_collection_resume_seed_fn(
+                context.execute_deps.analysis.build_analysis_collection_resume_seed_fn(
                     in_progress_paths=seed_paths
                 )
             )
@@ -2086,7 +2086,7 @@ def _run_analysis_with_progress(
             basis_path=("analysis", "call", "start"),
         )
         with policy_runtime.runtime_policy_scope(runtime_policy):
-            analysis = context.execute_deps.analyze_paths_fn(
+            analysis = context.execute_deps.analysis.analyze_paths_fn(
                 context.paths,
                 forest=context.forest,
                 recursive=not context.no_recursive,
@@ -3187,7 +3187,7 @@ def _render_timeout_partial_report(
                     forest=context.forest,
                     parse_failure_witnesses=[],
                 )
-                preview_sections = context.execute_deps.project_report_sections_fn(
+                preview_sections = context.execute_deps.analysis.project_report_sections_fn(
                     preview_groups_by_path,
                     preview_report,
                     max_phase="post",
@@ -3363,7 +3363,7 @@ def _handle_timeout_cleanup(
                 context.dataflow_capabilities.disabled_surface_reasons
             ),
         }
-        trace_artifacts = context.execute_deps.finalize_trace_fn(
+        trace_artifacts = context.execute_deps.progress.finalize_trace_fn(
             state=context.aspf_trace_state,
             root=context.runtime_root,
             semantic_surface_payloads={
@@ -3854,7 +3854,7 @@ def _compute_analysis_inclusion_flags(
 
 @dataclass(frozen=True)
 class _SuccessResponseContext:
-    execute_deps: CommandEffects
+    execute_deps: ExecuteCommandDeps
     aspf_trace_state: object | None
     analysis: AnalysisResult
     root: str
@@ -3896,7 +3896,7 @@ class _SuccessResponseOutcome:
 
 @dataclass(frozen=True)
 class _ExecuteCommandIngressStage:
-    execute_deps: CommandEffects
+    execute_deps: ExecuteCommandDeps
     execution_plan: ExecutionPlan
     payload: dict[str, object]
     profile_enabled: bool
@@ -3916,7 +3916,7 @@ class _ExecuteCommandIngressStage:
 
 @dataclass(frozen=True)
 class _ExecuteCommandFinalizeSuccessStage:
-    execute_deps: CommandEffects
+    execute_deps: ExecuteCommandDeps
     aspf_trace_state: object | None
     analysis: AnalysisResult
     root: str
@@ -4267,7 +4267,7 @@ def _build_success_response(
     response["disabled_surface_reasons"] = dict(
         context.dataflow_capabilities.disabled_surface_reasons
     )
-    trace_artifacts = context.execute_deps.finalize_trace_fn(
+    trace_artifacts = context.execute_deps.progress.finalize_trace_fn(
         state=context.aspf_trace_state,
         root=Path(context.root),
         semantic_surface_payloads={
@@ -4366,7 +4366,7 @@ def _stage_ingress(
     deps: ExecuteCommandDeps | None,
 ) -> _ExecuteCommandIngressStage:
     _bind_server_symbols()
-    execute_deps: CommandEffects = deps or _default_execute_command_deps()
+    execute_deps: ExecuteCommandDeps = deps or _default_execute_command_deps()
     execution_plan = _materialize_execution_plan(payload)
     payload = dict(execution_plan.inputs)
     _reject_removed_legacy_payload_keys(payload)
@@ -4590,7 +4590,7 @@ def execute_command_total(
     )
     report_phase_checkpoint_path: Path | None = None
     projection_rows: list[JSONObject] = (
-        execute_deps.report_projection_spec_rows_fn() if report_output_path else []
+        execute_deps.analysis.report_projection_spec_rows_fn() if report_output_path else []
     )
     enable_phase_projection_checkpoints = False
     phase_checkpoint_state: JSONObject = {}
@@ -4626,7 +4626,7 @@ def execute_command_total(
         nonlocal report_sections_cache_loaded
         if not report_sections_cache_loaded:
             report_sections_cache, report_sections_cache_reason = (
-                execute_deps.load_report_section_journal_fn(
+                execute_deps.output.load_report_section_journal_fn(
                 path=report_section_journal_path,
                 witness_digest=report_section_witness_digest,
                 )
@@ -4640,7 +4640,7 @@ def execute_command_total(
 
     raw_initial_paths = payload.get("paths")
     initial_paths_count_value = initial_paths_count(raw_initial_paths)
-    execute_deps.write_bootstrap_incremental_artifacts_fn(
+    execute_deps.output.write_bootstrap_incremental_artifacts_fn(
         report_output_path=report_output_path,
         report_section_journal_path=report_section_journal_path,
         report_phase_checkpoint_path=report_phase_checkpoint_path,
@@ -4726,14 +4726,14 @@ def execute_command_total(
         )
         report_phase_checkpoint_path = None
         projection_rows = (
-            execute_deps.report_projection_spec_rows_fn() if report_output_path else []
+            execute_deps.analysis.report_projection_spec_rows_fn() if report_output_path else []
         )
         options = _parse_execution_payload_options(
             payload=payload,
             root=Path(root),
             aux_operation=aux_operation,
         )
-        aspf_trace_state = execute_deps.start_trace_fn(
+        aspf_trace_state = execute_deps.progress.start_trace_fn(
             root=Path(root),
             payload=payload,
         )

--- a/src/gabion/server_core/command_orchestrator_primitives.py
+++ b/src/gabion/server_core/command_orchestrator_primitives.py
@@ -8,7 +8,7 @@ import json
 import threading
 import time
 from datetime import (datetime, timezone)
-from dataclasses import (dataclass, replace)
+from dataclasses import dataclass
 from decimal import (Decimal, InvalidOperation)
 from pathlib import Path
 from typing import (Callable, Literal, Mapping, Sequence, cast)
@@ -41,6 +41,7 @@ from gabion.config import (dataflow_defaults, dataflow_deadline_roots, decision_
 from gabion.analysis.core.type_fingerprints import (Fingerprint, PrimeRegistry, TypeConstructorRegistry, build_fingerprint_registry)
 from gabion.refactor.rewrite_plan import (normalize_rewrite_plan_order, validate_rewrite_plan_payload)
 from gabion.schema import (LegacyDataflowMonolithResponseDTO, LintEntryDTO)
+from gabion.server_core.ingress_primitives import AnalysisDeps, ExecuteCommandDeps, OutputDeps, ProgressDeps
 
 DATAFLOW_COMMAND = command_ids.DATAFLOW_COMMAND
 
@@ -151,29 +152,6 @@ def _deadline_tick_budget_allows_check(clock: object) -> bool:
     if isinstance(limit, int) and isinstance(current, int):
         return (limit - current) > 1
     return True
-
-@dataclass(frozen=True)
-class ExecuteCommandDeps:
-    analyze_paths_fn: Callable[..., AnalysisResult]
-    load_aspf_resume_state_fn: Callable[..., JSONObject | None]
-    analysis_input_manifest_fn: Callable[..., JSONObject]
-    analysis_input_manifest_digest_fn: Callable[[JSONObject], str]
-    build_analysis_collection_resume_seed_fn: Callable[..., JSONObject]
-    collection_semantic_progress_fn: Callable[..., JSONObject]
-    project_report_sections_fn: Callable[..., dict[str, list[str]]]
-    report_projection_spec_rows_fn: Callable[[], list[JSONObject]]
-    collection_checkpoint_flush_due_fn: Callable[..., bool]
-    write_bootstrap_incremental_artifacts_fn: Callable[..., None]
-    load_report_section_journal_fn: Callable[..., tuple[dict[str, list[str]], str | None]]
-    start_trace_fn: Callable[..., object]
-    record_1cell_fn: Callable[..., object]
-    record_2cell_witness_fn: Callable[..., object]
-    record_cofibration_fn: Callable[..., object]
-    merge_imported_trace_fn: Callable[..., object]
-    finalize_trace_fn: Callable[..., object]
-
-    def with_overrides(self, **overrides: object) -> "ExecuteCommandDeps":
-        return replace(self, **overrides)
 
 def _collection_checkpoint_flush_due(
     *,
@@ -2239,23 +2217,29 @@ def _materialize_execution_plan(payload: Mapping[str, object]) -> ExecutionPlan:
 
 def _default_execute_command_deps() -> ExecuteCommandDeps:
     return ExecuteCommandDeps(
-        analyze_paths_fn=analyze_paths,
-        load_aspf_resume_state_fn=_load_aspf_resume_state,
-        analysis_input_manifest_fn=_analysis_input_manifest,
-        analysis_input_manifest_digest_fn=_analysis_input_manifest_digest,
-        build_analysis_collection_resume_seed_fn=build_analysis_collection_resume_seed,
-        collection_semantic_progress_fn=_collection_semantic_progress,
-        project_report_sections_fn=project_report_sections,
-        report_projection_spec_rows_fn=report_projection_spec_rows,
-        collection_checkpoint_flush_due_fn=_collection_checkpoint_flush_due,
-        write_bootstrap_incremental_artifacts_fn=_write_bootstrap_incremental_artifacts,
-        load_report_section_journal_fn=_load_report_section_journal,
-        start_trace_fn=aspf_execution_fibration.start_execution_trace,
-        record_1cell_fn=aspf_execution_fibration.record_1cell,
-        record_2cell_witness_fn=aspf_execution_fibration.record_2cell_witness,
-        record_cofibration_fn=aspf_execution_fibration.record_cofibration,
-        merge_imported_trace_fn=aspf_execution_fibration.merge_imported_trace,
-        finalize_trace_fn=aspf_execution_fibration.finalize_execution_trace,
+        analysis=AnalysisDeps(
+            analyze_paths_fn=analyze_paths,
+            load_aspf_resume_state_fn=_load_aspf_resume_state,
+            analysis_input_manifest_fn=_analysis_input_manifest,
+            analysis_input_manifest_digest_fn=_analysis_input_manifest_digest,
+            build_analysis_collection_resume_seed_fn=build_analysis_collection_resume_seed,
+            collection_semantic_progress_fn=_collection_semantic_progress,
+            project_report_sections_fn=project_report_sections,
+            report_projection_spec_rows_fn=report_projection_spec_rows,
+        ),
+        output=OutputDeps(
+            collection_checkpoint_flush_due_fn=_collection_checkpoint_flush_due,
+            write_bootstrap_incremental_artifacts_fn=_write_bootstrap_incremental_artifacts,
+            load_report_section_journal_fn=_load_report_section_journal,
+        ),
+        progress=ProgressDeps(
+            start_trace_fn=aspf_execution_fibration.start_execution_trace,
+            record_1cell_fn=aspf_execution_fibration.record_1cell,
+            record_2cell_witness_fn=aspf_execution_fibration.record_2cell_witness,
+            record_cofibration_fn=aspf_execution_fibration.record_cofibration,
+            merge_imported_trace_fn=aspf_execution_fibration.merge_imported_trace,
+            finalize_trace_fn=aspf_execution_fibration.finalize_execution_trace,
+        ),
     )
 
 __all__ = [

--- a/src/gabion/server_core/ingress_primitives.py
+++ b/src/gabion/server_core/ingress_primitives.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable
+
+from gabion.analysis import AnalysisResult
+from gabion.json_types import JSONObject
+
+
+@dataclass(frozen=True)
+class AnalysisDeps:
+    analyze_paths_fn: Callable[..., AnalysisResult]
+    load_aspf_resume_state_fn: Callable[..., JSONObject | None]
+    analysis_input_manifest_fn: Callable[..., JSONObject]
+    analysis_input_manifest_digest_fn: Callable[[JSONObject], str]
+    build_analysis_collection_resume_seed_fn: Callable[..., JSONObject]
+    collection_semantic_progress_fn: Callable[..., JSONObject]
+    project_report_sections_fn: Callable[..., dict[str, list[str]]]
+    report_projection_spec_rows_fn: Callable[[], list[JSONObject]]
+
+
+@dataclass(frozen=True)
+class OutputDeps:
+    collection_checkpoint_flush_due_fn: Callable[..., bool]
+    write_bootstrap_incremental_artifacts_fn: Callable[..., None]
+    load_report_section_journal_fn: Callable[..., tuple[dict[str, list[str]], str | None]]
+
+
+@dataclass(frozen=True)
+class ProgressDeps:
+    start_trace_fn: Callable[..., object]
+    record_1cell_fn: Callable[..., object]
+    record_2cell_witness_fn: Callable[..., object]
+    record_cofibration_fn: Callable[..., object]
+    merge_imported_trace_fn: Callable[..., object]
+    finalize_trace_fn: Callable[..., object]
+
+
+@dataclass(frozen=True)
+class ExecuteCommandDeps:
+    analysis: AnalysisDeps
+    output: OutputDeps
+    progress: ProgressDeps
+
+
+    @property
+    def analyze_paths_fn(self):
+        return self.analysis.analyze_paths_fn
+
+    @property
+    def load_aspf_resume_state_fn(self):
+        return self.analysis.load_aspf_resume_state_fn
+
+    @property
+    def analysis_input_manifest_fn(self):
+        return self.analysis.analysis_input_manifest_fn
+
+    @property
+    def analysis_input_manifest_digest_fn(self):
+        return self.analysis.analysis_input_manifest_digest_fn
+
+    @property
+    def build_analysis_collection_resume_seed_fn(self):
+        return self.analysis.build_analysis_collection_resume_seed_fn
+
+    @property
+    def collection_semantic_progress_fn(self):
+        return self.analysis.collection_semantic_progress_fn
+
+    @property
+    def project_report_sections_fn(self):
+        return self.analysis.project_report_sections_fn
+
+    @property
+    def report_projection_spec_rows_fn(self):
+        return self.analysis.report_projection_spec_rows_fn
+
+    @property
+    def collection_checkpoint_flush_due_fn(self):
+        return self.output.collection_checkpoint_flush_due_fn
+
+    @property
+    def write_bootstrap_incremental_artifacts_fn(self):
+        return self.output.write_bootstrap_incremental_artifacts_fn
+
+    @property
+    def load_report_section_journal_fn(self):
+        return self.output.load_report_section_journal_fn
+
+    @property
+    def start_trace_fn(self):
+        return self.progress.start_trace_fn
+
+    @property
+    def record_1cell_fn(self):
+        return self.progress.record_1cell_fn
+
+    @property
+    def record_2cell_witness_fn(self):
+        return self.progress.record_2cell_witness_fn
+
+    @property
+    def record_cofibration_fn(self):
+        return self.progress.record_cofibration_fn
+
+    @property
+    def merge_imported_trace_fn(self):
+        return self.progress.merge_imported_trace_fn
+
+    @property
+    def finalize_trace_fn(self):
+        return self.progress.finalize_trace_fn
+    def with_overrides(self, **overrides: object) -> "ExecuteCommandDeps":
+        if not overrides:
+            return self
+        analysis_fields = set(AnalysisDeps.__dataclass_fields__.keys())
+        output_fields = set(OutputDeps.__dataclass_fields__.keys())
+        progress_fields = set(ProgressDeps.__dataclass_fields__.keys())
+
+        analysis_overrides: dict[str, object] = {}
+        output_overrides: dict[str, object] = {}
+        progress_overrides: dict[str, object] = {}
+        root_overrides: dict[str, object] = {}
+
+        for key, value in overrides.items():
+            if key in {"analysis", "output", "progress"}:
+                root_overrides[key] = value
+            elif key in analysis_fields:
+                analysis_overrides[key] = value
+            elif key in output_fields:
+                output_overrides[key] = value
+            elif key in progress_fields:
+                progress_overrides[key] = value
+            else:
+                raise TypeError(f"Unknown ExecuteCommandDeps override: {key}")
+
+        analysis = root_overrides.get("analysis", self.analysis)
+        output = root_overrides.get("output", self.output)
+        progress = root_overrides.get("progress", self.progress)
+
+        if analysis_overrides:
+            analysis = replace(self.analysis, **analysis_overrides)
+        if output_overrides:
+            output = replace(self.output, **output_overrides)
+        if progress_overrides:
+            progress = replace(self.progress, **progress_overrides)
+        return replace(self, analysis=analysis, output=output, progress=progress)
+
+
+__all__ = [
+    "AnalysisDeps",
+    "OutputDeps",
+    "ProgressDeps",
+    "ExecuteCommandDeps",
+]

--- a/src/gabion/server_core/output_primitives.py
+++ b/src/gabion/server_core/output_primitives.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.server_core import command_orchestrator_primitives as legacy
+
+
+@dataclass(frozen=True)
+class OutputPrimitives:
+    append_phase_timeline_event = staticmethod(legacy._append_phase_timeline_event)
+    apply_journal_pending_reason = staticmethod(legacy._apply_journal_pending_reason)
+    collection_components_preview_lines = staticmethod(legacy._collection_components_preview_lines)
+    collection_progress_intro_lines = staticmethod(legacy._collection_progress_intro_lines)
+    collection_report_flush_due = staticmethod(legacy._collection_report_flush_due)
+    is_stdout_target = staticmethod(legacy._is_stdout_target)
+    output_dirs = staticmethod(legacy._output_dirs)
+    phase_timeline_header_block = staticmethod(legacy._phase_timeline_header_block)
+    phase_timeline_jsonl_path = staticmethod(legacy._phase_timeline_jsonl_path)
+    phase_timeline_md_path = staticmethod(legacy._phase_timeline_md_path)
+    projection_phase_flush_due = staticmethod(legacy._projection_phase_flush_due)
+    resolve_report_output_path = staticmethod(legacy._resolve_report_output_path)
+    resolve_report_section_journal_path = staticmethod(legacy._resolve_report_section_journal_path)
+    split_incremental_obligations = staticmethod(legacy._split_incremental_obligations)
+    write_report_section_journal = staticmethod(legacy._write_report_section_journal)
+    write_text_profiled = staticmethod(legacy._write_text_profiled)
+
+
+def default_output_primitives() -> OutputPrimitives:
+    return OutputPrimitives()

--- a/src/gabion/server_core/progress_primitives.py
+++ b/src/gabion/server_core/progress_primitives.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.server_core import command_orchestrator_primitives as legacy
+
+
+@dataclass(frozen=True)
+class ProgressPrimitives:
+    lsp_progress_notification_method: str = legacy._LSP_PROGRESS_NOTIFICATION_METHOD
+    lsp_progress_token_v2: str = legacy._LSP_PROGRESS_TOKEN_V2
+    canonical_progress_event_schema_v2: str = legacy._CANONICAL_PROGRESS_EVENT_SCHEMA_V2
+    progress_deadline_flush_margin_seconds: float = legacy._PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS
+    progress_deadline_flush_seconds: float = legacy._PROGRESS_DEADLINE_FLUSH_SECONDS
+    progress_deadline_watchdog_seconds: float = legacy._PROGRESS_DEADLINE_WATCHDOG_SECONDS
+    progress_heartbeat_poll_seconds: float = legacy._PROGRESS_HEARTBEAT_POLL_SECONDS
+    build_phase_progress_v2 = staticmethod(legacy._build_phase_progress_v2)
+    incremental_progress_obligations = staticmethod(legacy._incremental_progress_obligations)
+    progress_heartbeat_seconds = staticmethod(legacy._progress_heartbeat_seconds)
+
+
+def default_progress_primitives() -> ProgressPrimitives:
+    return ProgressPrimitives()

--- a/src/gabion/server_core/timeout_primitives.py
+++ b/src/gabion/server_core/timeout_primitives.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.server_core import command_orchestrator_primitives as legacy
+
+
+@dataclass(frozen=True)
+class TimeoutPrimitives:
+    analysis_timeout_budget_ns = staticmethod(legacy._analysis_timeout_budget_ns)
+    analysis_timeout_total_ticks = staticmethod(legacy._analysis_timeout_total_ticks)
+    timeout_context_payload = staticmethod(legacy._timeout_context_payload)
+    deadline_profile_sample_interval = staticmethod(legacy._deadline_profile_sample_interval)
+
+
+def default_timeout_primitives() -> TimeoutPrimitives:
+    return TimeoutPrimitives()

--- a/src/gabion/tooling/runtime/policy_scanner_suite.py
+++ b/src/gabion/tooling/runtime/policy_scanner_suite.py
@@ -34,6 +34,51 @@ _DEFENSIVE_BASELINE = Path("baselines/defensive_fallback_policy_baseline.json")
 _LEGACY_MONOLITH_MODULE_PATH = Path("src/gabion/analysis/legacy_dataflow_monolith.py")
 
 
+_ORCHESTRATOR_PRIMITIVE_BARREL_PATH = Path("src/gabion/server_core/command_orchestrator_primitives.py")
+_ORCHESTRATOR_PRIMITIVE_MAX_LINES = 2400
+_ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS = 220
+
+
+def _scan_orchestrator_primitive_barrel(*, root: Path) -> list[dict[str, object]]:
+    path = root / _ORCHESTRATOR_PRIMITIVE_BARREL_PATH
+    if not path.exists():
+        return []
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    export_count = source.count("'" ) if "__all__" in source else 0
+    violations: list[dict[str, object]] = []
+    if len(lines) > _ORCHESTRATOR_PRIMITIVE_MAX_LINES:
+        violations.append({
+            "path": _ORCHESTRATOR_PRIMITIVE_BARREL_PATH.as_posix(),
+            "line": 1,
+            "column": 1,
+            "kind": "line_threshold",
+            "message": f"command_orchestrator_primitives.py exceeds line threshold {_ORCHESTRATOR_PRIMITIVE_MAX_LINES}",
+            "render": f"{_ORCHESTRATOR_PRIMITIVE_BARREL_PATH.as_posix()}:1:1: line_threshold: exceeds {_ORCHESTRATOR_PRIMITIVE_MAX_LINES} lines",
+        })
+    if "__all__" in source:
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            tree = None
+        if tree is not None:
+            for node in tree.body:
+                if isinstance(node, ast.Assign):
+                    if any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets):
+                        if isinstance(node.value, (ast.List, ast.Tuple)):
+                            export_count = len(node.value.elts)
+        if export_count > _ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS:
+            violations.append({
+                "path": _ORCHESTRATOR_PRIMITIVE_BARREL_PATH.as_posix(),
+                "line": 1,
+                "column": 1,
+                "kind": "export_threshold",
+                "message": f"command_orchestrator_primitives.py __all__ exports exceed {_ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS}",
+                "render": f"{_ORCHESTRATOR_PRIMITIVE_BARREL_PATH.as_posix()}:1:1: export_threshold: __all__ exceeds {_ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS} symbols",
+            })
+    return violations
+
+
 @dataclass(frozen=True)
 class PolicySuiteResult:
     root: Path
@@ -114,6 +159,7 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
         "branchless": [],
         "defensive_fallback": [],
         "no_legacy_monolith_import": [],
+        "orchestrator_primitive_barrel": [],
     }
 
     legacy_module_path = resolved_root / _LEGACY_MONOLITH_MODULE_PATH
@@ -129,6 +175,10 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
                 )
             )
         )
+
+    violations_by_rule["orchestrator_primitive_barrel"].extend(
+        _scan_orchestrator_primitive_barrel(root=resolved_root)
+    )
 
     for path in inventory:
         rel_path = path.relative_to(resolved_root).as_posix()
@@ -224,7 +274,7 @@ def _violations_from_payload(payload: dict[str, object]) -> dict[str, list[dict[
             "no_legacy_monolith_import": [],
         }
     normalized: dict[str, list[dict[str, object]]] = {}
-    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import"):
+    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel"):
         raw_items = violations_raw.get(rule)
         if not isinstance(raw_items, list):
             normalized[rule] = []
@@ -262,6 +312,7 @@ def _rule_set_hash() -> str:
             "branchless:v1",
             "defensive_fallback:v1",
             "no_legacy_monolith_import:v1",
+            "orchestrator_primitive_barrel:v1",
         ]
     )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()

--- a/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
+++ b/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
@@ -44,6 +44,7 @@ def test_policy_scanner_suite_scan_and_cache(tmp_path: Path) -> None:
     assert policy_scanner_suite.violations_for_rule(first, rule="defensive_fallback")
     assert policy_scanner_suite.violations_for_rule(first, rule="no_monkeypatch")
     assert policy_scanner_suite.violations_for_rule(first, rule="no_legacy_monolith_import")
+    assert policy_scanner_suite.violations_for_rule(first, rule="orchestrator_primitive_barrel") == []
 
     second = policy_scanner_suite.load_or_scan_policy_suite(
         root=root,
@@ -118,6 +119,7 @@ def test_policy_scanner_suite_private_cache_and_payload_branches(
         }
     )
     assert normalized["no_monkeypatch"] == []
+    assert normalized["orchestrator_primitive_barrel"] == []
 
 
 # gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_scan_with_explicit_nonstandard_files::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
@@ -289,3 +291,16 @@ def test_policy_scanner_suite_respects_branch_and_fallback_baselines(tmp_path: P
     assert policy_scanner_suite.violations_for_rule(result, rule="defensive_fallback") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="no_monkeypatch") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="no_legacy_monolith_import") == []
+    assert policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel") == []
+
+
+def test_policy_scanner_suite_flags_wide_orchestrator_primitive_barrel(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(
+        root / "src/gabion/server_core/command_orchestrator_primitives.py",
+        "\n".join(["x = 1"] * 2401),
+    )
+    result = policy_scanner_suite.scan_policy_suite(root=root)
+    violations = policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel")
+    assert violations
+    assert any(item.get("kind") == "line_threshold" for item in violations)


### PR DESCRIPTION
### Motivation

- Reduce the monolithic primitive barrel in `command_orchestrator_primitives.py` by splitting concerns into focused modules so call sites depend on narrower, typed contracts. 
- Keep runtime behavior and the `CommandEffects` compatibility surface while enabling clearer dependency grouping and easier future policy enforcement. 
- Prevent accidental reintroduction of a single wide primitive barrel by adding a static scanner rule that enforces size/export thresholds. 

### Description

- Added new focused modules under `src/gabion/server_core/`: `ingress_primitives.py`, `analysis_primitives.py`, `progress_primitives.py`, `timeout_primitives.py`, and `output_primitives.py` to house concern-specific primitives and small typed wrappers. 
- Moved the previous flat `ExecuteCommandDeps` shape into `ingress_primitives.py` as a nested carrier with `AnalysisDeps`, `OutputDeps`, and `ProgressDeps`, and exposed compatibility `@property` accessors and `with_overrides` so existing call sites and runtime checks continue to work. 
- Rewired `src/gabion/server_core/command_orchestrator.py` to consume the grouped contracts (e.g. `execute_deps.analysis.*`, `execute_deps.output.*`, `execute_deps.progress.*`) and updated the default builder in `command_orchestrator_primitives.py` to construct the nested `ExecuteCommandDeps`. 
- Added a static architecture guard to the policy scanner (`src/gabion/tooling/runtime/policy_scanner_suite.py` and `scripts/policy/policy_scanner_suite.py`) that flags `command_orchestrator_primitives.py` if it exceeds configured line or export (`__all__`) thresholds, and added tests exercising the new rule. 

### Testing

- Ran `python -m py_compile` over the modified modules and the scanner scripts, which completed successfully. 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py -q` and the suite passed (`9 passed`). 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/server_core/test_command_reducers.py -q` and it passed (`11 passed`). 
- Ran `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/server_core/command_orchestrator_edges_cases.py -q` and it passed (`17 passed`). 
- Executing the full scanner script (`python scripts/policy/policy_scanner_suite.py --root . --out artifacts/out/policy_suite_results.json`) produced a non-zero result because it reported many pre-existing repository policy violations; the introduced scanner rule itself is covered by targeted tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a899b258b4832488b1b1637d0792c6)