### PR TITLE
Add typing-surface policy, waiver mechanism, and scanner integration

### DIFF
--- a/baselines/typing_surface_policy_baseline.json
+++ b/baselines/typing_surface_policy_baseline.json
@@ -1,0 +1,5535 @@
+{
+  "version": 1,
+  "violations": [
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 82,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 103,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 153,
+      "column": 28,
+      "qualname": "_canonicalize_evidence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 153,
+      "column": 1,
+      "qualname": "_canonicalize_evidence",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 158,
+      "column": 1,
+      "qualname": "_canonicalize_evidence_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 158,
+      "column": 34,
+      "qualname": "_canonicalize_evidence_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 171,
+      "column": 13,
+      "qualname": "_canonicalize_evidence_value",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 31,
+      "column": 23,
+      "qualname": "_fingerprint_part",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 318,
+      "column": 45,
+      "qualname": "_intern_node",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 423,
+      "column": 9,
+      "qualname": "_suite_site_id",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 426,
+      "column": 9,
+      "qualname": "_suite_site_id",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 476,
+      "column": 9,
+      "qualname": "add_alt",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 519,
+      "column": 49,
+      "qualname": "add_node",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 350,
+      "column": 46,
+      "qualname": "add_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 357,
+      "column": 9,
+      "qualname": "add_site",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 454,
+      "column": 9,
+      "qualname": "add_spec_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 455,
+      "column": 9,
+      "qualname": "add_spec_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 459,
+      "column": 9,
+      "qualname": "add_spec_site",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 444,
+      "column": 9,
+      "qualname": "add_suite_contains",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 371,
+      "column": 9,
+      "qualname": "add_suite_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 373,
+      "column": 9,
+      "qualname": "add_suite_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 382,
+      "column": 9,
+      "qualname": "add_suite_site",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 69,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 88,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 112,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 121,
+      "column": 9,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 196,
+      "column": 5,
+      "qualname": "structural_key_atom",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 296,
+      "column": 1,
+      "qualname": "structural_key_json",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf.py",
+      "line": 523,
+      "column": 5,
+      "qualname": "to_json",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_core.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_core.py",
+      "line": 67,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_core.py",
+      "line": 81,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_core.py",
+      "line": 95,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_core.py",
+      "line": 115,
+      "column": 1,
+      "qualname": "parse_2cell_witness",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_decision_surface.py",
+      "line": 36,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_decision_surface.py",
+      "line": 65,
+      "column": 5,
+      "qualname": "classify_drift_by_homotopy",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_evidence.py",
+      "line": 10,
+      "column": 36,
+      "qualname": "normalize_alt_evidence_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_evidence.py",
+      "line": 10,
+      "column": 1,
+      "qualname": "normalize_alt_evidence_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_execution_fibration.py",
+      "line": 1056,
+      "column": 20,
+      "qualname": "_as_json_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_execution_fibration.py",
+      "line": 918,
+      "column": 20,
+      "qualname": "_optional_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_execution_fibration.py",
+      "line": 924,
+      "column": 20,
+      "qualname": "_path_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_execution_fibration.py",
+      "line": 1019,
+      "column": 32,
+      "qualname": "_semantic_surface_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_execution_fibration.py",
+      "line": 305,
+      "column": 5,
+      "qualname": "register_semantic_surface",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_morphisms.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_morphisms.py",
+      "line": 74,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_resume_state.py",
+      "line": 236,
+      "column": 20,
+      "qualname": "_as_json_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_resume_state.py",
+      "line": 24,
+      "column": 5,
+      "qualname": "append_delta_record",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/aspf/aspf_stream.py",
+      "line": 45,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_consolidation.py",
+      "line": 38,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_consolidation.py",
+      "line": 44,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_consolidation.py",
+      "line": 282,
+      "column": 24,
+      "qualname": "_targets_signature",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_shared.py",
+      "line": 16,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_shared.py",
+      "line": 41,
+      "column": 47,
+      "qualname": "render_cluster_heading",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_cluster_shared.py",
+      "line": 41,
+      "column": 64,
+      "qualname": "render_cluster_heading",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_clusters.py",
+      "line": 37,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/call_cluster/call_clusters.py",
+      "line": 48,
+      "column": 5,
+      "qualname": "build_call_clusters_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/ambiguity_state.py",
+      "line": 64,
+      "column": 5,
+      "qualname": "_normalize_witnesses",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/canonical.py",
+      "line": 15,
+      "column": 11,
+      "qualname": "canon",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/canonical.py",
+      "line": 54,
+      "column": 18,
+      "qualname": "digest_index",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/canonical.py",
+      "line": 44,
+      "column": 18,
+      "qualname": "encode_canon",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 53,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 217,
+      "column": 5,
+      "qualname": "build_deprecated_extraction_artifacts",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 218,
+      "column": 5,
+      "qualname": "build_deprecated_extraction_artifacts",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 90,
+      "column": 5,
+      "qualname": "deprecated",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 91,
+      "column": 5,
+      "qualname": "deprecated",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/deprecated_substrate.py",
+      "line": 103,
+      "column": 5,
+      "qualname": "deprecated",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 14,
+      "column": 1,
+      "qualname": "_identity_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 18,
+      "column": 21,
+      "qualname": "_noop_violation",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 87,
+      "column": 1,
+      "qualname": "require_canonical_multiset",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 103,
+      "column": 13,
+      "qualname": "require_canonical_multiset",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 59,
+      "column": 1,
+      "qualname": "require_no_dupes",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 77,
+      "column": 9,
+      "qualname": "require_no_dupes",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 136,
+      "column": 1,
+      "qualname": "require_no_python_hash",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 144,
+      "column": 5,
+      "qualname": "require_no_python_hash",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 22,
+      "column": 1,
+      "qualname": "require_sorted",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/determinism_invariants.py",
+      "line": 47,
+      "column": 9,
+      "qualname": "require_sorted",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_signature.py",
+      "line": 138,
+      "column": 21,
+      "qualname": "_is_json_scalar",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_signature.py",
+      "line": 131,
+      "column": 16,
+      "qualname": "_path_name",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_spec.py",
+      "line": 384,
+      "column": 5,
+      "qualname": "_normalize_decision_tiers",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_spec.py",
+      "line": 403,
+      "column": 21,
+      "qualname": "_sorted_strings",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_spec.py",
+      "line": 47,
+      "column": 5,
+      "qualname": "build_forest_spec",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/forest_spec.py",
+      "line": 366,
+      "column": 22,
+      "qualname": "forest_spec_hash",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/prime_identity_adapter.py",
+      "line": 38,
+      "column": 33,
+      "qualname": "load_seed_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/prime_identity_adapter.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "seed_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/structure_reuse_classes.py",
+      "line": 42,
+      "column": 5,
+      "qualname": "build_structure_class",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 1111,
+      "column": 5,
+      "qualname": "_apply_registry_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 89,
+      "column": 17,
+      "qualname": "_coerce_int",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 101,
+      "column": 29,
+      "qualname": "_dimension_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 56,
+      "column": 23,
+      "qualname": "_mapping_or_empty",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 63,
+      "column": 23,
+      "qualname": "_mapping_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 94,
+      "column": 16,
+      "qualname": "_maybe_int",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 773,
+      "column": 26,
+      "qualname": "_normalize_type_list",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 75,
+      "column": 20,
+      "qualname": "_str_int_pairs",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 315,
+      "column": 5,
+      "qualname": "bit_for",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 1294,
+      "column": 5,
+      "qualname": "build_fingerprint_registry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 1206,
+      "column": 5,
+      "qualname": "bundle_fingerprint_dimensional",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 601,
+      "column": 5,
+      "qualname": "fingerprint_stage_cache_identity",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 307,
+      "column": 5,
+      "qualname": "key_for_prime",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 377,
+      "column": 33,
+      "qualname": "load_seed_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/type_fingerprints.py",
+      "line": 304,
+      "column": 5,
+      "qualname": "prime_for",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/visitors.py",
+      "line": 327,
+      "column": 9,
+      "qualname": "_alias_from_call",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/visitors.py",
+      "line": 13,
+      "column": 13,
+      "qualname": "_is_ast",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/visitors.py",
+      "line": 17,
+      "column": 20,
+      "qualname": "_is_ast_one_of",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/wl_refinement.py",
+      "line": 59,
+      "column": 35,
+      "qualname": "emit_wl_refinement_facets._on_determinism_violation",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/core/wl_refinement.py",
+      "line": 67,
+      "column": 9,
+      "qualname": "emit_wl_refinement_facets._on_determinism_violation",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/ambiguity_projection_analyzer.py",
+      "line": 8,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/call_graph_analyzer.py",
+      "line": 8,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/call_graph_analyzer.py",
+      "line": 9,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_adapter_contract.py",
+      "line": 42,
+      "column": 32,
+      "qualname": "normalize_adapter_contract",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_adapter_contract.py",
+      "line": 22,
+      "column": 32,
+      "qualname": "parse_adapter_capabilities",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_ambiguity_helpers.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 149,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 161,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 169,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 170,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 171,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 178,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 193,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 199,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 200,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 201,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 207,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 208,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 209,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 210,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 216,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 321,
+      "column": 1,
+      "qualname": "_build_single_module_artifact",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 717,
+      "column": 5,
+      "qualname": "_canonical_stage_cache_identity",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 503,
+      "column": 5,
+      "qualname": "_collect_transitive_callers",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_analysis_index_owner.py",
+      "line": 475,
+      "column": 1,
+      "qualname": "_path_dependency_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 24,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 121,
+      "column": 5,
+      "qualname": "_effective_dataclass_registry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 108,
+      "column": 24,
+      "qualname": "_module_identifier",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 390,
+      "column": 5,
+      "qualname": "iter_dataclass_call_bundle_effects",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 391,
+      "column": 5,
+      "qualname": "iter_dataclass_call_bundle_effects",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_bundle_iteration.py",
+      "line": 392,
+      "column": 5,
+      "qualname": "iter_dataclass_call_bundle_effects",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 23,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 24,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 25,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 26,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 45,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 238,
+      "column": 1,
+      "qualname": "_resolve_class_hierarchy",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 228,
+      "column": 1,
+      "qualname": "_resolve_exact_qualified",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 102,
+      "column": 1,
+      "qualname": "_resolve_local_lambda",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 178,
+      "column": 1,
+      "qualname": "_resolve_symbol_table",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_callee_resolution.py",
+      "line": 132,
+      "column": 1,
+      "qualname": "_resolve_unqualified_local_or_global",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_contracts.py",
+      "line": 283,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_deadline_helpers.py",
+      "line": 65,
+      "column": 24,
+      "qualname": "_is_deadline_annot",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_deadline_helpers.py",
+      "line": 71,
+      "column": 35,
+      "qualname": "_is_deadline_param",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_deadline_runtime_owner.py",
+      "line": 327,
+      "column": 5,
+      "qualname": "_materialize_call_candidates",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_decision_surfaces.py",
+      "line": 146,
+      "column": 5,
+      "qualname": "compute_fingerprint_rewrite_plans",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_decision_surfaces.py",
+      "line": 198,
+      "column": 17,
+      "qualname": "compute_fingerprint_rewrite_plans",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_decision_surfaces.py",
+      "line": 590,
+      "column": 1,
+      "qualname": "extract_smell_sample",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_decision_surfaces.py",
+      "line": 517,
+      "column": 1,
+      "qualname": "parse_lint_location",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_event_algebra_adapter.py",
+      "line": 327,
+      "column": 27,
+      "qualname": "_positive_int_or_none",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 162,
+      "column": 1,
+      "qualname": "_builtin_exception_class",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 127,
+      "column": 5,
+      "qualname": "exception_handler_compatibility",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 128,
+      "column": 5,
+      "qualname": "exception_handler_compatibility",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 29,
+      "column": 5,
+      "qualname": "exception_param_names",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 50,
+      "column": 1,
+      "qualname": "exception_type_name",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "exception_type_name",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_exception_obligations.py",
+      "line": 104,
+      "column": 5,
+      "qualname": "handler_type_names",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_lint_helpers.py",
+      "line": 516,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_lint_helpers.py",
+      "line": 520,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_lint_helpers.py",
+      "line": 522,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_lint_helpers.py",
+      "line": 46,
+      "column": 5,
+      "qualname": "_analysis_index_by_qual_and_transitive_callers",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 60,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 758,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 759,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 760,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 79,
+      "column": 5,
+      "qualname": "_fallback_span",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 82,
+      "column": 9,
+      "qualname": "_fallback_span",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 83,
+      "column": 9,
+      "qualname": "_fallback_span",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 102,
+      "column": 9,
+      "qualname": "add_obligation",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 106,
+      "column": 9,
+      "qualname": "add_obligation",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 107,
+      "column": 9,
+      "qualname": "add_obligation",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 108,
+      "column": 9,
+      "qualname": "add_obligation",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_obligations.py",
+      "line": 169,
+      "column": 9,
+      "qualname": "add_obligation",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 84,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 108,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 150,
+      "column": 5,
+      "qualname": "_apply_forest_progress_delta",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 52,
+      "column": 25,
+      "qualname": "_capability_enabled",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 206,
+      "column": 5,
+      "qualname": "_run_forest_phase",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 245,
+      "column": 5,
+      "qualname": "_run_forest_phase",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 307,
+      "column": 29,
+      "qualname": "_run_forest_phase._on_forest_progress",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 578,
+      "column": 5,
+      "qualname": "_run_post_phase",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 913,
+      "column": 5,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 914,
+      "column": 5,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 915,
+      "column": 5,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 916,
+      "column": 5,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 917,
+      "column": 5,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 1079,
+      "column": 9,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 1080,
+      "column": 9,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 1083,
+      "column": 9,
+      "qualname": "analyze_paths",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 1224,
+      "column": 13,
+      "qualname": "analyze_paths._emit_phase_progress",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_pipeline.py",
+      "line": 922,
+      "column": 59,
+      "qualname": "analyze_paths._invalid_progress_callback",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 167,
+      "column": 1,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1054,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1064,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1065,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1066,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1067,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1504,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1666,
+      "column": 5,
+      "qualname": "_analyze_decision_surface_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1693,
+      "column": 5,
+      "qualname": "_analyze_decision_surfaces_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1719,
+      "column": 5,
+      "qualname": "_analyze_value_encoded_decisions_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 252,
+      "column": 1,
+      "qualname": "_extract_invariant_from_expr",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1261,
+      "column": 9,
+      "qualname": "_param_annotations_by_path",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 452,
+      "column": 5,
+      "qualname": "_refine_exception_name_from_annotations",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1574,
+      "column": 26,
+      "qualname": "_suite_site_label",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_post_phase_analyses.py",
+      "line": 1574,
+      "column": 42,
+      "qualname": "_suite_site_label",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 119,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 120,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 357,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 358,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 359,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 360,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_projection_materialization.py",
+      "line": 163,
+      "column": 5,
+      "qualname": "_materialize_projection_spec_rows",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_raw_runtime.py",
+      "line": 322,
+      "column": 1,
+      "qualname": "_normalize_transparent_decorators",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_raw_runtime.py",
+      "line": 323,
+      "column": 5,
+      "qualname": "_normalize_transparent_decorators",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_raw_runtime.py",
+      "line": 457,
+      "column": 9,
+      "qualname": "_run_impl",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_raw_runtime.py",
+      "line": 66,
+      "column": 32,
+      "qualname": "normalize_adapter_contract",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_raw_runtime.py",
+      "line": 46,
+      "column": 32,
+      "qualname": "parse_adapter_capabilities",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_resume_paths.py",
+      "line": 8,
+      "column": 41,
+      "qualname": "normalize_snapshot_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_runtime_reporting_owner.py",
+      "line": 33,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/dataflow_runtime_reporting_owner.py",
+      "line": 63,
+      "column": 5,
+      "qualname": "_report_section_spec",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/deadline_analyzer.py",
+      "line": 9,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/decision_surface_analyzer.py",
+      "line": 16,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/decision_surface_analyzer.py",
+      "line": 18,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/exception_obligation_analyzer.py",
+      "line": 8,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/scan_kernel.py",
+      "line": 13,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/scan_kernel.py",
+      "line": 17,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/scan_kernel.py",
+      "line": 18,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/engine/scan_kernel.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_baseline_gates.py",
+      "line": 10,
+      "column": 28,
+      "qualname": "_resolve_baseline_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_baseline_gates.py",
+      "line": 62,
+      "column": 27,
+      "qualname": "resolve_baseline_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_graph_rendering.py",
+      "line": 349,
+      "column": 42,
+      "qualname": "_normalize_snapshot_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_output_emitters.py",
+      "line": 70,
+      "column": 39,
+      "qualname": "write_json_or_stdout",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 340,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 341,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 342,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 343,
+      "column": 5,
+      "qualname": "_format_span_fields",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 147,
+      "column": 13,
+      "qualname": "_materialize_projection_spec_rows",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 365,
+      "column": 12,
+      "qualname": "_span4",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py",
+      "line": 597,
+      "column": 30,
+      "qualname": "_str_tuple_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 37,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 39,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 40,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 41,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 42,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 43,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 44,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 62,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 67,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 68,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 282,
+      "column": 1,
+      "qualname": "emit_optional_refactor_outputs",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 255,
+      "column": 1,
+      "qualname": "emit_optional_synthesis_outputs",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 330,
+      "column": 1,
+      "qualname": "emit_report_output",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 333,
+      "column": 5,
+      "qualname": "emit_report_output",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 334,
+      "column": 5,
+      "qualname": "emit_report_output",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 339,
+      "column": 5,
+      "qualname": "emit_report_output",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_run_outputs.py",
+      "line": 238,
+      "column": 1,
+      "qualname": "merge_overlap_threshold",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_snapshot_io.py",
+      "line": 93,
+      "column": 42,
+      "qualname": "_normalize_snapshot_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_structure_reuse.py",
+      "line": 194,
+      "column": 9,
+      "qualname": "compute_structure_reuse._reuse_site_from_location",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/dataflow/io/dataflow_synthesis.py",
+      "line": 138,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 216,
+      "column": 1,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 181,
+      "column": 9,
+      "qualname": "_intern_inputs",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 244,
+      "column": 1,
+      "qualname": "_node_id_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 55,
+      "column": 9,
+      "qualname": "derive",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 57,
+      "column": 9,
+      "qualname": "derive",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 58,
+      "column": 9,
+      "qualname": "derive",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 60,
+      "column": 9,
+      "qualname": "derive",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 123,
+      "column": 9,
+      "qualname": "invalidate",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 113,
+      "column": 5,
+      "qualname": "materialize",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 115,
+      "column": 9,
+      "qualname": "materialize",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 231,
+      "column": 38,
+      "qualname": "reset_global_derivation_cache",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_cache.py",
+      "line": 155,
+      "column": 5,
+      "qualname": "to_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_graph.py",
+      "line": 250,
+      "column": 1,
+      "qualname": "_node_id_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_graph.py",
+      "line": 65,
+      "column": 9,
+      "qualname": "intern_derived",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_graph.py",
+      "line": 66,
+      "column": 9,
+      "qualname": "intern_derived",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_graph.py",
+      "line": 28,
+      "column": 9,
+      "qualname": "intern_input",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_graph.py",
+      "line": 177,
+      "column": 5,
+      "qualname": "to_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_persistence.py",
+      "line": 122,
+      "column": 1,
+      "qualname": "_node_id_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_persistence.py",
+      "line": 123,
+      "column": 5,
+      "qualname": "_node_id_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_persistence.py",
+      "line": 142,
+      "column": 1,
+      "qualname": "_structural_json_to_atom",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_persistence.py",
+      "line": 142,
+      "column": 30,
+      "qualname": "_structural_json_to_atom",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/derivation/derivation_persistence.py",
+      "line": 35,
+      "column": 1,
+      "qualname": "read_derivation_checkpoint",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/baseline_io.py",
+      "line": 14,
+      "column": 15,
+      "qualname": "load_json",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/baseline_io.py",
+      "line": 32,
+      "column": 5,
+      "qualname": "parse_version",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/baseline_io.py",
+      "line": 22,
+      "column": 16,
+      "qualname": "write_json",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/delta_tools.py",
+      "line": 28,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/delta_tools.py",
+      "line": 29,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/delta_tools.py",
+      "line": 13,
+      "column": 16,
+      "qualname": "coerce_int",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/delta_tools.py",
+      "line": 20,
+      "column": 18,
+      "qualname": "format_delta",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/delta_tools.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "format_transition",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/event_algebra.py",
+      "line": 74,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_shadow_runtime.py",
+      "line": 165,
+      "column": 5,
+      "qualname": "sidecar_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_shadow_runtime.py",
+      "line": 167,
+      "column": 9,
+      "qualname": "sidecar_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_shadow_session.py",
+      "line": 48,
+      "column": 5,
+      "qualname": "identity_seed_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 53,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 149,
+      "column": 46,
+      "qualname": "intern_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 74,
+      "column": 33,
+      "qualname": "load_seed_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 233,
+      "column": 33,
+      "qualname": "load_seed_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 72,
+      "column": 5,
+      "qualname": "seed_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/identity_space.py",
+      "line": 229,
+      "column": 5,
+      "qualname": "seed_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/marker_protocol.py",
+      "line": 46,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 140,
+      "column": 33,
+      "qualname": "int_str_pairs_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 129,
+      "column": 24,
+      "qualname": "int_tuple4_or_none",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 207,
+      "column": 5,
+      "qualname": "load_allowed_paths_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 72,
+      "column": 22,
+      "qualname": "mapping_or_empty",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 16,
+      "column": 21,
+      "qualname": "mapping_or_none",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 25,
+      "column": 5,
+      "qualname": "mapping_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 56,
+      "column": 1,
+      "qualname": "mapping_sections",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 43,
+      "column": 1,
+      "qualname": "payload_with_format",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 44,
+      "column": 5,
+      "qualname": "payload_with_format",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 30,
+      "column": 1,
+      "qualname": "payload_with_phase",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 31,
+      "column": 5,
+      "qualname": "payload_with_phase",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 79,
+      "column": 22,
+      "qualname": "sequence_or_none",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 91,
+      "column": 28,
+      "qualname": "str_list_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 114,
+      "column": 26,
+      "qualname": "str_map_from_mapping",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 163,
+      "column": 32,
+      "qualname": "str_pair_set_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 110,
+      "column": 27,
+      "qualname": "str_set_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/resume_codec.py",
+      "line": 106,
+      "column": 29,
+      "qualname": "str_tuple_from_sequence",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 49,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 50,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 52,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 187,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 188,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 293,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 294,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 301,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 746,
+      "column": 40,
+      "qualname": "_decode_deadline_profile_edge_rows",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 764,
+      "column": 38,
+      "qualname": "_decode_deadline_profile_io_rows",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 685,
+      "column": 38,
+      "qualname": "_decode_deadline_profile_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 730,
+      "column": 40,
+      "qualname": "_decode_deadline_profile_site_rows",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 1002,
+      "column": 1,
+      "qualname": "_decode_site_part_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 1002,
+      "column": 31,
+      "qualname": "_decode_site_part_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 1144,
+      "column": 1,
+      "qualname": "_freeze_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 1144,
+      "column": 19,
+      "qualname": "_freeze_value",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 996,
+      "column": 1,
+      "qualname": "_site_part_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 996,
+      "column": 29,
+      "qualname": "_site_part_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 1029,
+      "column": 27,
+      "qualname": "_site_part_to_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 202,
+      "column": 30,
+      "qualname": "from_ingress",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/foundation/timeout_context.py",
+      "line": 202,
+      "column": 45,
+      "qualname": "from_ingress",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_ambiguities.py",
+      "line": 29,
+      "column": 5,
+      "qualname": "emit_call_ambiguities",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_ambiguity_summary.py",
+      "line": 15,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_edges.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "collect_call_edges",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_edges.py",
+      "line": 22,
+      "column": 5,
+      "qualname": "collect_call_edges",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_nodes_by_path.py",
+      "line": 23,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/call_nodes_by_path.py",
+      "line": 25,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/callee_outcome_runtime.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "resolve_callee",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/callee_outcome_runtime.py",
+      "line": 36,
+      "column": 5,
+      "qualname": "resolve_callee",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/callee_outcome_runtime.py",
+      "line": 78,
+      "column": 5,
+      "qualname": "resolve_callee_outcome",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/callee_outcome_runtime.py",
+      "line": 80,
+      "column": 5,
+      "qualname": "resolve_callee_outcome",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/calls/callee_outcome_runtime.py",
+      "line": 98,
+      "column": 9,
+      "qualname": "resolve_callee_outcome._sink",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 13,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 17,
+      "column": 9,
+      "qualname": "__call__",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 18,
+      "column": 9,
+      "qualname": "__call__",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 22,
+      "column": 1,
+      "qualname": "fallback_deadline_arg_info",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 23,
+      "column": 5,
+      "qualname": "fallback_deadline_arg_info",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 24,
+      "column": 5,
+      "qualname": "fallback_deadline_arg_info",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_fallback.py",
+      "line": 39,
+      "column": 5,
+      "qualname": "fallback_deadline_arg_info",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_function_facts.py",
+      "line": 18,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_function_facts.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_function_facts.py",
+      "line": 25,
+      "column": 1,
+      "qualname": "collect_deadline_function_facts",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_function_facts.py",
+      "line": 65,
+      "column": 9,
+      "qualname": "collect_deadline_function_facts",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_function_facts.py",
+      "line": 72,
+      "column": 5,
+      "qualname": "collect_deadline_function_facts",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_obligation_summary.py",
+      "line": 14,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_runtime.py",
+      "line": 576,
+      "column": 5,
+      "qualname": "deadline_loop_forwarded_params",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/deadline/deadline_runtime.py",
+      "line": 286,
+      "column": 5,
+      "qualname": "materialize_call_candidates",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_builder.py",
+      "line": 32,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_builder.py",
+      "line": 33,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_builder.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_builder.py",
+      "line": 42,
+      "column": 1,
+      "qualname": "build_analysis_index",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_resume_payload.py",
+      "line": 135,
+      "column": 5,
+      "qualname": "load_analysis_index_resume_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_resume_payload.py",
+      "line": 137,
+      "column": 5,
+      "qualname": "load_analysis_index_resume_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/index/analysis_index_stage_cache.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/decision_surface_runtime.py",
+      "line": 23,
+      "column": 5,
+      "qualname": "analyze_decision_surface_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/decision_surface_runtime.py",
+      "line": 25,
+      "column": 5,
+      "qualname": "analyze_decision_surface_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/decision_surface_runtime.py",
+      "line": 28,
+      "column": 5,
+      "qualname": "analyze_decision_surface_indexed",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/handledness_decision.py",
+      "line": 13,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/handledness_decision.py",
+      "line": 14,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/handledness_decision.py",
+      "line": 20,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/handledness_decision.py",
+      "line": 24,
+      "column": 5,
+      "qualname": "decide_handledness",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/never_invariants.py",
+      "line": 169,
+      "column": 13,
+      "qualname": "collect_never_invariants",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/obligation_decision.py",
+      "line": 17,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/obligation_decision.py",
+      "line": 18,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/obligation_decision.py",
+      "line": 58,
+      "column": 9,
+      "qualname": "_decision_from_handledness",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/reachability.py",
+      "line": 17,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/obligations/reachability.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/class_index_accumulator.py",
+      "line": 22,
+      "column": 5,
+      "qualname": "accumulate_class_index_for_tree",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/config_fields.py",
+      "line": 15,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/config_fields.py",
+      "line": 25,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/config_fields.py",
+      "line": 27,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/edge_param_events.py",
+      "line": 13,
+      "column": 5,
+      "qualname": "iter_resolved_edge_param_events",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/marker_metadata.py",
+      "line": 72,
+      "column": 1,
+      "qualname": "never_reason",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/bundle_forest_builder.py",
+      "line": 31,
+      "column": 5,
+      "qualname": "populate_bundle_forest",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/dataclass_registry.py",
+      "line": 17,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/dataclass_registry.py",
+      "line": 19,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/statement_materialization.py",
+      "line": 64,
+      "column": 5,
+      "qualname": "materialize_statement_suite_contains._emit_body_suite",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/structured_suite_sites.py",
+      "line": 16,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/materialization/structured_suite_sites.py",
+      "line": 77,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/report_sections.py",
+      "line": 35,
+      "column": 5,
+      "qualname": "extract_report_sections",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/report_sections.py",
+      "line": 15,
+      "column": 1,
+      "qualname": "parse_report_section_marker",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 83,
+      "column": 1,
+      "qualname": "normalize_transparent_decorators",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 84,
+      "column": 5,
+      "qualname": "normalize_transparent_decorators",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 52,
+      "column": 1,
+      "qualname": "resolve_baseline_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 52,
+      "column": 27,
+      "qualname": "resolve_baseline_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 61,
+      "column": 1,
+      "qualname": "resolve_synth_registry_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/scanners/run_entry.py",
+      "line": 61,
+      "column": 33,
+      "qualname": "resolve_synth_registry_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_internal_analysis.py",
+      "line": 33,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 48,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 49,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 50,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 52,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 53,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/file_scan_resume_state.py",
+      "line": 54,
+      "column": 5,
+      "qualname": "serialize_file_scan_resume_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/function_index_accumulator.py",
+      "line": 40,
+      "column": 5,
+      "qualname": "accumulate_function_index_for_tree",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/indexed_scan/state/function_info_resume.py",
+      "line": 104,
+      "column": 1,
+      "qualname": "deserialize_function_info_for_resume",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 503,
+      "column": 5,
+      "qualname": "detect_execution_pattern_matches",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 547,
+      "column": 5,
+      "qualname": "execution_pattern_instances",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 978,
+      "column": 5,
+      "qualname": "execution_pattern_suggestions",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 807,
+      "column": 5,
+      "qualname": "pattern_schema_matches",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 839,
+      "column": 5,
+      "qualname": "pattern_schema_suggestions",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/pattern_schema_projection.py",
+      "line": 998,
+      "column": 5,
+      "qualname": "pattern_schema_surface_payloads",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/projection_exec.py",
+      "line": 58,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/projection_exec.py",
+      "line": 154,
+      "column": 1,
+      "qualname": "_hashable",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/projection_spec.py",
+      "line": 101,
+      "column": 28,
+      "qualname": "_op_payload_from_entry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/projection/projection_spec.py",
+      "line": 86,
+      "column": 5,
+      "qualname": "_op_payloads_from_pipeline",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence.py",
+      "line": 79,
+      "column": 5,
+      "qualname": "from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence.py",
+      "line": 79,
+      "column": 27,
+      "qualname": "from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence.py",
+      "line": 13,
+      "column": 26,
+      "qualname": "normalize_bundle_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence.py",
+      "line": 39,
+      "column": 27,
+      "qualname": "normalize_string_list",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 529,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 530,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 531,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 30,
+      "column": 23,
+      "qualname": "_mapping_or_empty",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 87,
+      "column": 21,
+      "qualname": "_normalize_site",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 87,
+      "column": 1,
+      "qualname": "_normalize_site",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 100,
+      "column": 5,
+      "qualname": "_normalize_site",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 60,
+      "column": 21,
+      "qualname": "_normalize_span",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 44,
+      "column": 1,
+      "qualname": "_normalize_target",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 44,
+      "column": 23,
+      "qualname": "_normalize_target",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 37,
+      "column": 24,
+      "qualname": "_sequence_or_empty",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 533,
+      "column": 5,
+      "qualname": "as_dict",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 211,
+      "column": 1,
+      "qualname": "make_ambiguity_set_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 219,
+      "column": 5,
+      "qualname": "make_ambiguity_set_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 200,
+      "column": 1,
+      "qualname": "make_call_cluster_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 183,
+      "column": 1,
+      "qualname": "make_call_footprint_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 130,
+      "column": 1,
+      "qualname": "make_decision_surface_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 172,
+      "column": 1,
+      "qualname": "make_function_site_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 149,
+      "column": 1,
+      "qualname": "make_never_sink_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 154,
+      "column": 5,
+      "qualname": "make_never_sink_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 266,
+      "column": 1,
+      "qualname": "make_opaque_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 123,
+      "column": 1,
+      "qualname": "make_paramset_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 233,
+      "column": 1,
+      "qualname": "make_partition_witness_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 238,
+      "column": 5,
+      "qualname": "make_partition_witness_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 239,
+      "column": 5,
+      "qualname": "make_partition_witness_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 243,
+      "column": 5,
+      "qualname": "make_partition_witness_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 270,
+      "column": 1,
+      "qualname": "normalize_key",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/evidence_keys.py",
+      "line": 443,
+      "column": 1,
+      "qualname": "parse_display",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 42,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 376,
+      "column": 1,
+      "qualname": "_build_graph_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 953,
+      "column": 25,
+      "qualname": "_coerce_target_list",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 923,
+      "column": 5,
+      "qualname": "_parse_frontmatter",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 63,
+      "column": 50,
+      "qualname": "add_node",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 214,
+      "column": 5,
+      "qualname": "emit_impact_index",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/impact_index.py",
+      "line": 72,
+      "column": 5,
+      "qualname": "to_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/report_doc.py",
+      "line": 42,
+      "column": 25,
+      "qualname": "codeblock",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/schema_audit.py",
+      "line": 112,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/schema_audit.py",
+      "line": 42,
+      "column": 1,
+      "qualname": "_name",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/schema_audit.py",
+      "line": 17,
+      "column": 33,
+      "qualname": "_normalize_path",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/schema_audit.py",
+      "line": 93,
+      "column": 1,
+      "qualname": "_suggest_type_name",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/schema_audit.py",
+      "line": 209,
+      "column": 5,
+      "qualname": "find_anonymous_schema_surfaces",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/semantic_coverage_map.py",
+      "line": 41,
+      "column": 5,
+      "qualname": "build_semantic_coverage_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/semantics/semantic_coverage_map.py",
+      "line": 42,
+      "column": 5,
+      "qualname": "build_semantic_coverage_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence.py",
+      "line": 79,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence.py",
+      "line": 87,
+      "column": 1,
+      "qualname": "build_test_evidence_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence.py",
+      "line": 187,
+      "column": 5,
+      "qualname": "write_test_evidence",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence_suggestions.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence_suggestions.py",
+      "line": 1182,
+      "column": 30,
+      "qualname": "_normalize_evidence_list",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_evidence_suggestions.py",
+      "line": 267,
+      "column": 1,
+      "qualname": "render_json_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 42,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 590,
+      "column": 30,
+      "qualname": "_normalize_evidence_refs",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 456,
+      "column": 5,
+      "qualname": "_pareto_sort_key",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 273,
+      "column": 9,
+      "qualname": "classify_candidates",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 29,
+      "column": 27,
+      "qualname": "from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence.py",
+      "line": 545,
+      "column": 1,
+      "qualname": "render_json_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence_delta.py",
+      "line": 38,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/surfaces/test_obsolescence_delta.py",
+      "line": 481,
+      "column": 27,
+      "qualname": "_parse_evidence_index",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_lifecycle.py",
+      "line": 103,
+      "column": 5,
+      "qualname": "build_demotion_incidents_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_lifecycle.py",
+      "line": 65,
+      "column": 5,
+      "qualname": "build_promotion_decision_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_lifecycle.py",
+      "line": 38,
+      "column": 5,
+      "qualname": "build_readiness_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 140,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 674,
+      "column": 5,
+      "qualname": "_boundary_diagnostic_codes",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 413,
+      "column": 31,
+      "qualname": "_boundary_entries_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 662,
+      "column": 1,
+      "qualname": "_boundary_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 662,
+      "column": 28,
+      "qualname": "_boundary_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 692,
+      "column": 5,
+      "qualname": "_expiry_diagnostic_codes",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 436,
+      "column": 22,
+      "qualname": "_mapping_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 443,
+      "column": 22,
+      "qualname": "_normalize_links",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 728,
+      "column": 23,
+      "qualname": "_normalized_today",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 430,
+      "column": 23,
+      "qualname": "_sequence_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 556,
+      "column": 5,
+      "qualname": "_status_for_entry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 557,
+      "column": 5,
+      "qualname": "_status_for_entry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 559,
+      "column": 5,
+      "qualname": "_status_for_entry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 654,
+      "column": 1,
+      "qualname": "_witness_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 654,
+      "column": 27,
+      "qualname": "_witness_from_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 93,
+      "column": 29,
+      "qualname": "is_expired",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 149,
+      "column": 26,
+      "qualname": "normalize_taint_kind",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 144,
+      "column": 29,
+      "qualname": "normalize_taint_profile",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 176,
+      "column": 35,
+      "qualname": "parse_taint_boundary_registry",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 220,
+      "column": 5,
+      "qualname": "project_taint_ledgers",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 221,
+      "column": 5,
+      "qualname": "project_taint_ledgers",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_projection.py",
+      "line": 154,
+      "column": 5,
+      "qualname": "resolve_taint_kind",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_state.py",
+      "line": 82,
+      "column": 22,
+      "qualname": "_normalized_rows",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_state.py",
+      "line": 34,
+      "column": 5,
+      "qualname": "build_state_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/analysis/taint/taint_state.py",
+      "line": 35,
+      "column": 5,
+      "qualname": "build_state_payload",
+      "kind": "bare_object_annotation",
+      "scope": "semantic_core",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in semantic_core; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/analysis_stage.py",
+      "line": 8,
+      "column": 5,
+      "qualname": "run_analysis_stage",
+      "kind": "bare_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/analysis_stage.py",
+      "line": 9,
+      "column": 5,
+      "qualname": "run_analysis_stage",
+      "kind": "bare_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/ingress_stage.py",
+      "line": 28,
+      "column": 61,
+      "qualname": "default_mode_selector",
+      "kind": "bare_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/ingress_stage.py",
+      "line": 16,
+      "column": 5,
+      "qualname": "run_ingress_stage",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 14,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 15,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 21,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 29,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 35,
+      "column": 5,
+      "qualname": "<module>",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 39,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 39,
+      "column": 27,
+      "qualname": "__call__",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 43,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 47,
+      "column": 58,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 51,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 51,
+      "column": 27,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 51,
+      "column": 41,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 55,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 55,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 55,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 59,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 59,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 63,
+      "column": 47,
+      "qualname": "__call__",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/stage_contracts.py",
+      "line": 63,
+      "column": 5,
+      "qualname": "__call__",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/timeout_stage.py",
+      "line": 24,
+      "column": 1,
+      "qualname": "render_timeout_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/server_core/timeout_stage.py",
+      "line": 18,
+      "column": 5,
+      "qualname": "run_timeout_stage",
+      "kind": "bare_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "object",
+      "message": "'object' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 314,
+      "column": 42,
+      "qualname": "_append_markdown_summary",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 520,
+      "column": 5,
+      "qualname": "_install_signal_debug_dump_handler",
+      "kind": "any_annotation",
+      "scope": "stage_contracts",
+      "annotation": "Any",
+      "message": "'Any' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 101,
+      "column": 1,
+      "qualname": "_load_json_object",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 188,
+      "column": 44,
+      "qualname": "_obligation_rows_from_timeout_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 237,
+      "column": 1,
+      "qualname": "_obligation_trace_payload",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 289,
+      "column": 37,
+      "qualname": "_obligation_trace_summary_lines",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 118,
+      "column": 1,
+      "qualname": "_timeout_payload_from_aspf_state",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    },
+    {
+      "path": "src/gabion/tooling/runtime/run_dataflow_stage.py",
+      "line": 282,
+      "column": 1,
+      "qualname": "_write_obligation_trace",
+      "kind": "dict_str_object_annotation",
+      "scope": "stage_contracts",
+      "annotation": "dict[str, object]",
+      "message": "'dict[str, object]' annotation is forbidden in stage_contracts; use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+    }
+  ]
+}

