### PR TITLE
Extract canonical dataflow runtime contract helpers for server + orchestrator

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -65,9 +65,9 @@ from gabion.refactor.rewrite_plan import normalize_rewrite_plan_order, validate_
 from gabion.schema import (
     LegacyDataflowMonolithResponseDTO, DecisionDiffResponseDTO, LspParityGateResponseDTO, LintEntryDTO, RefactorProtocolResponseDTO, RefactorRequest, RefactorResponse, RewritePlanEntryDTO, StructureDiffResponseDTO, StructureReuseResponseDTO, SynthesisPlanResponseDTO, SynthesisResponse, SynthesisRequest, TextEditDTO)
 from gabion.server_core import command_orchestrator_primitives as orchestrator_primitives
+from gabion.server_core import dataflow_runtime_contract as runtime_contract
 from gabion.synthesis import NamingContext, SynthesisConfig, Synthesizer
 from gabion.tooling.governance.governance_rules import GovernanceRules, load_governance_rules
-from gabion.runtime import path_policy
 
 server = LanguageServer("gabion", "0.1.0")
 CHECK_COMMAND = command_ids.CHECK_COMMAND
@@ -89,45 +89,30 @@ _IMPACT_TEST_PATH_TOKENS = ("/tests/", "\\tests\\")
 
 _ANALYSIS_INPUT_MANIFEST_FORMAT_VERSION = 1
 _ANALYSIS_INPUT_WITNESS_FORMAT_VERSION = 2
-_DEFAULT_PHASE_TIMELINE_MD = Path(
-    "artifacts/audit_reports/dataflow_phase_timeline.md"
-)
-_DEFAULT_PHASE_TIMELINE_JSONL = Path(
-    "artifacts/audit_reports/dataflow_phase_timeline.jsonl"
-)
+_DEFAULT_PHASE_TIMELINE_MD = runtime_contract.DEFAULT_PHASE_TIMELINE_MD
+_DEFAULT_PHASE_TIMELINE_JSONL = runtime_contract.DEFAULT_PHASE_TIMELINE_JSONL
 _REPORT_SECTION_JOURNAL_FORMAT_VERSION = 1
-_DEFAULT_REPORT_SECTION_JOURNAL = Path(
-    "artifacts/audit_reports/dataflow_report_sections.json"
-)
-_COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS = 2_000_000_000
-_COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS = 1_000_000_000
-_COLLECTION_REPORT_FLUSH_INTERVAL_NS = 10_000_000_000
-_COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE = 8
-_DEFAULT_PROGRESS_HEARTBEAT_SECONDS = 55.0
-_MIN_PROGRESS_HEARTBEAT_SECONDS = 5.0
-_PROGRESS_DEADLINE_FLUSH_SECONDS = 5.0
-_PROGRESS_DEADLINE_WATCHDOG_SECONDS = 10.0
-_PROGRESS_HEARTBEAT_POLL_SECONDS = 0.05
-_PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = 0.5
-_LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
-_LSP_PROGRESS_TOKEN_V2 = "gabion.dataflowAudit/progress-v2"
+_DEFAULT_REPORT_SECTION_JOURNAL = runtime_contract.DEFAULT_REPORT_SECTION_JOURNAL
+_COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS = runtime_contract.COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
+_COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS = runtime_contract.COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS
+_COLLECTION_REPORT_FLUSH_INTERVAL_NS = runtime_contract.COLLECTION_REPORT_FLUSH_INTERVAL_NS
+_COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE = runtime_contract.COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE
+_DEFAULT_PROGRESS_HEARTBEAT_SECONDS = runtime_contract.DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+_MIN_PROGRESS_HEARTBEAT_SECONDS = runtime_contract.MIN_PROGRESS_HEARTBEAT_SECONDS
+_PROGRESS_DEADLINE_FLUSH_SECONDS = runtime_contract.PROGRESS_DEADLINE_FLUSH_SECONDS
+_PROGRESS_DEADLINE_WATCHDOG_SECONDS = runtime_contract.PROGRESS_DEADLINE_WATCHDOG_SECONDS
+_PROGRESS_HEARTBEAT_POLL_SECONDS = runtime_contract.PROGRESS_HEARTBEAT_POLL_SECONDS
+_PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = runtime_contract.PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS
+_LSP_PROGRESS_NOTIFICATION_METHOD = runtime_contract.LSP_PROGRESS_NOTIFICATION_METHOD
+_LSP_PROGRESS_TOKEN_V2 = runtime_contract.LSP_PROGRESS_TOKEN_V2
 _LSP_PROGRESS_TOKEN = _LSP_PROGRESS_TOKEN_V2
