### PR TITLE
Refactor server orchestration helpers to canonical primitives module

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -136,26 +136,11 @@ def _analysis_resume_cache_verdict(
     reused_files: int,
     compatibility_status: str | None,
 ) -> Literal["hit", "miss", "invalidated", "seeded"]:
-    invalidation_statuses = {
-        "checkpoint_manifest_mismatch",
-        "checkpoint_unreadable",
-        "checkpoint_invalid_payload",
-        "checkpoint_manifest_missing",
-        "checkpoint_missing_collection_resume",
-        "aspf_state_manifest_mismatch",
-        "aspf_state_missing_manifest_digest",
-        "aspf_state_missing_current_manifest_digest",
-        "aspf_state_missing_collection_resume",
-    }
-    if status in {"checkpoint_loaded", "aspf_state_loaded"}:
-        if reused_files > 0:
-            return "hit"
-        return "miss"
-    if status == "checkpoint_seeded":
-        if compatibility_status in invalidation_statuses:
-            return "invalidated"
-        return "seeded"
-    return "invalidated" if compatibility_status in invalidation_statuses else "miss"
+    return orchestrator_primitives._analysis_resume_cache_verdict(
+        status=status,
+        reused_files=reused_files,
+        compatibility_status=compatibility_status,
+    )
 
 
 def _deadline_tick_budget_allows_check(clock: object) -> bool:
@@ -591,20 +576,10 @@ def _normalize_progress_work(
     work_done: object | None,
     work_total: object | None,
 ) -> tuple[int | None, int | None]:
-    normalized_done: int | None = None
-    normalized_total: int | None = None
-    if isinstance(work_done, int) and not isinstance(work_done, bool):
-        normalized_done = max(work_done, 0)
-    if isinstance(work_total, int) and not isinstance(work_total, bool):
-        normalized_total = max(work_total, 0)
-    if (
-        normalized_done is not None
-        and normalized_total is not None
-        and normalized_done > normalized_total
-    ):
-        normalized_done = normalized_total
-    return normalized_done, normalized_total
-
+    return orchestrator_primitives._normalize_progress_work(
+        work_done=work_done,
+        work_total=work_total,
+    )
 
 def _phase_primary_unit_for_phase(phase: str) -> str:
     primary_unit = _PHASE_PRIMARY_UNITS.get(phase)
