### PR TITLE
Refactor synth payload construction through shared dataflow options

### DIFF
--- a/src/gabion/cli_support/shared/payload_builder.py
+++ b/src/gabion/cli_support/shared/payload_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
@@ -13,6 +14,69 @@ from gabion.json_types import JSONObject
 
 NormalizeOptionalOutputTargetFn = Callable[[object], str | None]
 BuildDataflowPayloadCommonFn = Callable[..., JSONObject]
+
+
+@dataclass(frozen=True)
+class SynthPayloadOptions:
+    no_recursive: bool
+    max_components: int
+    type_audit_report: bool
+    type_audit_max: int
+    synthesis_plan: Path
+    synthesis_report: bool
+    synthesis_protocols: Path
+    synthesis_protocols_kind: str
+    synthesis_max_tier: int
+    synthesis_min_bundle_size: int
+    synthesis_allow_singletons: bool
+    refactor_plan: bool
+    refactor_plan_json: Path | None
+    fingerprint_synth_json: Path
+    fingerprint_provenance_json: Path
+    fingerprint_coherence_json: Path
+    fingerprint_rewrite_plans_json: Path
+    fingerprint_exception_obligations_json: Path
+    fingerprint_handledness_json: Path
+
+
+def build_synth_payload(
+    *,
+    options: DataflowPayloadCommonOptions,
+    synth_options: SynthPayloadOptions,
+    build_dataflow_payload_common_fn: BuildDataflowPayloadCommonFn,
+) -> JSONObject:
+    payload = build_dataflow_payload_common_fn(options=options)
+    payload.update(
+        {
+            "dot": None,
+            "no_recursive": synth_options.no_recursive,
+            "max_components": synth_options.max_components,
+            "type_audit_report": synth_options.type_audit_report,
+            "type_audit_max": synth_options.type_audit_max,
+            "synthesis_plan": str(synth_options.synthesis_plan),
+            "synthesis_report": synth_options.synthesis_report,
+            "synthesis_protocols": str(synth_options.synthesis_protocols),
+            "synthesis_protocols_kind": synth_options.synthesis_protocols_kind,
+            "synthesis_max_tier": synth_options.synthesis_max_tier,
+            "synthesis_min_bundle_size": synth_options.synthesis_min_bundle_size,
+            "synthesis_allow_singletons": synth_options.synthesis_allow_singletons,
+            "refactor_plan": synth_options.refactor_plan,
+            "refactor_plan_json": str(synth_options.refactor_plan_json)
+            if synth_options.refactor_plan_json is not None
+            else None,
+            "fingerprint_synth_json": str(synth_options.fingerprint_synth_json),
+            "fingerprint_provenance_json": str(synth_options.fingerprint_provenance_json),
+            "fingerprint_coherence_json": str(synth_options.fingerprint_coherence_json),
+            "fingerprint_rewrite_plans_json": str(
+                synth_options.fingerprint_rewrite_plans_json
+            ),
+            "fingerprint_exception_obligations_json": str(
+                synth_options.fingerprint_exception_obligations_json
+            ),
+            "fingerprint_handledness_json": str(synth_options.fingerprint_handledness_json),
+        }
+    )
+    return payload
 
 
 def build_dataflow_payload(

--- a/src/gabion/cli_support/synth/synth_runtime.py
+++ b/src/gabion/cli_support/synth/synth_runtime.py
@@ -8,6 +8,8 @@ from typing import Callable, Optional
 
 import typer
 
+from gabion.cli_support.shared import payload_builder
+from gabion.commands import check_contract
 from gabion.commands.check_contract import DataflowFilterBundle
 from gabion.json_types import JSONObject
 from gabion.lsp_client import run_command
@@ -51,15 +53,7 @@ def run_synth(
 ) -> tuple[JSONObject, dict[str, Path], Path | None]:
     check_deadline_fn()
     resolved_filter_bundle = filter_bundle or DataflowFilterBundle(None, None)
-    if not paths:
-        paths = [Path(".")]
-    exclude_dirs: list[str] | None = None
-    if exclude is not None:
-        exclude_dirs = []
-        for entry in exclude:
-            check_deadline_fn()
-            exclude_dirs.extend([part.strip() for part in entry.split(",") if part.strip()])
-    ignore_list, transparent_list = resolved_filter_bundle.to_payload_lists()
+    resolved_paths = paths or [Path(".")]
     if strictness is not None and strictness not in {"high", "low"}:
         raise typer.BadParameter("strictness must be 'high' or 'low'")
     if synthesis_protocols_kind not in {"dataclass", "protocol", "contextvar"}:
@@ -90,54 +84,55 @@ def run_synth(
     )
     fingerprint_handledness_path = output_root / "fingerprint_handledness.json"
 
-    payload: JSONObject = {
-        "paths": [str(p) for p in paths],
-        "root": str(root),
-        "config": str(config) if config is not None else None,
-        "report": str(report_path),
-        "dot": str(dot_path),
-        "fail_on_violations": fail_on_violations,
-        "no_recursive": no_recursive,
-        "max_components": max_components,
-        "type_audit_report": type_audit_report,
-        "type_audit_max": type_audit_max,
-        "exclude": exclude_dirs,
-        "ignore_params": ignore_list,
-        "transparent_decorators": transparent_list,
-        "allow_external": allow_external,
-        "strictness": strictness,
-        "synthesis_plan": str(plan_path),
-        "synthesis_report": True,
-        "synthesis_protocols": str(protocol_path),
-        "synthesis_protocols_kind": synthesis_protocols_kind,
-        "synthesis_max_tier": synthesis_max_tier,
-        "synthesis_min_bundle_size": synthesis_min_bundle_size,
-        "synthesis_allow_singletons": synthesis_allow_singletons,
-        "refactor_plan": refactor_plan,
-        "refactor_plan_json": str(refactor_plan_path) if refactor_plan else None,
-        "fingerprint_synth_json": str(fingerprint_synth_path),
-        "fingerprint_provenance_json": str(fingerprint_provenance_path),
-        "fingerprint_coherence_json": str(fingerprint_coherence_path),
-        "fingerprint_rewrite_plans_json": str(fingerprint_rewrite_plans_path),
-        "fingerprint_exception_obligations_json": str(
-            fingerprint_exception_obligations_path
+    payload = payload_builder.build_synth_payload(
+        options=check_contract.DataflowPayloadCommonOptions(
+            paths=resolved_paths,
+            root=root,
+            config=config,
+            report=report_path,
+            fail_on_violations=fail_on_violations,
+            fail_on_type_ambiguities=False,
+            baseline=None,
+            baseline_write=None,
+            decision_snapshot=None,
+            exclude=exclude,
+            filter_bundle=resolved_filter_bundle,
+            allow_external=allow_external,
+            strictness=strictness,
+            lint=False,
+            aspf_trace_json=aspf_trace_json,
+            aspf_import_trace=aspf_import_trace,
+            aspf_equivalence_against=aspf_equivalence_against,
+            aspf_opportunities_json=aspf_opportunities_json,
+            aspf_state_json=aspf_state_json,
+            aspf_import_state=aspf_import_state,
+            aspf_delta_jsonl=aspf_delta_jsonl,
+            aspf_semantic_surface=aspf_semantic_surface,
         ),
-        "fingerprint_handledness_json": str(fingerprint_handledness_path),
-        "aspf_trace_json": str(aspf_trace_json) if aspf_trace_json is not None else None,
-        "aspf_import_trace": [str(path) for path in (aspf_import_trace or [])],
-        "aspf_equivalence_against": [
-            str(path) for path in (aspf_equivalence_against or [])
-        ],
-        "aspf_opportunities_json": (
-            str(aspf_opportunities_json) if aspf_opportunities_json is not None else None
+        synth_options=payload_builder.SynthPayloadOptions(
+            no_recursive=no_recursive,
+            max_components=max_components,
+            type_audit_report=type_audit_report,
+            type_audit_max=type_audit_max,
+            synthesis_plan=plan_path,
+            synthesis_report=True,
+            synthesis_protocols=protocol_path,
+            synthesis_protocols_kind=synthesis_protocols_kind,
+            synthesis_max_tier=synthesis_max_tier,
+            synthesis_min_bundle_size=synthesis_min_bundle_size,
+            synthesis_allow_singletons=synthesis_allow_singletons,
+            refactor_plan=refactor_plan,
+            refactor_plan_json=refactor_plan_path if refactor_plan else None,
+            fingerprint_synth_json=fingerprint_synth_path,
+            fingerprint_provenance_json=fingerprint_provenance_path,
+            fingerprint_coherence_json=fingerprint_coherence_path,
+            fingerprint_rewrite_plans_json=fingerprint_rewrite_plans_path,
+            fingerprint_exception_obligations_json=fingerprint_exception_obligations_path,
+            fingerprint_handledness_json=fingerprint_handledness_path,
         ),
-        "aspf_state_json": str(aspf_state_json) if aspf_state_json is not None else None,
-        "aspf_import_state": [str(path) for path in (aspf_import_state or [])],
-        "aspf_delta_jsonl": str(aspf_delta_jsonl) if aspf_delta_jsonl is not None else None,
-        "aspf_semantic_surface": [
-            str(surface) for surface in (aspf_semantic_surface or [])
-        ],
-    }
+        build_dataflow_payload_common_fn=check_contract.build_dataflow_payload_common,
+    )
+    payload["dot"] = str(dot_path)
     result = dispatch_command_fn(
         command=dataflow_command,
         payload=payload,

--- a/tests/gabion/cli/cli_helpers_cases.py
+++ b/tests/gabion/cli/cli_helpers_cases.py
@@ -15,8 +15,11 @@ from typer.testing import CliRunner
 
 from gabion import cli
 from gabion.analysis.foundation.timeout_context import check_deadline
+from gabion.commands import check_contract
 from gabion.commands import progress_contract as progress_timeline
 from gabion.commands import transport_policy
+from gabion.cli_support.check import check_runtime
+from gabion.cli_support.synth import synth_runtime
 from gabion.exceptions import NeverThrown
 from gabion.runtime import env_policy
 from gabion.tooling.runtime import tool_specs
@@ -1893,6 +1896,130 @@ def test_legacy_dataflow_monolith_emits_fingerprint_outputs(capsys) -> None:
     assert "\"plan_id\"" in captured.out
     assert "\"exception_path_id\"" in captured.out
     assert "\"handledness_id\"" in captured.out
+
+
+# gabion:evidence E:decision_surface/direct::cli.py::gabion.cli._run_check::aspf_delta_jsonl,aspf_equivalence_against,aspf_import_state,aspf_import_trace,aspf_opportunities_json,aspf_semantic_surface,aspf_state_json,aspf_trace_json,exclude,filter_bundle,paths,root,strictness E:decision_surface/direct::cli.py::gabion.cli._run_synth::aspf_delta_jsonl,aspf_equivalence_against,aspf_import_state,aspf_import_trace,aspf_opportunities_json,aspf_semantic_surface,aspf_state_json,aspf_trace_json,exclude,filter_bundle,paths,root,strictness
+def test_check_and_synth_encode_common_payload_fields_identically(tmp_path: Path) -> None:
+    check_payload: dict[str, object] = {}
+    synth_payload: dict[str, object] = {}
+
+    def _dispatch_check(*, payload: dict[str, object], **_kwargs: object) -> dict[str, object]:
+        check_payload.update(payload)
+        return {"exit_code": 0}
+
+    def _dispatch_synth(*, payload: dict[str, object], **_kwargs: object) -> dict[str, object]:
+        synth_payload.update(payload)
+        return {"exit_code": 0}
+
+    policy = check_contract.CheckPolicyFlags(
+        fail_on_violations=False,
+        fail_on_type_ambiguities=False,
+        lint=False,
+    )
+    artifact_flags = check_contract.CheckArtifactFlags(
+        emit_test_obsolescence=False,
+        emit_test_evidence_suggestions=False,
+        emit_call_clusters=False,
+        emit_call_cluster_consolidation=False,
+        emit_test_annotation_drift=False,
+    )
+    delta_options = check_contract.CheckDeltaOptions(
+        obsolescence_mode=check_contract.CheckAuxMode(kind="off"),
+        annotation_drift_mode=check_contract.CheckAuxMode(kind="off"),
+        ambiguity_mode=check_contract.CheckAuxMode(kind="off"),
+        semantic_coverage_mapping=None,
+    )
+    filter_bundle = check_contract.DataflowFilterBundle("x, y", "deco")
+    common_paths = [tmp_path / "pkg"]
+    root = tmp_path
+    aspf_trace_json = tmp_path / "trace.json"
+    aspf_import_trace = [tmp_path / "trace_a.json"]
+    aspf_equivalence_against = [tmp_path / "equiv.json"]
+    aspf_opportunities_json = tmp_path / "opp.json"
+    aspf_state_json = tmp_path / "state.json"
+    aspf_import_state = [tmp_path / "state_import.json"]
+    aspf_delta_jsonl = tmp_path / "delta.jsonl"
+    aspf_semantic_surface = ["bundle", "state"]
+
+    check_runtime.run_check(
+        paths=common_paths,
+        report=tmp_path / "check_report.md",
+        policy=policy,
+        root=root,
+        config=None,
+        baseline=None,
+        baseline_write=False,
+        decision_snapshot=None,
+        artifact_flags=artifact_flags,
+        delta_options=delta_options,
+        exclude=["a, b"],
+        filter_bundle=filter_bundle,
+        allow_external=None,
+        strictness="high",
+        runner=lambda *_a, **_k: {"exit_code": 0},
+        resolve_check_report_path_fn=lambda report, *, root: report or (root / "report.md"),
+        build_check_payload_fn=check_contract.build_check_payload,
+        build_check_execution_plan_request_fn=lambda **_kwargs: object(),
+        dispatch_command_fn=_dispatch_check,
+        dataflow_command="dataflow.check",
+        aspf_trace_json=aspf_trace_json,
+        aspf_import_trace=aspf_import_trace,
+        aspf_equivalence_against=aspf_equivalence_against,
+        aspf_opportunities_json=aspf_opportunities_json,
+        aspf_state_json=aspf_state_json,
+        aspf_import_state=aspf_import_state,
+        aspf_delta_jsonl=aspf_delta_jsonl,
+        aspf_semantic_surface=aspf_semantic_surface,
+    )
+
+    synth_runtime.run_synth(
+        paths=common_paths,
+        root=root,
+        out_dir=tmp_path / "synth_out",
+        no_timestamp=True,
+        config=None,
+        exclude=["a, b"],
+        filter_bundle=filter_bundle,
+        allow_external=None,
+        strictness="high",
+        no_recursive=False,
+        max_components=3,
+        type_audit_report=True,
+        type_audit_max=5,
+        synthesis_max_tier=2,
+        synthesis_min_bundle_size=1,
+        synthesis_allow_singletons=False,
+        synthesis_protocols_kind="dataclass",
+        refactor_plan=False,
+        fail_on_violations=False,
+        runner=lambda *_a, **_k: {"exit_code": 0},
+        dispatch_command_fn=_dispatch_synth,
+        check_deadline_fn=lambda: None,
+        dataflow_command="dataflow.synth",
+        aspf_trace_json=aspf_trace_json,
+        aspf_import_trace=aspf_import_trace,
+        aspf_equivalence_against=aspf_equivalence_against,
+        aspf_opportunities_json=aspf_opportunities_json,
+        aspf_state_json=aspf_state_json,
+        aspf_import_state=aspf_import_state,
+        aspf_delta_jsonl=aspf_delta_jsonl,
+        aspf_semantic_surface=aspf_semantic_surface,
+    )
+
+    for key in (
+        "paths",
+        "root",
+        "strictness",
+        "aspf_trace_json",
+        "aspf_import_trace",
+        "aspf_equivalence_against",
+        "aspf_opportunities_json",
+        "aspf_state_json",
+        "aspf_import_state",
+        "aspf_delta_jsonl",
+        "aspf_semantic_surface",
+    ):
+        assert synth_payload[key] == check_payload[key]
 
 
 # gabion:evidence E:decision_surface/direct::cli.py::gabion.cli._run_synth::config,exclude,filter_bundle,no_timestamp,paths,refactor_plan,strictness,synthesis_protocols_kind


### PR DESCRIPTION
### Motivation

- Make synth payload composition follow the same typed/bundle pattern as the check flow to remove duplicated coercion and CSV parsing logic. 
- Ensure `aspf_*` and shared fields (`paths`, `root`, `strictness`, etc.) are encoded identically between `check` and `synth` commands for equivalent inputs. 
- Keep synth-only artifacts (plan/protocol/refactor/fingerprint outputs) as an explicit add-on layer after shared payload generation.

### Description

- Add a typed `SynthPayloadOptions` dataclass and a `build_synth_payload(...)` helper in `src/gabion/cli_support/shared/payload_builder.py` that composes synth-specific fields on top of the common payload. 
- Refactor `src/gabion/cli_support/synth/synth_runtime.py` to construct `DataflowPayloadCommonOptions` and call the shared `build_dataflow_payload_common` path via the new helper instead of manually assembling the full dict. 
- Normalize exclude/filter/ASPF/path/list coercion by routing synth through the same parsing/encoding path used by the check flow (no bespoke CSV splitting in synth). 
- Add a command-level contract test `test_check_and_synth_encode_common_payload_fields_identically` in `tests/gabion/cli/cli_helpers_cases.py` that asserts shared fields (`paths`, `root`, `strictness`, and `aspf_*`) are encoded identically for equivalent inputs. 
- Refresh `out/test_evidence.json` to include the new evidence mapping and updated line anchors for the inserted test.

### Testing

- Ran the repo policy checks with `PYTHONPATH=src:. python scripts/policy/policy_check.py --workflows` which completed successfully. 
- Ran the ambiguity contract check with `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which completed successfully. 
- Ran the targeted pytest invocation `PYTHONPATH=src:. pytest -q -o addopts='' tests/gabion/cli/test_cli.py -k "synth_parses_optional_inputs or check_and_synth_encode_common_payload_fields_identically"` and both selected tests passed (`2 passed`). 
- Re-generated the evidence index via `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to reflect the new test mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a977e7d0e4832498571565449db307)