--- a/baselines/typing_surface_policy_waivers.json
+++ b/baselines/typing_surface_policy_waivers.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "waivers": []
+}

--- a/docs/typing_surface_policy.md
+++ b/docs/typing_surface_policy.md
@@ -1,0 +1,73 @@
+---
+doc_revision: 1
+doc_id: typing_surface_policy
+doc_role: normative
+doc_scope:
+  - repo
+  - typing
+  - policy
+doc_authority: normative
+doc_requires:
+  - POLICY_SEED.md#policy_seed
+  - glossary.md#contract
+doc_change_protocol: "POLICY_SEED.md#change_protocol"
+doc_owner: maintainer
+---
+
+<a id="typing_surface_policy"></a>
+# Typing Surface Policy (Normative)
+
+## 1) Allowed coarse typing surfaces
+
+`Any`, bare `object`, and `dict[str, object]` are allowed only at **explicit boundary ingress/egress** where the source shape is external and immediately normalized.
+
+Allowed boundary examples:
+- parsing raw external payloads before DTO/model validation,
+- temporary adapters that convert legacy payloads into typed carriers,
+- tooling-only probes that do not participate in semantic-core decisions.
+
+These boundary uses must be followed by deterministic normalization into one of:
+- DTOs,
+- `Protocol` contracts,
+- dataclass carriers,
+- `TypedDict` or Pydantic models.
+
+## 2) Forbidden surfaces
+
+The following are forbidden policy surfaces:
+- **semantic core** (`src/gabion/analysis/**`),
+- **stage contracts** (modules under `*/stages/*`, `*stage_contract*`, or `*_stage.py`),
+- **reducers** (modules under `*/reducers/*` or `*_reducer.py`).
+
+In those surfaces, do not introduce `Any`, bare `object`, or `dict[str, object]` annotations.
+
+## 3) Required alternatives
+
+When a coarse annotation would otherwise be used, replace it with:
+- a typed DTO (including Pydantic model DTOs),
+- a `Protocol` decision/bundle contract,
+- a dataclass carrier with explicit fields,
+- a `TypedDict`/Pydantic model for dictionary-shaped payloads.
+
+## 4) Waiver mechanism (required metadata)
+
+Waivers are declared in `baselines/typing_surface_policy_waivers.json`.
+
+Each waiver entry must include:
+- `path`
+- `qualname`
+- `line`
+- `kind`
+- `rationale`
+- `scope`
+- `expiry`
+- `owner`
+
+Policy scanner behavior:
+- waivers with complete metadata suppress matching findings,
+- waivers with missing/invalid metadata produce `invalid_waiver` findings,
+- ratchet policy is baseline-first: current exceptions are seeded in baseline, then reduced in future correction units.
+
+## 5) Enforcement
+
+`src/gabion/tooling/runtime/policy_scanner_suite.py` publishes machine-readable `typing_surface` findings with stable keys for baseline/waiver ratcheting.

