### PR TITLE
Refactor check aux CLI wiring to typed option profiles

### DIFF
--- a/src/gabion/cli_support/check/check_commands.py
+++ b/src/gabion/cli_support/check/check_commands.py
@@ -20,25 +20,49 @@ RunCheckAuxOperationFn = Callable[..., None]
 class CheckAuxCommandRegistration:
     domain: str
     action: str
-    option_profile: str
+    option_profile: "CheckAuxOptionProfile"
+
+
+@dataclass(frozen=True)
+class CheckAuxOptionProfile:
+    name: str
+    baseline_required: bool
+    out_md_allowed: bool
+
+
+CHECK_AUX_OPTION_PROFILE_REPORT = CheckAuxOptionProfile(
+    name="report",
+    baseline_required=False,
+    out_md_allowed=True,
+)
+CHECK_AUX_OPTION_PROFILE_STATE = CheckAuxOptionProfile(
+    name="state",
+    baseline_required=False,
+    out_md_allowed=False,
+)
+CHECK_AUX_OPTION_PROFILE_DELTA = CheckAuxOptionProfile(
+    name="delta",
+    baseline_required=True,
+    out_md_allowed=True,
+)
 
 
 CHECK_AUX_COMMAND_REGISTRATIONS: tuple[CheckAuxCommandRegistration, ...] = (
-    CheckAuxCommandRegistration("obsolescence", "report", "report"),
-    CheckAuxCommandRegistration("obsolescence", "state", "state"),
-    CheckAuxCommandRegistration("obsolescence", "delta", "delta"),
-    CheckAuxCommandRegistration("obsolescence", "baseline-write", "delta"),
-    CheckAuxCommandRegistration("annotation-drift", "report", "report"),
-    CheckAuxCommandRegistration("annotation-drift", "state", "state"),
-    CheckAuxCommandRegistration("annotation-drift", "delta", "delta"),
-    CheckAuxCommandRegistration("annotation-drift", "baseline-write", "delta"),
-    CheckAuxCommandRegistration("ambiguity", "state", "state"),
-    CheckAuxCommandRegistration("ambiguity", "delta", "delta"),
-    CheckAuxCommandRegistration("ambiguity", "baseline-write", "delta"),
-    CheckAuxCommandRegistration("taint", "state", "state"),
-    CheckAuxCommandRegistration("taint", "delta", "delta"),
-    CheckAuxCommandRegistration("taint", "baseline-write", "delta"),
-    CheckAuxCommandRegistration("taint", "lifecycle", "state"),
+    CheckAuxCommandRegistration("obsolescence", "report", CHECK_AUX_OPTION_PROFILE_REPORT),
+    CheckAuxCommandRegistration("obsolescence", "state", CHECK_AUX_OPTION_PROFILE_STATE),
+    CheckAuxCommandRegistration("obsolescence", "delta", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("obsolescence", "baseline-write", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("annotation-drift", "report", CHECK_AUX_OPTION_PROFILE_REPORT),
+    CheckAuxCommandRegistration("annotation-drift", "state", CHECK_AUX_OPTION_PROFILE_STATE),
+    CheckAuxCommandRegistration("annotation-drift", "delta", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("annotation-drift", "baseline-write", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("ambiguity", "state", CHECK_AUX_OPTION_PROFILE_STATE),
+    CheckAuxCommandRegistration("ambiguity", "delta", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("ambiguity", "baseline-write", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("taint", "state", CHECK_AUX_OPTION_PROFILE_STATE),
+    CheckAuxCommandRegistration("taint", "delta", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("taint", "baseline-write", CHECK_AUX_OPTION_PROFILE_DELTA),
+    CheckAuxCommandRegistration("taint", "lifecycle", CHECK_AUX_OPTION_PROFILE_STATE),
 )
 
 
@@ -52,48 +76,131 @@ def register_check_aux_commands(
     commands: dict[str, Callable[..., None]] = {}
     for registration in command_registrations:
         command_app = command_domains[registration.domain]
-        if registration.option_profile == "report":
-            command = _build_check_aux_report_command(
-                command_app=command_app,
-                command_name=registration.action,
-                domain=registration.domain,
-                action=registration.action,
-                check_strictness_mode=check_strictness_mode,
-                run_check_aux_operation_fn=run_check_aux_operation_fn,
-            )
-        elif registration.option_profile == "state":
-            command = _build_check_aux_state_command(
-                command_app=command_app,
-                command_name=registration.action,
-                domain=registration.domain,
-                action=registration.action,
-                check_strictness_mode=check_strictness_mode,
-                run_check_aux_operation_fn=run_check_aux_operation_fn,
-            )
-        elif registration.option_profile == "delta":
-            command = _build_check_aux_delta_command(
-                command_app=command_app,
-                command_name=registration.action,
-                domain=registration.domain,
-                action=registration.action,
-                check_strictness_mode=check_strictness_mode,
-                run_check_aux_operation_fn=run_check_aux_operation_fn,
-            )
-        else:
-            raise ValueError(f"Unknown option profile: {registration.option_profile}")
+        command = _build_check_aux_command(
+            command_app=command_app,
+            command_name=registration.action,
+            domain=registration.domain,
+            action=registration.action,
+            option_profile=registration.option_profile,
+            check_strictness_mode=check_strictness_mode,
+            run_check_aux_operation_fn=run_check_aux_operation_fn,
+        )
         commands[f"{registration.domain}:{registration.action}"] = command
     return commands
 
 
-def _build_check_aux_report_command(
+def _build_check_aux_operation_kwargs(
+    *,
+    option_profile: CheckAuxOptionProfile,
+    ctx: typer.Context,
+    domain: str,
+    action: str,
+    paths: list[Path],
+    root: Path,
+    config: Path | None,
+    strictness: object,
+    allow_external: bool | None,
+    baseline: Path | None,
+    state_in: Path | None,
+    out_json: Path | None,
+    out_md: Path | None,
+    report: Path | None,
+    decision_snapshot: Path | None,
+    analysis_budget_checks: int | None,
+    aspf_state_json: Path | None,
+    aspf_import_state: list[Path] | None,
+) -> dict[str, object]:
+    if option_profile.baseline_required and baseline is None:
+        raise typer.BadParameter("--baseline is required for this command profile")
+    return {
+        "ctx": ctx,
+        "domain": domain,
+        "action": action,
+        "paths": paths,
+        "root": root,
+        "config": config,
+        "strictness": strictness,
+        "allow_external": allow_external,
+        "baseline": baseline,
+        "state_in": state_in,
+        "out_json": out_json,
+        "out_md": out_md if option_profile.out_md_allowed else None,
+        "report": report,
+        "decision_snapshot": decision_snapshot,
+        "analysis_budget_checks": analysis_budget_checks,
+        "aspf_state_json": aspf_state_json,
+        "aspf_import_state": aspf_import_state,
+    }
+
+
+def _build_check_aux_command(
     *,
     command_app: typer.Typer,
     command_name: str,
     domain: str,
     action: str,
+    option_profile: CheckAuxOptionProfile,
     check_strictness_mode: type,
     run_check_aux_operation_fn: RunCheckAuxOperationFn,
 ) -> Callable[..., None]:
+    if option_profile.out_md_allowed:
+
+        @command_app.command(command_name)
+        def command(
+            ctx: typer.Context,
+            paths: list[Path] = typer.Argument(None),
+            root: Path = typer.Option(Path("."), "--root"),
+            config: Path | None = typer.Option(None, "--config"),
+            strictness: check_strictness_mode = typer.Option(check_strictness_mode.high, "--strictness"),
+            allow_external: bool | None = typer.Option(
+                None, "--allow-external/--no-allow-external"
+            ),
+            baseline: Path | None = typer.Option(
+                ..., "--baseline"
+            )
+            if option_profile.baseline_required
+            else typer.Option(None, "--baseline"),
+            state_in: Path | None = typer.Option(None, "--state-in"),
+            out_json: Path | None = typer.Option(None, "--out-json"),
+            out_md: Path | None = typer.Option(None, "--out-md"),
+            report: Path | None = typer.Option(None, "--report"),
+            decision_snapshot: Path | None = typer.Option(None, "--decision-snapshot"),
+            analysis_budget_checks: int | None = typer.Option(
+                None,
+                "--analysis-budget-checks",
+                min=1,
+            ),
+            aspf_state_json: Path | None = typer.Option(None, "--aspf-state-json"),
+            aspf_import_state: list[Path] | None = typer.Option(
+                None,
+                "--aspf-import-state",
+            ),
+        ) -> None:
+            run_check_aux_operation_fn(
+                **_build_check_aux_operation_kwargs(
+                    option_profile=option_profile,
+                    ctx=ctx,
+                    domain=domain,
+                    action=action,
+                    paths=paths,
+                    root=root,
+                    config=config,
+                    strictness=strictness,
+                    allow_external=allow_external,
+                    baseline=baseline,
+                    state_in=state_in,
+                    out_json=out_json,
+                    out_md=out_md,
+                    report=report,
+                    decision_snapshot=decision_snapshot,
+                    analysis_budget_checks=analysis_budget_checks,
+                    aspf_state_json=aspf_state_json,
+                    aspf_import_state=aspf_import_state,
+                )
+            )
+
+        return command
+
     @command_app.command(command_name)
     def command(
         ctx: typer.Context,
@@ -104,64 +211,11 @@ def _build_check_aux_report_command(
         allow_external: bool | None = typer.Option(
             None, "--allow-external/--no-allow-external"
         ),
-        state_in: Path | None = typer.Option(None, "--state-in"),
-        out_json: Path | None = typer.Option(None, "--out-json"),
-        out_md: Path | None = typer.Option(None, "--out-md"),
-        report: Path | None = typer.Option(None, "--report"),
-        decision_snapshot: Path | None = typer.Option(None, "--decision-snapshot"),
-        analysis_budget_checks: int | None = typer.Option(
-            None,
-            "--analysis-budget-checks",
-            min=1,
-        ),
-        aspf_state_json: Path | None = typer.Option(None, "--aspf-state-json"),
-        aspf_import_state: list[Path] | None = typer.Option(
-            None,
-            "--aspf-import-state",
-        ),
-    ) -> None:
-        run_check_aux_operation_fn(
-            ctx=ctx,
-            domain=domain,
-            action=action,
-            paths=paths,
-            root=root,
-            config=config,
-            strictness=strictness,
-            allow_external=allow_external,
-            baseline=None,
-            state_in=state_in,
-            out_json=out_json,
-            out_md=out_md,
-            report=report,
-            decision_snapshot=decision_snapshot,
-            analysis_budget_checks=analysis_budget_checks,
-            aspf_state_json=aspf_state_json,
-            aspf_import_state=aspf_import_state,
+        baseline: Path | None = typer.Option(
+            ..., "--baseline"
         )
-
-    return command
-
-
-def _build_check_aux_state_command(
-    *,
-    command_app: typer.Typer,
-    command_name: str,
-    domain: str,
-    action: str,
-    check_strictness_mode: type,
-    run_check_aux_operation_fn: RunCheckAuxOperationFn,
-) -> Callable[..., None]:
-    @command_app.command(command_name)
-    def command(
-        ctx: typer.Context,
-        paths: list[Path] = typer.Argument(None),
-        root: Path = typer.Option(Path("."), "--root"),
-        config: Path | None = typer.Option(None, "--config"),
-        strictness: check_strictness_mode = typer.Option(check_strictness_mode.high, "--strictness"),
-        allow_external: bool | None = typer.Option(
-            None, "--allow-external/--no-allow-external"
-        ),
+        if option_profile.baseline_required
+        else typer.Option(None, "--baseline"),
         state_in: Path | None = typer.Option(None, "--state-in"),
         out_json: Path | None = typer.Option(None, "--out-json"),
         report: Path | None = typer.Option(None, "--report"),
@@ -178,82 +232,26 @@ def _build_check_aux_state_command(
         ),
     ) -> None:
         run_check_aux_operation_fn(
-            ctx=ctx,
-            domain=domain,
-            action=action,
-            paths=paths,
-            root=root,
-            config=config,
-            strictness=strictness,
-            allow_external=allow_external,
-            baseline=None,
-            state_in=state_in,
-            out_json=out_json,
-            out_md=None,
-            report=report,
-            decision_snapshot=decision_snapshot,
-            analysis_budget_checks=analysis_budget_checks,
-            aspf_state_json=aspf_state_json,
-            aspf_import_state=aspf_import_state,
-        )
-
-    return command
-
-
-def _build_check_aux_delta_command(
-    *,
-    command_app: typer.Typer,
-    command_name: str,
-    domain: str,
-    action: str,
-    check_strictness_mode: type,
-    run_check_aux_operation_fn: RunCheckAuxOperationFn,
-) -> Callable[..., None]:
-    @command_app.command(command_name)
-    def command(
-        ctx: typer.Context,
-        paths: list[Path] = typer.Argument(None),
-        root: Path = typer.Option(Path("."), "--root"),
-        config: Path | None = typer.Option(None, "--config"),
-        strictness: check_strictness_mode = typer.Option(check_strictness_mode.high, "--strictness"),
-        allow_external: bool | None = typer.Option(
-            None, "--allow-external/--no-allow-external"
-        ),
-        baseline: Path = typer.Option(..., "--baseline"),
-        state_in: Path | None = typer.Option(None, "--state-in"),
-        out_json: Path | None = typer.Option(None, "--out-json"),
-        out_md: Path | None = typer.Option(None, "--out-md"),
-        report: Path | None = typer.Option(None, "--report"),
-        decision_snapshot: Path | None = typer.Option(None, "--decision-snapshot"),
-        analysis_budget_checks: int | None = typer.Option(
-            None,
-            "--analysis-budget-checks",
-            min=1,
-        ),
-        aspf_state_json: Path | None = typer.Option(None, "--aspf-state-json"),
-        aspf_import_state: list[Path] | None = typer.Option(
-            None,
-            "--aspf-import-state",
-        ),
-    ) -> None:
-        run_check_aux_operation_fn(
-            ctx=ctx,
-            domain=domain,
-            action=action,
-            paths=paths,
-            root=root,
-            config=config,
-            strictness=strictness,
-            allow_external=allow_external,
-            baseline=baseline,
-            state_in=state_in,
-            out_json=out_json,
-            out_md=out_md,
-            report=report,
-            decision_snapshot=decision_snapshot,
-            analysis_budget_checks=analysis_budget_checks,
-            aspf_state_json=aspf_state_json,
-            aspf_import_state=aspf_import_state,
+            **_build_check_aux_operation_kwargs(
+                option_profile=option_profile,
+                ctx=ctx,
+                domain=domain,
+                action=action,
+                paths=paths,
+                root=root,
+                config=config,
+                strictness=strictness,
+                allow_external=allow_external,
+                baseline=baseline,
+                state_in=state_in,
+                out_json=out_json,
+                out_md=None,
+                report=report,
+                decision_snapshot=decision_snapshot,
+                analysis_budget_checks=analysis_budget_checks,
+                aspf_state_json=aspf_state_json,
+                aspf_import_state=aspf_import_state,
+            )
         )
 
     return command

--- a/tests/gabion/cli/cli_commands_cases.py
+++ b/tests/gabion/cli/cli_commands_cases.py
@@ -804,3 +804,67 @@ def test_register_check_aux_commands_uses_registration_table() -> None:
     assert ("obsolescence", "delta") in observed
     assert ("taint", "state") in observed
     assert ("annotation-drift", "report") in observed
+
+
+def test_register_check_aux_commands_profile_argument_shaping() -> None:
+    captured: list[dict[str, object]] = []
+
+    def _capture(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    apps = {
+        "obsolescence": typer.Typer(),
+        "annotation-drift": typer.Typer(),
+        "ambiguity": typer.Typer(),
+        "taint": typer.Typer(),
+    }
+    check_commands.register_check_aux_commands(
+        command_domains=apps,
+        check_strictness_mode=cli.CheckStrictnessMode,
+        run_check_aux_operation_fn=_capture,
+    )
+
+    app = typer.Typer()
+    for domain, domain_app in apps.items():
+        app.add_typer(domain_app, name=domain)
+    runner = CliRunner()
+
+    report_result = runner.invoke(
+        app,
+        [
+            "annotation-drift",
+            "report",
+            "sample.py",
+            "--out-md",
+            "report.md",
+        ],
+    )
+    assert report_result.exit_code == 0
+    state_result = runner.invoke(app, ["taint", "state", "sample.py"])
+    assert state_result.exit_code == 0
+    delta_result = runner.invoke(
+        app,
+        [
+            "obsolescence",
+            "delta",
+            "sample.py",
+            "--baseline",
+            "obs.json",
+            "--out-md",
+            "delta.md",
+        ],
+    )
+    assert delta_result.exit_code == 0
+
+    report_call, state_call, delta_call = captured
+    assert report_call["action"] == "report"
+    assert report_call["baseline"] is None
+    assert report_call["out_md"] == Path("report.md")
+
+    assert state_call["action"] == "state"
+    assert state_call["baseline"] is None
+    assert state_call["out_md"] is None
+
+    assert delta_call["action"] == "delta"
+    assert delta_call["baseline"] == Path("obs.json")
+    assert delta_call["out_md"] == Path("delta.md")


### PR DESCRIPTION
### Motivation
- Reduce branching and accidental argument mismatches across aux `check` subcommands by reifying the option surface into a single typed profile descriptor.
- Centralize argument shaping to ensure consistent payloads are passed to the aux operation runner and make future profile changes simpler and safer.

### Description
- Added a typed `CheckAuxOptionProfile` dataclass and changed `CheckAuxCommandRegistration` to carry profile objects instead of strings, with constants for `report`, `state`, and `delta` profiles in `src/gabion/cli_support/check/check_commands.py`.
- Replaced the three builders (`_build_check_aux_report_command`, `_build_check_aux_state_command`, `_build_check_aux_delta_command`) with a single factory `_build_check_aux_command(...)` that constructs the Typer command surface based on the profile.
- Centralized run-argument shaping in `_build_check_aux_operation_kwargs(...)`, enforcing profile constraints (e.g., `baseline` required for `delta`, `out_md` allowed only when permitted by profile) and normalizing `out_md`/`baseline` behavior.
- Updated the `CHECK_AUX_COMMAND_REGISTRATIONS` matrix to reference profile objects (constants) rather than string cases.
- Added focused CLI wiring tests exercising one command from each profile type (`report`, `state`, `delta`) in `tests/gabion/cli/cli_commands_cases.py` and refreshed `out/test_evidence.json` to include the new test mapping.

### Testing
- Ran the workflow policy check with `python scripts/policy/policy_check.py --workflows` and the ambiguity contract check with `python scripts/policy/policy_check.py --ambiguity-contract`, both executed successfully in the environment (the environment emitted a `mise` resolver warning but the checks completed).
- Ran the targeted pytest selection for the CLI wiring with `pytest -o addopts='' tests/gabion/cli/cli_commands_cases.py -k "check_aux_commands"`, and the selected tests passed (2 passed, others deselected).
- Re-ran the test-evidence extraction with `python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to record the added test (diff included in this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a977f953ec8324b12b1d7037d1dfe6)