### PR TITLE
Extract shared execution-plan payload DTO for CLI/runtime parity

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -25,6 +25,9 @@ from gabion.cli_support.check.check_command_runtime import (
 from gabion.cli_support.check import check_runtime_facade
 from gabion.cli_support.check.check_execution_plan import (
     check_derived_artifacts as _check_derived_artifacts_impl, build_check_execution_plan_request as _build_check_execution_plan_request_impl)
+from gabion.cli_support.check.execution_plan_payload import (
+    ExecutionPlanRequestPayload as ExecutionPlanRequest,
+)
 from gabion.cli_support.check.check_runtime import run_check as _run_check_impl
 from gabion.cli_support.shared.dispatch_runtime import (
     dispatch_command as _dispatch_command_impl)
@@ -255,27 +258,6 @@ class SnapshotDiffRequest:
 
     def to_payload(self) -> JSONObject:
         return {"baseline": str(self.baseline), "current": str(self.current)}
-
-
-@dataclass(frozen=True)
-class ExecutionPlanRequest:
-    requested_operations: list[str]
-    inputs: JSONObject
-    derived_artifacts: list[str]
-    obligations: dict[str, list[str]]
-    policy_metadata: dict[str, object]
-
-    def to_payload(self) -> JSONObject:
-        return {
-            "requested_operations": list(self.requested_operations),
-            "inputs": dict(self.inputs),
-            "derived_artifacts": list(self.derived_artifacts),
-            "obligations": {
-                "preconditions": list(self.obligations.get("preconditions") or []),
-                "postconditions": list(self.obligations.get("postconditions") or []),
-            },
-            "policy_metadata": dict(self.policy_metadata),
-        }
 
 
 def _run_sppf_git(

--- a/src/gabion/cli_support/check/execution_plan_payload.py
+++ b/src/gabion/cli_support/check/execution_plan_payload.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.json_types import JSONObject
+
+
+@dataclass(frozen=True)
+class ExecutionPlanRequestPayload:
+    requested_operations: list[str]
+    inputs: JSONObject
+    derived_artifacts: list[str]
+    obligations: dict[str, list[str]]
+    policy_metadata: dict[str, object]
+
+    def to_payload(self) -> JSONObject:
+        return {
+            "requested_operations": list(self.requested_operations),
+            "inputs": dict(self.inputs),
+            "derived_artifacts": list(self.derived_artifacts),
+            "obligations": {
+                "preconditions": list(self.obligations.get("preconditions") or []),
+                "postconditions": list(self.obligations.get("postconditions") or []),
+            },
+            "policy_metadata": dict(self.policy_metadata),
+        }

--- a/src/gabion/tooling/runtime/dataflow_invocation_runner.py
+++ b/src/gabion/tooling/runtime/dataflow_invocation_runner.py
@@ -5,13 +5,16 @@ import argparse
 from dataclasses import dataclass
 from pathlib import Path
 import sys
-from typing import Callable, Protocol, Sequence
+from typing import Callable, Sequence
 
 from gabion.cli_support.check.check_execution_plan import (
     build_check_execution_plan_request as _build_check_execution_plan_request_impl,
     check_derived_artifacts as _check_derived_artifacts_impl,
 )
 from gabion.cli_support.check.check_runtime import run_check as _run_check_impl
+from gabion.cli_support.check.execution_plan_payload import (
+    ExecutionPlanRequestPayload,
+)
 from gabion.cli_support.shared.dispatch_runtime import (
     dispatch_command as _dispatch_command_impl,
 )
@@ -31,31 +34,6 @@ from gabion.tooling.runtime.execution_envelope import ExecutionEnvelope
 
 _STDOUT_ALIAS = "-"
 _STDOUT_PATH = "/dev/stdout"
-
-
-class _ExecutionPlanRequest(Protocol):
-    def to_payload(self) -> JSONObject: ...
-
-
-@dataclass(frozen=True)
-class _ExecutionPlanRequestPayload:
-    requested_operations: list[str]
-    inputs: JSONObject
-    derived_artifacts: list[str]
-    obligations: dict[str, list[str]]
-    policy_metadata: dict[str, object]
-
-    def to_payload(self) -> JSONObject:
-        return {
-            "requested_operations": list(self.requested_operations),
-            "inputs": dict(self.inputs),
-            "derived_artifacts": list(self.derived_artifacts),
-            "obligations": {
-                "preconditions": list(self.obligations.get("preconditions") or []),
-                "postconditions": list(self.obligations.get("postconditions") or []),
-            },
-            "policy_metadata": dict(self.policy_metadata),
-        }
 
 
 def _cli_timeout_ticks() -> tuple[int, int]:
@@ -100,11 +78,11 @@ def _build_dataflow_payload(opts: argparse.Namespace) -> JSONObject:
     )
 
 
-def _build_check_execution_plan_request(**kwargs) -> _ExecutionPlanRequest:
+def _build_check_execution_plan_request(**kwargs) -> ExecutionPlanRequestPayload:
     return _build_check_execution_plan_request_impl(
         **kwargs,
         check_derived_artifacts_fn=_check_derived_artifacts_impl,
-        execution_plan_request_ctor=_ExecutionPlanRequestPayload,
+        execution_plan_request_ctor=ExecutionPlanRequestPayload,
         dataflow_command=command_ids.DATAFLOW_COMMAND,
         check_command=command_ids.CHECK_COMMAND,
     )
@@ -116,7 +94,7 @@ def _dispatch_command(
     payload: JSONObject,
     root: Path = Path("."),
     runner: Callable[..., JSONObject] = run_command,
-    execution_plan_request: _ExecutionPlanRequest | None = None,
+    execution_plan_request: ExecutionPlanRequestPayload | None = None,
 ) -> JSONObject:
     return _dispatch_command_impl(
         command=command,

--- a/tests/gabion/cli/cli_payload_cases.py
+++ b/tests/gabion/cli/cli_payload_cases.py
@@ -7,6 +7,7 @@ import typer
 
 from gabion import cli
 from gabion.commands import check_contract
+from gabion.tooling.runtime import dataflow_invocation_runner
 
 _DEFAULT_CHECK_ARTIFACT_FLAGS = cli.CheckArtifactFlags(
     emit_test_obsolescence=False,
@@ -318,6 +319,40 @@ def test_build_check_execution_plan_request_sets_read_baseline_mode() -> None:
     policy_metadata = payload["policy_metadata"]
     assert isinstance(policy_metadata, dict)
     assert policy_metadata["baseline_mode"] == "read"
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_payloads.py::test_build_check_execution_plan_request_cli_runtime_payload_parity::cli.py::gabion.cli.build_check_execution_plan_request E:call_footprint::tests/test_cli_payloads.py::test_build_check_execution_plan_request_cli_runtime_payload_parity::dataflow_invocation_runner.py::gabion.tooling.runtime.dataflow_invocation_runner._build_check_execution_plan_request
+def test_build_check_execution_plan_request_cli_runtime_payload_parity() -> None:
+    kwargs = dict(
+        payload={"analysis_timeout_ticks": 11, "analysis_timeout_tick_ns": 22},
+        report=Path("artifacts/audit_reports/dataflow_report.md"),
+        decision_snapshot=None,
+        baseline=Path("baselines/dataflow_baseline.txt"),
+        baseline_write=False,
+        policy=cli.CheckPolicyFlags(
+            fail_on_violations=True,
+            fail_on_type_ambiguities=True,
+            lint=True,
+        ),
+        profile="strict",
+        artifact_flags=_DEFAULT_CHECK_ARTIFACT_FLAGS,
+        emit_test_obsolescence_state=True,
+        emit_test_obsolescence_delta=False,
+        emit_test_annotation_drift_delta=False,
+        emit_ambiguity_delta=False,
+        emit_ambiguity_state=True,
+        aspf_trace_json=Path("artifacts/out/aspf_trace.custom.json"),
+        aspf_opportunities_json=Path("artifacts/out/aspf_opportunities.custom.json"),
+        aspf_state_json=Path("artifacts/out/aspf_state.custom.json"),
+        aspf_delta_jsonl=Path("artifacts/out/aspf_delta.custom.jsonl"),
+        aspf_equivalence_enabled=True,
+    )
+    cli_payload = cli.build_check_execution_plan_request(**kwargs).to_payload()
+    runtime_payload = (
+        dataflow_invocation_runner._build_check_execution_plan_request(**kwargs)
+        .to_payload()
+    )
+    assert runtime_payload == cli_payload
 
 
 # gabion:evidence E:decision_surface/direct::cli.py::gabion.cli._split_csv_entries::entries E:decision_surface/direct::cli.py::gabion.cli.build_dataflow_payload::opts E:decision_surface/direct::cli.py::gabion.cli._split_csv::value E:decision_surface/direct::cli.py::gabion.cli._split_csv::stale_613d9e303867_0c617420


### PR DESCRIPTION
### Motivation
- Reduce duplicated execution-plan request shape/serialization and ensure CLI and runtime paths produce identical payloads by centralizing the DTO.

### Description
- Add `ExecutionPlanRequestPayload` in `src/gabion/cli_support/check/execution_plan_payload.py` to define the execution-plan payload shape and `to_payload()` serialization.
- Replace the local `ExecutionPlanRequest` dataclass in `src/gabion/cli.py` with an import alias to the shared DTO to remove duplicate serialization logic.
- Replace the protocol + local payload dataclass in `src/gabion/tooling/runtime/dataflow_invocation_runner.py` with the shared `ExecutionPlanRequestPayload` and keep layer-specific adapter changes minimal (only constructor wiring and type annotations).
- Add a regression test `test_build_check_execution_plan_request_cli_runtime_payload_parity` in `tests/gabion/cli/cli_payload_cases.py` that builds requests via the CLI builder and the runtime builder with identical inputs and asserts payload parity.
- Update the test evidence artifact (`out/test_evidence.json`) to reflect the new test mapping.

### Testing
- Ran the policy checks: `PYTHONPATH=src:. mise exec -- python -m scripts.policy.policy_check --workflows` and `--ambiguity-contract`, both completed successfully.
- Ran targeted unit tests: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/cli/cli_payload_cases.py tests/gabion/analysis/dataflow_s1/test_dataflow_invocation_runner.py -q`, all tests passed (`32 passed`).
- Re-extracted evidence with `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` to refresh mappings successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90956bc588324975a2498383a6205)