--- a/src/gabion/tooling/policy_rules/__init__.py
+++ b/src/gabion/tooling/policy_rules/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from . import branchless_rule, defensive_fallback_rule, no_monkeypatch_rule
+from . import branchless_rule, defensive_fallback_rule, no_monkeypatch_rule, typing_surface_rule
 
 __all__ = [
     "branchless_rule",
     "defensive_fallback_rule",
     "no_monkeypatch_rule",
+    "typing_surface_rule",
 ]

--- a/src/gabion/tooling/policy_rules/typing_surface_rule.py
+++ b/src/gabion/tooling/policy_rules/typing_surface_rule.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+BASELINE_VERSION = 1
+WAIVER_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line: int
+    column: int
+    qualname: str
+    kind: str
+    message: str
+    scope: str
+    annotation: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.path}:{self.qualname}:{self.line}:{self.kind}"
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line}:{self.column}: [{self.qualname}] {self.message}"
+
+
+@dataclass(frozen=True)
+class InvalidWaiver:
+    index: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class WaiverLoadResult:
+    allowed_keys: set[str]
+    invalid_waivers: list[InvalidWaiver]
+
+
+class _TypingSurfaceVisitor(ast.NodeVisitor):
+    def __init__(self, *, rel_path: str, source: str) -> None:
+        self._rel_path = rel_path
+        self._source = source
+        self._scope = _forbidden_scope(rel_path)
+        self.violations: list[Violation] = []
+        self._qualname_stack: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._check_annotation(node.annotation, node=node)
+        self.generic_visit(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._qualname_stack.append(node.name)
+        self._check_annotation(node.returns, node=node)
+        for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
+            self._check_annotation(arg.annotation, node=arg)
+        self._check_annotation(node.args.vararg.annotation if node.args.vararg is not None else None, node=node)
+        self._check_annotation(node.args.kwarg.annotation if node.args.kwarg is not None else None, node=node)
+        self.generic_visit(node)
+        self._qualname_stack.pop()
+
+    def _check_annotation(self, annotation: ast.AST | None, *, node: ast.AST) -> None:
+        if annotation is None or self._scope is None:
+            return
+        kind = _annotation_kind(annotation)
+        if kind is None:
+            return
+        line = int(getattr(node, "lineno", 1) or 1)
+        column = int(getattr(node, "col_offset", 0) or 0) + 1
+        qualname = ".".join(self._qualname_stack) if self._qualname_stack else "<module>"
+        annotation_text = ast.get_source_segment(self._source, annotation) or "<unknown>"
+        self.violations.append(
+            Violation(
+                path=self._rel_path,
+                line=line,
+                column=column,
+                qualname=qualname,
+                kind=kind,
+                scope=self._scope,
+                annotation=annotation_text,
+                message=(
+                    f"{annotation_text!r} annotation is forbidden in {self._scope}; "
+                    "use DTO/Protocol/dataclass carrier or TypedDict/Pydantic model"
+                ),
+            )
+        )
+
+
+def _forbidden_scope(rel_path: str) -> str | None:
+    if rel_path.startswith("src/gabion/analysis/"):
+        return "semantic_core"
+    if "/stages/" in rel_path or "stage_contract" in rel_path or rel_path.endswith("_stage.py"):
+        return "stage_contracts"
+    if "/reducers/" in rel_path or rel_path.endswith("_reducer.py"):
+        return "reducers"
+    return None
+
+
+def _annotation_kind(annotation: ast.AST) -> str | None:
+    if _is_any(annotation):
+        return "any_annotation"
+    if _is_bare_object(annotation):
+        return "bare_object_annotation"
+    if _is_dict_str_object(annotation):
+        return "dict_str_object_annotation"
+    return None
+
+
+def _is_any(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "Any") or (
+        isinstance(node, ast.Attribute) and node.attr == "Any"
+    )
+
+
+def _is_bare_object(node: ast.AST) -> bool:
+    return isinstance(node, ast.Name) and node.id == "object"
+
+
+def _is_dict_str_object(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Subscript):
+        return False
+    base_name = _dotted_name(node.value)
+    if base_name not in {"dict", "typing.Dict", "Dict"}:
+        return False
+    slice_node = node.slice
+    if isinstance(slice_node, ast.Tuple) and len(slice_node.elts) == 2:
+        key_node, value_node = slice_node.elts
+    else:
+        return False
+    return _is_str_node(key_node) and _is_bare_object(value_node)
+
+
+def _is_str_node(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "str") or (
+        isinstance(node, ast.Constant) and node.value == "str"
+    )
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_name(node.value)
+        if parent is None:
+            return None
+        return f"{parent}.{node.attr}"
+    return None
+
+
+def _load_baseline(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return set()
+    raw_items = payload.get("violations")
+    if not isinstance(raw_items, list):
+        return set()
+    keys: set[str] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        path_value = str(item.get("path", "") or "")
+        qualname = str(item.get("qualname", "") or "")
+        kind = str(item.get("kind", "") or "")
+        line = item.get("line")
+        if not path_value or not qualname or not kind or not isinstance(line, int):
+            continue
+        keys.add(f"{path_value}:{qualname}:{line}:{kind}")
+    return keys
+
+
+def load_waivers(path: Path) -> WaiverLoadResult:
+    if not path.exists():
+        return WaiverLoadResult(allowed_keys=set(), invalid_waivers=[])
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return WaiverLoadResult(allowed_keys=set(), invalid_waivers=[InvalidWaiver(index=0, reason="waiver_file_not_object")])
+    raw_waivers = payload.get("waivers")
+    if not isinstance(raw_waivers, list):
+        return WaiverLoadResult(allowed_keys=set(), invalid_waivers=[InvalidWaiver(index=0, reason="waivers_not_list")])
+
+    keys: set[str] = set()
+    invalid: list[InvalidWaiver] = []
+    required = ("path", "qualname", "line", "kind", "rationale", "scope", "expiry", "owner")
+    for index, raw in enumerate(raw_waivers, start=1):
+        if not isinstance(raw, dict):
+            invalid.append(InvalidWaiver(index=index, reason="waiver_not_object"))
+            continue
+        missing = [field for field in required if raw.get(field) in (None, "")]
+        if missing:
+            invalid.append(InvalidWaiver(index=index, reason=f"missing_fields:{','.join(missing)}"))
+            continue
+        line = raw.get("line")
+        if not isinstance(line, int):
+            invalid.append(InvalidWaiver(index=index, reason="line_not_int"))
+            continue
+        key = f"{raw['path']}:{raw['qualname']}:{line}:{raw['kind']}"
+        keys.add(key)
+    return WaiverLoadResult(allowed_keys=keys, invalid_waivers=invalid)
+
+
+def collect_violations(*, rel_path: str, source: str, tree: ast.AST) -> list[Violation]:
+    visitor = _TypingSurfaceVisitor(rel_path=rel_path, source=source)
+    visitor.visit(tree)
+    return visitor.violations

--- a/src/gabion/tooling/runtime/policy_scanner_suite.py
+++ b/src/gabion/tooling/runtime/policy_scanner_suite.py
@@ -8,12 +8,14 @@ import json
 from pathlib import Path
 from typing import Iterable
 import ast
-from gabion.tooling.policy_rules import branchless_rule, defensive_fallback_rule, no_monkeypatch_rule
+from gabion.tooling.policy_rules import branchless_rule, defensive_fallback_rule, no_monkeypatch_rule, typing_surface_rule
 
 _POLICY_ARTIFACT = Path("artifacts/out/policy_suite_results.json")
 _FORMAT_VERSION = 1
 _BRANCHLESS_BASELINE = Path("baselines/branchless_policy_baseline.json")
 _DEFENSIVE_BASELINE = Path("baselines/defensive_fallback_policy_baseline.json")
+_TYPING_SURFACE_BASELINE = Path("baselines/typing_surface_policy_baseline.json")
+_TYPING_SURFACE_WAIVERS = Path("baselines/typing_surface_policy_waivers.json")
 _LEGACY_MONOLITH_MODULE_PATH = Path("src/gabion/analysis/legacy_dataflow_monolith.py")
 
 
@@ -136,6 +138,13 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
         module=defensive_fallback_rule,
         baseline_path=resolved_root / _DEFENSIVE_BASELINE,
     )
+    typing_surface_allowed = _load_rule_baseline_keys(
+        module=typing_surface_rule,
+        baseline_path=resolved_root / _TYPING_SURFACE_BASELINE,
+    )
+    typing_surface_waiver_result = typing_surface_rule.load_waivers(
+        resolved_root / _TYPING_SURFACE_WAIVERS,
+    )
 
     violations_by_rule: dict[str, list[dict[str, object]]] = {
         "no_monkeypatch": [],
@@ -143,7 +152,24 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
         "defensive_fallback": [],
         "no_legacy_monolith_import": [],
         "orchestrator_primitive_barrel": [],
+        "typing_surface": [],
     }
+
+    for invalid in typing_surface_waiver_result.invalid_waivers:
+        violations_by_rule["typing_surface"].append(
+            {
+                "path": _TYPING_SURFACE_WAIVERS.as_posix(),
+                "line": int(invalid.index),
+                "column": 1,
+                "qualname": "<waiver>",
+                "kind": "invalid_waiver",
+                "scope": "waiver",
+                "annotation": "<none>",
+                "message": f"invalid typing-surface waiver metadata: {invalid.reason}",
+                "key": f"{_TYPING_SURFACE_WAIVERS.as_posix()}:<waiver>:{int(invalid.index)}:invalid_waiver",
+                "render": f"{_TYPING_SURFACE_WAIVERS.as_posix()}:{int(invalid.index)}:1: invalid_waiver: {invalid.reason}",
+            }
+        )
 
     legacy_module_path = resolved_root / _LEGACY_MONOLITH_MODULE_PATH
     if legacy_module_path.exists():
@@ -210,6 +236,18 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
                     _serialize_defensive(item) for item in defensive_violations
                 )
 