-_STDOUT_ALIAS = "-"
-_STDOUT_PATH = "/dev/stdout"
-_PHASE_PRIMARY_UNITS: Mapping[str, str] = {
-    "collection": "collection_files",
-    "forest": "forest_mutable_steps",
-    "edge": "edge_tasks",
-    "post": "post_tasks",
-}
+_STDOUT_ALIAS = runtime_contract.STDOUT_ALIAS
+_STDOUT_PATH = runtime_contract.STDOUT_PATH
+_PHASE_PRIMARY_UNITS: Mapping[str, str] = runtime_contract.PHASE_PRIMARY_UNITS
 
 
 def _is_stdout_target(target: object) -> bool:
-    return path_policy.is_stdout_target(
-        target,
-        stdout_alias=_STDOUT_ALIAS,
-        stdout_path=_STDOUT_PATH,
-    )
+    return runtime_contract.is_stdout_target(target)
 
 
 def _analysis_resume_cache_verdict(
@@ -144,11 +129,7 @@ def _analysis_resume_cache_verdict(
 
 
 def _deadline_tick_budget_allows_check(clock: object) -> bool:
-    limit = getattr(clock, "limit", None)
-    current = getattr(clock, "current", None)
-    if isinstance(limit, int) and isinstance(current, int):
-        return (limit - current) > 1
-    return True
+    return runtime_contract.deadline_tick_budget_allows_check(clock)
 
 
 # Boundary aliases preserve server.py test/import surface while converging
@@ -171,15 +152,13 @@ def _collection_checkpoint_flush_due(
     now_ns: int,
     last_flush_ns: int,
 ) -> bool:
-    if intro_changed or remaining_files == 0:
-        return True
-    elapsed_ns = max(0, now_ns - last_flush_ns)
-    if semantic_substantive_progress:
-        return (
-            elapsed_ns >= _COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS
-            or elapsed_ns >= _COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
-        )
-    return elapsed_ns >= _COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
+    return runtime_contract.collection_checkpoint_flush_due(
+        intro_changed=intro_changed,
+        remaining_files=remaining_files,
+        semantic_substantive_progress=semantic_substantive_progress,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+    )
 
 
 def _collection_report_flush_due(
@@ -190,13 +169,13 @@ def _collection_report_flush_due(
     last_flush_ns: int,
     last_flush_completed: int,
 ) -> bool:
-    if last_flush_completed < 0:
-        return True
-    if completed_files - last_flush_completed >= _COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE:
-        return True
-    if now_ns - last_flush_ns >= _COLLECTION_REPORT_FLUSH_INTERVAL_NS:
-        return True
-    return remaining_files == 0
+    return runtime_contract.collection_report_flush_due(
+        completed_files=completed_files,
+        remaining_files=remaining_files,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+        last_flush_completed=last_flush_completed,
+    )
 
 
 def _projection_phase_flush_due(
@@ -205,9 +184,11 @@ def _projection_phase_flush_due(
     now_ns: int,
     last_flush_ns: int,
 ) -> bool:
-    if phase == "post":
-        return True
-    return now_ns - last_flush_ns >= _COLLECTION_REPORT_FLUSH_INTERVAL_NS
+    return runtime_contract.projection_phase_flush_due(
+        phase=phase,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+    )
 
 
 def _read_text_profiled(
@@ -1174,28 +1155,7 @@ def _phase_timeline_jsonl_path(*, root: Path) -> Path:
 
 
 def _progress_heartbeat_seconds(payload: Mapping[str, JSONValue]) -> float:
-    raw = payload.get("progress_heartbeat_seconds")
-    if isinstance(raw, bool):
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    if isinstance(raw, (int, float)):
-        parsed = float(raw)
-    elif isinstance(raw, str):
-        text = raw.strip()
-        if not text:
-            return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-        try:
-            parsed = float(text)
-        except ValueError:
-            return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    elif raw is None:
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    else:
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    if parsed <= 0:
-        return 0.0
-    if parsed < _MIN_PROGRESS_HEARTBEAT_SECONDS:
-        return _MIN_PROGRESS_HEARTBEAT_SECONDS
-    return parsed
+    return runtime_contract.progress_heartbeat_seconds(payload)
 
 
 def _markdown_table_cell(value: object) -> str:

--- a/src/gabion/server_core/command_orchestrator_primitives.py
+++ b/src/gabion/server_core/command_orchestrator_primitives.py
@@ -42,6 +42,7 @@ from gabion.analysis.core.type_fingerprints import (Fingerprint, PrimeRegistry, 
 from gabion.refactor.rewrite_plan import (normalize_rewrite_plan_order, validate_rewrite_plan_payload)
 from gabion.schema import (LegacyDataflowMonolithResponseDTO, LintEntryDTO)
 from gabion.server_core.ingress_primitives import AnalysisDeps, ExecuteCommandDeps, OutputDeps, ProgressDeps
+from gabion.server_core import dataflow_runtime_contract as runtime_contract
 
 DATAFLOW_COMMAND = command_ids.DATAFLOW_COMMAND
 
@@ -57,67 +58,53 @@ _ANALYSIS_TIMEOUT_GRACE_RATIO_DENOMINATOR = 5
 
 _ANALYSIS_INPUT_MANIFEST_FORMAT_VERSION = 1
 
-_DEFAULT_PHASE_TIMELINE_MD = Path(
-    "artifacts/audit_reports/dataflow_phase_timeline.md"
-)
+_DEFAULT_PHASE_TIMELINE_MD = runtime_contract.DEFAULT_PHASE_TIMELINE_MD
 
-_DEFAULT_PHASE_TIMELINE_JSONL = Path(
-    "artifacts/audit_reports/dataflow_phase_timeline.jsonl"
-)
+_DEFAULT_PHASE_TIMELINE_JSONL = runtime_contract.DEFAULT_PHASE_TIMELINE_JSONL
 
 _REPORT_SECTION_JOURNAL_FORMAT_VERSION = 1
 
-_DEFAULT_REPORT_SECTION_JOURNAL = Path(
-    "artifacts/audit_reports/dataflow_report_sections.json"
-)
+_DEFAULT_REPORT_SECTION_JOURNAL = runtime_contract.DEFAULT_REPORT_SECTION_JOURNAL
 
-_COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS = 2_000_000_000
+_COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS = runtime_contract.COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
 
-_COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS = 1_000_000_000
+_COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS = runtime_contract.COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS
 
-_COLLECTION_REPORT_FLUSH_INTERVAL_NS = 10_000_000_000
+_COLLECTION_REPORT_FLUSH_INTERVAL_NS = runtime_contract.COLLECTION_REPORT_FLUSH_INTERVAL_NS
 
-_COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE = 8
+_COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE = runtime_contract.COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE
 
 _DEFAULT_DEADLINE_PROFILE_SAMPLE_INTERVAL = 16
 
-_DEFAULT_PROGRESS_HEARTBEAT_SECONDS = 55.0
+_DEFAULT_PROGRESS_HEARTBEAT_SECONDS = runtime_contract.DEFAULT_PROGRESS_HEARTBEAT_SECONDS
 
-_MIN_PROGRESS_HEARTBEAT_SECONDS = 5.0
+_MIN_PROGRESS_HEARTBEAT_SECONDS = runtime_contract.MIN_PROGRESS_HEARTBEAT_SECONDS
 
-_PROGRESS_DEADLINE_FLUSH_SECONDS = 5.0
+_PROGRESS_DEADLINE_FLUSH_SECONDS = runtime_contract.PROGRESS_DEADLINE_FLUSH_SECONDS
 
-_PROGRESS_DEADLINE_WATCHDOG_SECONDS = 10.0
+_PROGRESS_DEADLINE_WATCHDOG_SECONDS = runtime_contract.PROGRESS_DEADLINE_WATCHDOG_SECONDS
 
-_PROGRESS_HEARTBEAT_POLL_SECONDS = 0.05
+_PROGRESS_HEARTBEAT_POLL_SECONDS = runtime_contract.PROGRESS_HEARTBEAT_POLL_SECONDS
 
-_PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = 0.5
+_PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = runtime_contract.PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS
 
 
-_LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
+_LSP_PROGRESS_NOTIFICATION_METHOD = runtime_contract.LSP_PROGRESS_NOTIFICATION_METHOD
 
-_LSP_PROGRESS_TOKEN_V2 = "gabion.dataflowAudit/progress-v2"
+_LSP_PROGRESS_TOKEN_V2 = runtime_contract.LSP_PROGRESS_TOKEN_V2
 
 _LSP_PROGRESS_TOKEN = _LSP_PROGRESS_TOKEN_V2
 
 _CANONICAL_PROGRESS_EVENT_SCHEMA_V2 = "gabion/canonical_progress_event_v2"
 
-_STDOUT_ALIAS = "-"
+_STDOUT_ALIAS = runtime_contract.STDOUT_ALIAS
 
-_STDOUT_PATH = "/dev/stdout"
+_STDOUT_PATH = runtime_contract.STDOUT_PATH
 
-_PHASE_PRIMARY_UNITS: Mapping[str, str] = {
-    "collection": "collection_files",
-    "forest": "forest_mutable_steps",
-    "edge": "edge_tasks",
-    "post": "post_tasks",
-}
+_PHASE_PRIMARY_UNITS: Mapping[str, str] = runtime_contract.PHASE_PRIMARY_UNITS
 
 def _is_stdout_target(target: object) -> bool:
-    if not isinstance(target, (str, Path)):
-        return False
-    text = str(target).strip()
-    return text in {_STDOUT_ALIAS, _STDOUT_PATH}
+    return runtime_contract.is_stdout_target(target)
 
 def _analysis_resume_cache_verdict(
     *,
@@ -147,11 +134,7 @@ def _analysis_resume_cache_verdict(
     return "invalidated" if compatibility_status in invalidation_statuses else "miss"
 
 def _deadline_tick_budget_allows_check(clock: object) -> bool:
-    limit = getattr(clock, "limit", None)
-    current = getattr(clock, "current", None)
-    if isinstance(limit, int) and isinstance(current, int):
-        return (limit - current) > 1
-    return True
+    return runtime_contract.deadline_tick_budget_allows_check(clock)
 
 def _collection_checkpoint_flush_due(
     *,
@@ -161,15 +144,13 @@ def _collection_checkpoint_flush_due(
     now_ns: int,
     last_flush_ns: int,
 ) -> bool:
-    if intro_changed or remaining_files == 0:
-        return True
-    elapsed_ns = max(0, now_ns - last_flush_ns)
-    if semantic_substantive_progress:
-        return (
-            elapsed_ns >= _COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS
-            or elapsed_ns >= _COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
-        )
-    return elapsed_ns >= _COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
+    return runtime_contract.collection_checkpoint_flush_due(
+        intro_changed=intro_changed,
+        remaining_files=remaining_files,
+        semantic_substantive_progress=semantic_substantive_progress,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+    )
 
 def _collection_report_flush_due(
     *,
@@ -179,13 +160,13 @@ def _collection_report_flush_due(
     last_flush_ns: int,
     last_flush_completed: int,
 ) -> bool:
-    if last_flush_completed < 0:
-        return True
-    if completed_files - last_flush_completed >= _COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE:
-        return True
-    if now_ns - last_flush_ns >= _COLLECTION_REPORT_FLUSH_INTERVAL_NS:
-        return True
-    return remaining_files == 0
+    return runtime_contract.collection_report_flush_due(
+        completed_files=completed_files,
+        remaining_files=remaining_files,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+        last_flush_completed=last_flush_completed,
+    )
 
 def _projection_phase_flush_due(
     *,
@@ -193,9 +174,11 @@ def _projection_phase_flush_due(
     now_ns: int,
     last_flush_ns: int,
 ) -> bool:
-    if phase == "post":
-        return True
-    return now_ns - last_flush_ns >= _COLLECTION_REPORT_FLUSH_INTERVAL_NS
+    return runtime_contract.projection_phase_flush_due(
+        phase=phase,
+        now_ns=now_ns,
+        last_flush_ns=last_flush_ns,
+    )
 
 def _read_text_profiled(
     path: Path,
@@ -1277,28 +1260,7 @@ def _phase_timeline_jsonl_path(*, root: Path) -> Path:
     return root / _DEFAULT_PHASE_TIMELINE_JSONL
 
 def _progress_heartbeat_seconds(payload: Mapping[str, JSONValue]) -> float:
-    raw = payload.get("progress_heartbeat_seconds")
-    if isinstance(raw, bool):
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    if isinstance(raw, (int, float)):
-        parsed = float(raw)
-    elif isinstance(raw, str):
-        text = raw.strip()
-        if not text:
-            return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-        try:
-            parsed = float(text)
-        except ValueError:
-            return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    elif raw is None:
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    else:
-        return _DEFAULT_PROGRESS_HEARTBEAT_SECONDS
-    if parsed <= 0:
-        return 0.0
-    if parsed < _MIN_PROGRESS_HEARTBEAT_SECONDS:
-        return _MIN_PROGRESS_HEARTBEAT_SECONDS
-    return parsed
+    return runtime_contract.progress_heartbeat_seconds(payload)
 
 def _markdown_table_cell(value: object) -> str:
     return ("" if value is None else str(value)).replace("\n", " ").replace("|", "\\|")

--- a/src/gabion/server_core/dataflow_runtime_contract.py
+++ b/src/gabion/server_core/dataflow_runtime_contract.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+"""Server-core ownership module and single source of truth for progress/deadline/report runtime contract values."""
+
+from pathlib import Path
+from typing import Literal, Mapping
+
+from gabion.json_types import JSONValue
+from gabion.runtime import path_policy
+
+DEFAULT_PHASE_TIMELINE_MD = Path("artifacts/audit_reports/dataflow_phase_timeline.md")
+DEFAULT_PHASE_TIMELINE_JSONL = Path("artifacts/audit_reports/dataflow_phase_timeline.jsonl")
+DEFAULT_REPORT_SECTION_JOURNAL = Path("artifacts/audit_reports/dataflow_report_sections.json")
+
+COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS = 2_000_000_000
+COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS = 1_000_000_000
+COLLECTION_REPORT_FLUSH_INTERVAL_NS = 10_000_000_000
+COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE = 8
+
+DEFAULT_PROGRESS_HEARTBEAT_SECONDS = 55.0
+MIN_PROGRESS_HEARTBEAT_SECONDS = 5.0
+PROGRESS_DEADLINE_FLUSH_SECONDS = 5.0
+PROGRESS_DEADLINE_WATCHDOG_SECONDS = 10.0
+PROGRESS_HEARTBEAT_POLL_SECONDS = 0.05
+PROGRESS_DEADLINE_FLUSH_MARGIN_SECONDS = 0.5
+
+LSP_PROGRESS_NOTIFICATION_METHOD = "$/progress"
+LSP_PROGRESS_TOKEN_V2 = "gabion.dataflowAudit/progress-v2"
+LSP_PROGRESS_TOKEN = LSP_PROGRESS_TOKEN_V2
+
+STDOUT_ALIAS = "-"
+STDOUT_PATH = "/dev/stdout"
+
+PHASE_PRIMARY_UNITS: Mapping[str, str] = {
+    "collection": "collection_files",
+    "forest": "forest_mutable_steps",
+    "edge": "edge_tasks",
+    "post": "post_tasks",
+}
+
+
+def is_stdout_target(target: object) -> bool:
+    return path_policy.is_stdout_target(
+        target,
+        stdout_alias=STDOUT_ALIAS,
+        stdout_path=STDOUT_PATH,
+    )
+
+
+def deadline_tick_budget_allows_check(clock: object) -> bool:
+    limit = getattr(clock, "limit", None)
+    current = getattr(clock, "current", None)
+    if isinstance(limit, int) and isinstance(current, int):
+        return (limit - current) > 1
+    return True
+
+
+def collection_checkpoint_flush_due(
+    *,
+    intro_changed: bool,
+    remaining_files: int,
+    semantic_substantive_progress: bool = False,
+    now_ns: int,
+    last_flush_ns: int,
+) -> bool:
+    if intro_changed or remaining_files == 0:
+        return True
+    elapsed_ns = max(0, now_ns - last_flush_ns)
+    if semantic_substantive_progress:
+        return (
+            elapsed_ns >= COLLECTION_CHECKPOINT_MEANINGFUL_MIN_INTERVAL_NS
+            or elapsed_ns >= COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
+        )
+    return elapsed_ns >= COLLECTION_CHECKPOINT_FLUSH_INTERVAL_NS
+
+
+def collection_report_flush_due(
+    *,
+    completed_files: int,
+    remaining_files: int,
+    now_ns: int,
+    last_flush_ns: int,
+    last_flush_completed: int,
+) -> bool:
+    if last_flush_completed < 0:
+        return True
+    if completed_files - last_flush_completed >= COLLECTION_REPORT_FLUSH_COMPLETED_STRIDE:
+        return True
+    if now_ns - last_flush_ns >= COLLECTION_REPORT_FLUSH_INTERVAL_NS:
+        return True
+    return remaining_files == 0
+
+
+def projection_phase_flush_due(
+    *,
+    phase: Literal["collection", "forest", "edge", "post"],
+    now_ns: int,
+    last_flush_ns: int,
+) -> bool:
+    if phase == "post":
+        return True
+    return now_ns - last_flush_ns >= COLLECTION_REPORT_FLUSH_INTERVAL_NS
+
+
+def progress_heartbeat_seconds(payload: Mapping[str, JSONValue]) -> float:
+    raw = payload.get("progress_heartbeat_seconds")
+    if isinstance(raw, bool):
+        return DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+    if isinstance(raw, (int, float)):
+        parsed = float(raw)
+    elif isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+        try:
+            parsed = float(text)
+        except ValueError:
+            return DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+    elif raw is None:
+        return DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+    else:
+        return DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+    if parsed <= 0:
+        return 0.0
+    if parsed < MIN_PROGRESS_HEARTBEAT_SECONDS:
+        return MIN_PROGRESS_HEARTBEAT_SECONDS
+    return parsed

--- a/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
+++ b/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
@@ -49,3 +49,44 @@ def test_analysis_timeout_budget_parity() -> None:
     assert server._analysis_timeout_budget_ns(payload) == (
         command_orchestrator_primitives._analysis_timeout_budget_ns(payload)
     )
+
+
+def test_flush_decision_helpers_parity() -> None:
+    checkpoint_kwargs = {
+        "intro_changed": False,
+        "remaining_files": 2,
+        "semantic_substantive_progress": True,
+        "now_ns": 5_000_000_000,
+        "last_flush_ns": 3_000_000_000,
+    }
+    assert server._collection_checkpoint_flush_due(**checkpoint_kwargs) == (
+        command_orchestrator_primitives._collection_checkpoint_flush_due(**checkpoint_kwargs)
+    )
+
+    report_kwargs = {
+        "completed_files": 9,
+        "remaining_files": 1,
+        "now_ns": 20_000_000_000,
+        "last_flush_ns": 5_000_000_000,
+        "last_flush_completed": 0,
+    }
+    assert server._collection_report_flush_due(**report_kwargs) == (
+        command_orchestrator_primitives._collection_report_flush_due(**report_kwargs)
+    )
+
+    assert server._projection_phase_flush_due(
+        phase="post",
+        now_ns=0,
+        last_flush_ns=10_000_000_000,
+    ) == command_orchestrator_primitives._projection_phase_flush_due(
+        phase="post",
+        now_ns=0,
+        last_flush_ns=10_000_000_000,
+    )
+
+
+def test_progress_heartbeat_seconds_parity() -> None:
+    payload = {"progress_heartbeat_seconds": "4"}
+    assert server._progress_heartbeat_seconds(payload) == (
+        command_orchestrator_primitives._progress_heartbeat_seconds(payload)
+    )

--- a/tests/gabion/server_core/test_dataflow_runtime_contract.py
+++ b/tests/gabion/server_core/test_dataflow_runtime_contract.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from gabion.server_core import dataflow_runtime_contract as runtime_contract
+
+
+def test_collection_checkpoint_flush_due_semantic_interval() -> None:
+    assert runtime_contract.collection_checkpoint_flush_due(
+        intro_changed=False,
+        remaining_files=3,
+        semantic_substantive_progress=True,
+        now_ns=2_000_000_000,
+        last_flush_ns=1_000_000_000,
+    ) is True
+
+
+def test_collection_report_flush_due_terminal_and_stride() -> None:
+    assert runtime_contract.collection_report_flush_due(
+        completed_files=8,
+        remaining_files=2,
+        now_ns=0,
+        last_flush_ns=0,
+        last_flush_completed=0,
+    ) is True
+    assert runtime_contract.collection_report_flush_due(
+        completed_files=1,
+        remaining_files=0,
+        now_ns=1,
+        last_flush_ns=1,
+        last_flush_completed=1,
+    ) is True
+
+
+def test_progress_heartbeat_seconds_bounds() -> None:
+    assert runtime_contract.progress_heartbeat_seconds({"progress_heartbeat_seconds": " "}) == (
+        runtime_contract.DEFAULT_PROGRESS_HEARTBEAT_SECONDS
+    )
+    assert runtime_contract.progress_heartbeat_seconds({"progress_heartbeat_seconds": "1"}) == (
+        runtime_contract.MIN_PROGRESS_HEARTBEAT_SECONDS
+    )


### PR DESCRIPTION
### Motivation
- Reduce duplicated runtime constants and pure helper logic (progress/flush/heartbeat/stdout/deadline) present in both `src/gabion/server.py` and `src/gabion/server_core/command_orchestrator_primitives.py` by centralizing them under a single ownership module.
- Provide a clear single source of truth for progress/deadline/report contract values to avoid drift during further refactors and to keep server and orchestrator behavior aligned.

### Description
- Added a new canonical module `src/gabion/server_core/dataflow_runtime_contract.py` containing constants and pure helpers for progress heartbeat parsing, checkpoint/report/phase flush decisions, stdout-target normalization, and deadline tick-budget checks, with a short ownership module docstring.
- Updated `src/gabion/server.py` to import and use the runtime contract symbols and helpers (replacing local duplicated constants/functions with calls to `runtime_contract`).
- Updated `src/gabion/server_core/command_orchestrator_primitives.py` to import and use the same canonical runtime contract module instead of redefining those constants and helpers.
- Added targeted tests to guard moved behavior and parity: `tests/gabion/server_core/test_dataflow_runtime_contract.py` and extended parity checks in `tests/gabion/server/server_orchestrator_primitive_parity_cases.py` to cover flush-decision helpers and heartbeat parsing.
- Refreshed `out/test_evidence.json` to include the new tests/evidence entries.

### Testing
- Ran the repo workflow policy check with `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` which completed successfully after addressing environment/tool path concerns.
- Ran ambiguity-contract check with `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which completed successfully.
- Ran the targeted pytest subset with `PYTHONPATH=src:. pytest -q -o addopts='' tests/gabion/server/server_orchestrator_primitive_parity_cases.py tests/gabion/server_core/test_dataflow_runtime_contract.py` and observed `9 passed` (successful).
- Extracted test evidence with `PYTHONPATH=src:. python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` which completed and updated `out/test_evidence.json`.
- Note: initial attempts to run tooling via `mise` and `python -m` had environment/tool-resolution issues in this session (untrusted `mise.toml` and build dependency resolution for editable install), but the above checks were run successfully via direct `PYTHONPATH` invocation and targeted pytest invocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a977b1289483249628807d073c1086)