@@ -877,91 +852,43 @@ def _collection_semantic_witness(
 
 
 def _resolve_report_output_path(*, root: Path, report_path: str | None) -> Path | None:
-    if report_path in (None, ""):
-        return None
-    if _is_stdout_target(report_path):
-        return None
-    candidate = Path(str(report_path))
-    if candidate.is_absolute():
-        return candidate
-    return root / candidate
-
+    return orchestrator_primitives._resolve_report_output_path(
+        root=root,
+        report_path=report_path,
+    )
 
 def _resolve_report_section_journal_path(
     *,
     root: Path,
     report_path: str | None,
 ) -> Path | None:
-    resolved_report = _resolve_report_output_path(root=root, report_path=report_path)
-    if resolved_report is None:
-        return None
-    default_journal = root / _DEFAULT_REPORT_SECTION_JOURNAL
-    if resolved_report.name == "dataflow_report.md":
-        return default_journal
-    return resolved_report.with_name(f"{resolved_report.stem}_sections.json")
-
+    return orchestrator_primitives._resolve_report_section_journal_path(
+        root=root,
+        report_path=report_path,
+    )
 
 def _report_witness_digest(
     *,
     input_witness: Mapping[str, JSONValue] | None,
     manifest_digest: str | None,
 ) -> str | None:
-    digest = input_witness.get("witness_digest") if input_witness is not None else None
-    digest_text = digest if isinstance(digest, str) and digest else None
-    manifest_text = (
-        manifest_digest
-        if isinstance(manifest_digest, str) and manifest_digest
-        else None
+    return orchestrator_primitives._report_witness_digest(
+        input_witness=input_witness,
+        manifest_digest=manifest_digest,
     )
-    return digest_text or manifest_text
-
 
 def _coerce_section_lines(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    lines: list[str] = []
-    for item in value:
-        check_deadline()
-        if isinstance(item, str):
-            lines.append(item)
-    return lines
-
+    return orchestrator_primitives._coerce_section_lines(value)
 
 def _load_report_section_journal(
     *,
     path: Path | None,
     witness_digest: str | None,
 ) -> tuple[dict[str, list[str]], str | None]:
-    if path is None or not path.exists():
-        return {}, None
-    try:
-        payload = json.loads(
-            _read_text_profiled(path, io_name="report_section_journal.read")
-        )
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return {}, "policy"
-    if not isinstance(payload, dict):
-        return {}, "policy"
-    if payload.get("format_version") != _REPORT_SECTION_JOURNAL_FORMAT_VERSION:
-        return {}, "policy"
-    expected_digest = payload.get("witness_digest")
-    if isinstance(expected_digest, str):
-        if not isinstance(witness_digest, str) or expected_digest != witness_digest:
-            return {}, "stale_input"
-    sections_payload = payload.get("sections")
-    if not isinstance(sections_payload, Mapping):
-        return {}, "policy"
-    sections: dict[str, list[str]] = {}
-    for key, entry in sections_payload.items():
-        check_deadline()
-        if not isinstance(key, str) or not isinstance(entry, Mapping):
-            continue
-        lines = _coerce_section_lines(entry.get("lines"))
-        if not lines:
-            continue
-        sections[key] = lines
-    return sections, None
-
+    return orchestrator_primitives._load_report_section_journal(
+        path=path,
+        witness_digest=witness_digest,
+    )
 
 def _write_report_section_journal(
     *,
@@ -971,51 +898,13 @@ def _write_report_section_journal(
     sections: Mapping[str, list[str]],
     pending_reasons: Mapping[str, str] | None = None,
 ) -> None:
-    if path is None:
-        return
-    rows_payload: list[JSONObject] = []
-    sections_payload: JSONObject = {}
-    pending_reasons = pending_reasons or {}
-    for row in projection_rows:
-        check_deadline()
-        section_id = str(row.get("section_id", "") or "")
-        if not section_id:
-            continue
-        phase = str(row.get("phase", "") or "")
-        deps_raw = row.get("deps")
-        deps: list[str] = []
-        if isinstance(deps_raw, list):
-            deps = [str(dep) for dep in deps_raw if isinstance(dep, str)]
-        status = "resolved" if section_id in sections else "pending"
-        section_entry: JSONObject = {
-            "phase": phase,
-            "deps": deps,
-            "status": status,
-            "lines": sections.get(section_id, []),
-        }
-        section_entry["reason"] = pending_reasons.get(section_id)
-        sections_payload[section_id] = section_entry
-        rows_payload.append(
-            {
-                "section_id": section_id,
-                "phase": phase,
-                "deps": deps,
-                "status": status,
-            }
-        )
-    payload: JSONObject = {
-        "format_version": _REPORT_SECTION_JOURNAL_FORMAT_VERSION,
-        "witness_digest": witness_digest,
-        "sections": sections_payload,
-        "projection_rows": rows_payload,
-    }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    _write_text_profiled(
-        path,
-        json.dumps(payload, indent=2, sort_keys=False) + "\n",
-        io_name="report_section_journal.write",
+    orchestrator_primitives._write_report_section_journal(
+        path=path,
+        witness_digest=witness_digest,
+        projection_rows=projection_rows,
+        sections=sections,
+        pending_reasons=pending_reasons,
     )
-
 
 def _write_bootstrap_incremental_artifacts(
     *,
@@ -1586,179 +1475,16 @@ def _incremental_progress_obligations(
     sections: Mapping[str, list[str]],
     pending_reasons: Mapping[str, str],
 ) -> list[JSONObject]:
-    check_deadline()
-    obligations: list[JSONObject] = []
-    classification = (
-        str(progress_payload.get("classification", "") or "")
-        if isinstance(progress_payload, Mapping)
-        else ""
+    return orchestrator_primitives._incremental_progress_obligations(
+        analysis_state=analysis_state,
+        progress_payload=progress_payload,
+        resume_payload_available=resume_payload_available,
+        partial_report_written=partial_report_written,
+        report_requested=report_requested,
+        projection_rows=projection_rows,
+        sections=sections,
+        pending_reasons=pending_reasons,
     )
-    resume_supported = (
-        bool(progress_payload.get("resume_supported"))
-        if isinstance(progress_payload, Mapping)
-        else False
-    )
-    semantic_progress = (
-        progress_payload.get("semantic_progress")
-        if isinstance(progress_payload, Mapping)
-        else None
-    )
-    semantic_monotonic_progress: bool | None = None
-    semantic_substantive_progress: bool | None = None
-    if isinstance(semantic_progress, Mapping):
-        raw_monotonic = semantic_progress.get("monotonic_progress")
-        raw_substantive = semantic_progress.get("substantive_progress")
-        if isinstance(raw_monotonic, bool):
-            semantic_monotonic_progress = raw_monotonic
-        if isinstance(raw_substantive, bool):
-            semantic_substantive_progress = raw_substantive
-    is_timeout_state = analysis_state.startswith("timed_out_")
-    if is_timeout_state:
-        expected_progress = analysis_state == "timed_out_progress_resume"
-        classification_ok = (expected_progress and resume_supported) or (
-            not expected_progress and not resume_supported
-        )
-    else:
-        classification_ok = True
-    obligations.append(
-        {
-            "status": "SATISFIED" if classification_ok else "VIOLATION",
-            "contract": "resume_contract",
-            "kind": "classification_matches_resume_support",
-            "detail": (
-                f"analysis_state={analysis_state} classification={classification} "
-                f"resume_supported={resume_supported}"
-            ),
-        }
-    )
-    if semantic_monotonic_progress is not None:
-        obligations.append(
-            {
-                "status": "SATISFIED" if semantic_monotonic_progress else "VIOLATION",
-                "contract": "resume_contract",
-                "kind": "progress_monotonicity",
-                "detail": (
-                    "semantic progress is monotonic"
-                    if semantic_monotonic_progress
-                    else "semantic progress regression detected"
-                ),
-            }
-        )
-    if is_timeout_state and semantic_substantive_progress is not None:
-        expected_substantive_progress = analysis_state == "timed_out_progress_resume"
-        obligations.append(
-            {
-                "status": (
-                    "SATISFIED"
-                    if semantic_substantive_progress == expected_substantive_progress
-                    else "VIOLATION"
-                ),
-                "contract": "resume_contract",
-                "kind": "substantive_progress_required",
-                "detail": (
-                    f"analysis_state={analysis_state} "
-                    f"substantive_progress={semantic_substantive_progress}"
-                ),
-            }
-        )
-
-    resume_payload_ok = True
-    if resume_supported and is_timeout_state:
-        resume_payload_ok = resume_payload_available
-    obligations.append(
-        {
-            "status": "SATISFIED" if resume_payload_ok else "VIOLATION",
-            "contract": "resume_contract",
-            "kind": "resume_payload_present_when_resumable",
-            "detail": "resume payload available"
-            if resume_payload_ok
-            else "resume payload missing",
-        }
-    )
-    stale_input_detected = any(
-        reason == "stale_input" for reason in pending_reasons.values()
-    )
-    if stale_input_detected and sections:
-        restart_status = "VIOLATION"
-        restart_detail = "witness_mismatch_with_reused_sections"
-    elif stale_input_detected:
-        restart_status = "SATISFIED"
-        restart_detail = "restart_required"
-    else:
-        restart_status = "OBLIGATION"
-        restart_detail = "no_witness_mismatch"
-    obligations.append(
-        {
-            "status": restart_status,
-            "contract": "resume_contract",
-            "kind": "restart_required_on_witness_mismatch",
-            "detail": restart_detail,
-        }
-    )
-    if report_requested and is_timeout_state:
-        projection_count = sum(
-            1
-            for row in projection_rows
-            if isinstance(row, Mapping)
-            and isinstance(row.get("section_id"), str)
-            and str(row.get("section_id") or "")
-        )
-        resolved_count = len(sections)
-        obligations.append(
-            {
-                "status": "SATISFIED" if resolved_count > 0 else "VIOLATION",
-                "contract": "resume_contract",
-                "kind": "no_projection_progress",
-                "detail": (
-                    f"resolved_sections={resolved_count} "
-                    f"projected_sections={projection_count}"
-                ),
-            }
-        )
-
-    if report_requested and is_timeout_state:
-        obligations.append(
-            {
-                "status": "SATISFIED" if partial_report_written else "VIOLATION",
-                "contract": "progress_report_contract",
-                "kind": "partial_report_emitted",
-                "detail": "partial report emission on timeout",
-            }
-        )
-    elif report_requested:
-        obligations.append(
-            {
-                "status": "SATISFIED",
-                "contract": "progress_report_contract",
-                "kind": "partial_report_emitted",
-                "detail": "not_applicable_without_timeout",
-            }
-        )
-    for row in projection_rows:
-        check_deadline()
-        section_id = str(row.get("section_id", "") or "")
-        if not section_id:
-            continue
-        if section_id in sections:
-            status = "SATISFIED"
-            detail = "section reused from witness-matched journal"
-        else:
-            status = "OBLIGATION"
-            detail = pending_reasons.get(section_id, "section pending")
-            if stale_input_detected and detail == "policy":
-                detail = "stale_input"
-        obligations.append(
-            {
-                "status": status,
-                "contract": "incremental_projection_contract",
-                "kind": "section_projection_state",
-                "section_id": section_id,
-                "phase": str(row.get("phase", "") or ""),
-                "detail": detail,
-            }
-        )
-    return obligations
-
 
 def _split_incremental_obligations(
     obligations: Sequence[Mapping[str, JSONValue]],

--- a/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
+++ b/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion import server
+from gabion.server_core import command_orchestrator_primitives
+
+
+def test_report_path_resolution_parity(tmp_path: Path) -> None:
+    inputs = [None, "", "-", "/dev/stdout", "report.md", "/tmp/report.md"]
+    for report_path in inputs:
+        assert server._resolve_report_output_path(
+            root=tmp_path,
+            report_path=report_path,
+        ) == command_orchestrator_primitives._resolve_report_output_path(
+            root=tmp_path,
+            report_path=report_path,
+        )
+
+
+def test_report_section_journal_path_resolution_parity(tmp_path: Path) -> None:
+    for report_path in ("dataflow_report.md", "subdir/custom.md", None):
+        assert server._resolve_report_section_journal_path(
+            root=tmp_path,
+            report_path=report_path,
+        ) == command_orchestrator_primitives._resolve_report_section_journal_path(
+            root=tmp_path,
+            report_path=report_path,
+        )
+
+
+def test_normalize_dataflow_response_parity() -> None:
+    payload = {
+        "lint_lines": ["a.py:1:2: W sample", 1],
+        "analysis_surfaces": ["decision", "taint", 7],
+        "disabled_surfaces": ["exception", 9],
+        "payload_capabilities": {"report_projection": 1, "resume": True},
+    }
+    assert server._normalize_dataflow_response(payload) == (
+        command_orchestrator_primitives._normalize_dataflow_response(payload)
+    )
+
+
+def test_analysis_timeout_budget_parity() -> None:
+    payload = {
+        "analysis_timeout_ms": 500,
+        "analysis_timeout_grace_ms": 50,
+    }
+    assert server._analysis_timeout_budget_ns(payload) == (
+        command_orchestrator_primitives._analysis_timeout_budget_ns(payload)
+    )

--- a/tests/gabion/server/test_server.py
+++ b/tests/gabion/server/test_server.py
@@ -4,3 +4,4 @@ from tests.gabion.server.server_code_action_stub_cases import *  # noqa: F401,F4
 from tests.gabion.server.server_execute_command_cases import *  # noqa: F401,F403
 from tests.gabion.server.server_helpers_cases import *  # noqa: F401,F403
 from tests.gabion.server.server_rewrite_plan_projection_cases import *  # noqa: F401,F403
+from tests.gabion.server.server_orchestrator_primitive_parity_cases import *  # noqa: F401,F403


### PR DESCRIPTION
### Motivation
- Remove duplicated orchestration helper logic from `src/gabion/server.py` and converge shared behavior into the canonical host `gabion.server_core.command_orchestrator_primitives` to preserve a single authoritative implementation for report path resolution, section journal IO, timeout normalization, and progress/obligation synthesis.  
- Preserve the `server.py` command-handler entrypoints while routing internal implementations to the canonical primitives so the public server surface and tests remain stable.  

### Description
- Replaced local helper implementations in `src/gabion/server.py` with thin delegating wrappers that call into `gabion.server_core.command_orchestrator_primitives` for `_analysis_resume_cache_verdict`, `_normalize_progress_work`, `_resolve_report_output_path`, `_resolve_report_section_journal_path`, `_report_witness_digest`, `_coerce_section_lines`, `_load_report_section_journal`, `_write_report_section_journal`, and `_incremental_progress_obligations`.  
- Added boundary aliasing to preserve the server import/test surface while using primitives from `server_core` (existing aliases like `ExecuteCommandDeps`, `_analysis_input_manifest`, `_collection_semantic_progress`, `_materialize_execution_plan`, `_default_execute_command_deps` remain).  
- Added parity tests in `tests/gabion/server/server_orchestrator_primitive_parity_cases.py` that assert equality between `server` helpers and `command_orchestrator_primitives` for report path resolution, report-section-journal path resolution, `_normalize_dataflow_response`, and analysis timeout budget derivation, and wired that module into the server test aggregator.  
- Updated the repository test-evidence output (`out/test_evidence.json`) to reflect the new parity tests.  

### Testing
- Ran `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` which executed successfully in this environment.  
- Ran `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which executed successfully.  
- Ran `PYTHONPATH=src:. pytest -q -o addopts='' tests/gabion/server/server_orchestrator_primitive_parity_cases.py tests/gabion/server/server_execute_command_edges_cases.py -k "analysis_timeout_budget or report_section_journal or normalize_dataflow_response or misc_small_helpers"` which succeeded with `12 passed, 209 deselected`.  
- A prior `pytest` invocation using the repo `pytest.ini` default parallel flags failed in this environment due to the runner configuration injecting `-n --dist=loadfile`, and that was worked around by clearing `addopts` for the focused run.  
- Ran `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` which succeeded and produced an updated `out/test_evidence.json`.  
- Ran `python -m py_compile src/gabion/server.py tests/gabion/server/server_orchestrator_primitive_parity_cases.py tests/gabion/server/test_server.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9096ed6488324b4bedac664a93900)