+                typing_surface_violations = _filter_baseline_violations(
+                    typing_surface_rule.collect_violations(
+                        rel_path=rel_path,
+                        source=source,
+                        tree=tree,
+                    ),
+                    allowed_keys=(typing_surface_allowed | typing_surface_waiver_result.allowed_keys),
+                )
+                violations_by_rule["typing_surface"].extend(
+                    _serialize_typing_surface(item) for item in typing_surface_violations
+                )
+
     for rule, items in list(violations_by_rule.items()):
         violations_by_rule[rule] = sorted(
             items,
@@ -255,9 +293,11 @@ def _violations_from_payload(payload: dict[str, object]) -> dict[str, list[dict[
             "branchless": [],
             "defensive_fallback": [],
             "no_legacy_monolith_import": [],
+            "orchestrator_primitive_barrel": [],
+            "typing_surface": [],
         }
     normalized: dict[str, list[dict[str, object]]] = {}
-    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel"):
+    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel", "typing_surface"):
         raw_items = violations_raw.get(rule)
         if not isinstance(raw_items, list):
             normalized[rule] = []
@@ -296,6 +336,7 @@ def _rule_set_hash() -> str:
             "defensive_fallback:v1",
             "no_legacy_monolith_import:v1",
             "orchestrator_primitive_barrel:v1",
+            "typing_surface:v1",
         ]
     )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
@@ -453,6 +494,21 @@ def _serialize_legacy_monolith(violation: object) -> dict[str, object]:
         "line": getattr(violation, "line"),
         "column": getattr(violation, "column"),
         "kind": getattr(violation, "kind"),
+        "message": getattr(violation, "message"),
+        "key": getattr(violation, "key"),
+        "render": getattr(violation, "render")(),
+    }
+
+
+def _serialize_typing_surface(violation: object) -> dict[str, object]:
+    return {
+        "path": getattr(violation, "path"),
+        "line": getattr(violation, "line"),
+        "column": getattr(violation, "column"),
+        "qualname": getattr(violation, "qualname"),
+        "kind": getattr(violation, "kind"),
+        "scope": getattr(violation, "scope"),
+        "annotation": getattr(violation, "annotation"),
         "message": getattr(violation, "message"),
         "key": getattr(violation, "key"),
         "render": getattr(violation, "render")(),

--- a/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
+++ b/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
@@ -45,6 +45,7 @@ def test_policy_scanner_suite_scan_and_cache(tmp_path: Path) -> None:
     assert policy_scanner_suite.violations_for_rule(first, rule="no_monkeypatch")
     assert policy_scanner_suite.violations_for_rule(first, rule="no_legacy_monolith_import")
     assert policy_scanner_suite.violations_for_rule(first, rule="orchestrator_primitive_barrel") == []
+    assert policy_scanner_suite.violations_for_rule(first, rule="typing_surface") == []
 
     second = policy_scanner_suite.load_or_scan_policy_suite(
         root=root,
@@ -81,6 +82,8 @@ def test_policy_scanner_suite_cache_invalidation_and_payload_normalization(
     assert normalized.violations_by_rule["defensive_fallback"] == []
     assert normalized.violations_by_rule["no_monkeypatch"] == []
     assert normalized.violations_by_rule["no_legacy_monolith_import"] == []
+    assert normalized.violations_by_rule["orchestrator_primitive_barrel"] == []
+    assert normalized.violations_by_rule["typing_surface"] == []
 
     _write(
         root / "src/gabion/new_file.py",
@@ -120,6 +123,7 @@ def test_policy_scanner_suite_private_cache_and_payload_branches(
     )
     assert normalized["no_monkeypatch"] == []
     assert normalized["orchestrator_primitive_barrel"] == []
+    assert normalized["typing_surface"] == []
 
 
 # gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_scan_with_explicit_nonstandard_files::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
@@ -292,6 +296,7 @@ def test_policy_scanner_suite_respects_branch_and_fallback_baselines(tmp_path: P
     assert policy_scanner_suite.violations_for_rule(result, rule="no_monkeypatch") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="no_legacy_monolith_import") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel") == []
+    assert policy_scanner_suite.violations_for_rule(result, rule="typing_surface") == []
 
 
 def test_policy_scanner_suite_flags_wide_orchestrator_primitive_barrel(tmp_path: Path) -> None:
@@ -304,3 +309,69 @@ def test_policy_scanner_suite_flags_wide_orchestrator_primitive_barrel(tmp_path:
     violations = policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel")
     assert violations
     assert any(item.get("kind") == "line_threshold" for item in violations)
+
+
+# gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_flags_typing_surface_and_respects_baseline_and_waivers::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
+def test_policy_scanner_suite_flags_typing_surface_and_respects_baseline_and_waivers(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(
+        root / "src/gabion/analysis/core/sample.py",
+        "from typing import Any\n\ndef normalize(payload: dict[str, object], raw: Any, marker: object) -> None:\n    return None\n",
+    )
+    result = policy_scanner_suite.scan_policy_suite(root=root)
+    violations = policy_scanner_suite.violations_for_rule(result, rule="typing_surface")
+    assert len(violations) == 3
+
+    baseline_path = root / "baselines/typing_surface_policy_baseline.json"
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps({"version": 1, "violations": violations}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    with_baseline = policy_scanner_suite.scan_policy_suite(root=root)
+    assert policy_scanner_suite.violations_for_rule(with_baseline, rule="typing_surface") == []
+
+    baseline_path.write_text(json.dumps({"version": 1, "violations": []}, indent=2) + "\n", encoding="utf-8")
+    waivers_path = root / "baselines/typing_surface_policy_waivers.json"
+    waivers_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "waivers": [
+                    {
+                        "path": "src/gabion/analysis/core/sample.py",
+                        "qualname": "normalize",
+                        "line": 3,
+                        "kind": "dict_str_object_annotation",
+                        "rationale": "legacy inbound payload shape",
+                        "scope": "semantic_core",
+                        "expiry": "2027-01-01",
+                        "owner": "@gabion-core",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with_waiver = policy_scanner_suite.scan_policy_suite(root=root)
+    waiver_violations = policy_scanner_suite.violations_for_rule(with_waiver, rule="typing_surface")
+    assert len(waiver_violations) == 2
+
+
+
+# gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_flags_invalid_typing_surface_waiver_metadata::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
+def test_policy_scanner_suite_flags_invalid_typing_surface_waiver_metadata(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(root / "src/gabion/analysis/core/sample.py", "from typing import Any\n\nvalue: Any = 'x'\n")
+    waivers_path = root / "baselines/typing_surface_policy_waivers.json"
+    waivers_path.parent.mkdir(parents=True, exist_ok=True)
+    waivers_path.write_text(
+        json.dumps({"version": 1, "waivers": [{"path": "src/gabion/analysis/core/sample.py"}]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = policy_scanner_suite.scan_policy_suite(root=root)
+    violations = policy_scanner_suite.violations_for_rule(result, rule="typing_surface")
+    assert any(item.get("kind") == "invalid_waiver" for item in violations)


### PR DESCRIPTION
### Motivation
- Enforce a normative typing-surface contract that restricts coarse annotations (`Any`, bare `object`, `dict[str, object]`) to explicit boundary ingress/egress and forbids them in the semantic core, stage contracts, and reducers.
- Provide a structured waiver mechanism so existing exceptions can be tracked, validated, and ratcheted down over time.
- Surface typing-surface violations as machine-readable findings in the existing policy scan pipeline to enable automated baseline/waiver ratcheting and governance telemetry.

### Description
- Added a new normative doc `docs/typing_surface_policy.md` that defines allowed/forbidden surfaces, required alternatives (DTOs, `Protocol`, dataclasses, `TypedDict`/Pydantic), and a waiver metadata schema.
- Implemented a new policy rule module `src/gabion/tooling/policy_rules/typing_surface_rule.py` that AST-scans annotations, detects `Any`, `object`, and `dict[str, object]` in forbidden scopes, emits typed `Violation` objects with stable `key` values, and validates waiver metadata via `load_waivers`.
- Wired the new rule into the runtime scanner by updating `src/gabion/tooling/runtime/policy_scanner_suite.py` to load baselines/waivers, include `typing_surface` in the rule-set hash, filter violations by baseline/waivers, emit `invalid_waiver` findings, and serialize `typing_surface` findings.
- Seeded repository state: added `baselines/typing_surface_policy_baseline.json` (seeded from current scan) and an empty waiver file `baselines/typing_surface_policy_waivers.json`, registered the rule in `src/gabion/tooling/policy_rules/__init__.py`, and extended `tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py` to exercise baseline/waiver behavior and invalid-waiver reporting.

### Testing
- Ran the scanner unit tests with `PYTHONPATH=src pytest -c /dev/null tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py -q` and all tests passed (`11 passed`).
- Executed the policy checks with `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` which completed successfully.
- Executed ambiguity-contract check with `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which completed successfully.
- Regenerated and extracted test evidence with `PYTHONPATH=src:. python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` (command succeeded).
- Verified syntax by compiling scanner and new rule with `PYTHONPATH=src python -m py_compile src/gabion/tooling/runtime/policy_scanner_suite.py src/gabion/tooling/policy_rules/typing_surface_rule.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97c40a3688324949c2a0ca30542be)