### PR TITLE
Refine server-core stage contracts with typed carriers and mode enum

### DIFF
--- a/src/gabion/server_core/analysis_stage.py
+++ b/src/gabion/server_core/analysis_stage.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-from gabion.server_core.stage_contracts import AnalysisRunner, JSONObject, StageAnalysisResult
+from gabion.server_core.stage_contracts import (
+    AnalysisContextContract,
+    AnalysisRunner,
+    AnalysisStateContract,
+    JSONObject,
+    StageAnalysisResult,
+)
 
 
 def run_analysis_stage(
     *,
-    context: object,
-    state: object,
+    context: AnalysisContextContract,
+    state: AnalysisStateContract,
     collection_resume_payload: JSONObject | None,
     run_analysis_with_progress: AnalysisRunner,
 ) -> StageAnalysisResult:

--- a/src/gabion/server_core/command_contract.py
+++ b/src/gabion/server_core/command_contract.py
@@ -1,15 +1,38 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Protocol
+
+from gabion.json_types import JSONObject, JSONValue
+
+
+class IngressStageMode(str, Enum):
+    ANALYSIS = "analysis"
+    AUX_OPERATION = "aux_operation"
+
+
+class ExecutionPayloadOptionsContract(Protocol):
+    emit_phase_timeline: bool
+    progress_heartbeat_seconds: float
+
+
+class AnalysisOutcomeContract(Protocol):
+    semantic_progress_cumulative: JSONObject | None
+    latest_collection_progress: JSONObject
+    last_collection_resume_payload: JSONObject | None
+
+
+class ProgressTraceStateContract(Protocol):
+    """Opaque progress trace state transported across progress hooks."""
 
 
 @dataclass(frozen=True)
 class CommandRuntimeInput:
     """Normalized command boundary inputs for server-core orchestration."""
 
-    payload: Mapping[str, object]
+    payload: Mapping[str, JSONValue]
     root: Path
     report_path_text: str | None
     timeout_total_ticks: int
@@ -20,19 +43,19 @@ class CommandRuntimeState:
     """Mutable runtime state carried through command execution."""
 
     latest_collection_progress: dict[str, int]
-    semantic_progress_cumulative: dict[str, object] | None = None
+    semantic_progress_cumulative: JSONObject | None = None
 
 
 @dataclass(frozen=True)
 class ProgressEvent:
     event_kind: str
     phase: str
-    dimensions: Mapping[str, object] = field(default_factory=dict)
+    dimensions: Mapping[str, JSONValue] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class CommandRuntimeOutcome:
-    response: dict[str, object]
+    response: JSONObject
     terminal_phase: str
 
 

--- a/src/gabion/server_core/ingress_primitives.py
+++ b/src/gabion/server_core/ingress_primitives.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 from gabion.analysis import AnalysisResult
 from gabion.json_types import JSONObject
+from gabion.server_core.command_contract import ProgressTraceStateContract
 
 
 @dataclass(frozen=True)
@@ -28,12 +29,12 @@ class OutputDeps:
 
 @dataclass(frozen=True)
 class ProgressDeps:
-    start_trace_fn: Callable[..., object]
-    record_1cell_fn: Callable[..., object]
-    record_2cell_witness_fn: Callable[..., object]
-    record_cofibration_fn: Callable[..., object]
-    merge_imported_trace_fn: Callable[..., object]
-    finalize_trace_fn: Callable[..., object]
+    start_trace_fn: Callable[..., ProgressTraceStateContract]
+    record_1cell_fn: Callable[..., ProgressTraceStateContract]
+    record_2cell_witness_fn: Callable[..., ProgressTraceStateContract]
+    record_cofibration_fn: Callable[..., ProgressTraceStateContract]
+    merge_imported_trace_fn: Callable[..., ProgressTraceStateContract]
+    finalize_trace_fn: Callable[..., ProgressTraceStateContract]
 
 
 @dataclass(frozen=True)

--- a/src/gabion/server_core/ingress_stage.py
+++ b/src/gabion/server_core/ingress_stage.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Mapping
 
 from gabion.server_core.stage_contracts import (
+    ExecutionPayloadOptionsContract,
+    IngressStageMode,
     IngressModeSelector,
     PayloadNormalizer,
     PayloadOptionsParser,
@@ -25,7 +27,10 @@ def run_ingress_stage(
     return StageIngressResult(payload=normalized_payload, options=options, mode=mode)
 
 
-def default_mode_selector(*, payload: Mapping[str, object], options: object) -> str:
+def default_mode_selector(
+    *, payload: Mapping[str, object], options: ExecutionPayloadOptionsContract
+) -> IngressStageMode:
+    del options
     if payload.get("aux_operation") is not None:
-        return "aux_operation"
-    return "analysis"
+        return IngressStageMode.AUX_OPERATION
+    return IngressStageMode.ANALYSIS

--- a/src/gabion/server_core/output_stage.py
+++ b/src/gabion/server_core/output_stage.py
@@ -1,28 +1,18 @@
 from __future__ import annotations
 
 from gabion.server_core.stage_contracts import (
-    AuxiliaryOutputEmitter,
-    PrimaryOutputEmitter,
+    AuxiliaryOutputRequest,
     StageOutputResult,
+    PrimaryOutputRequest,
 )
 
 
 def run_output_stage(
     *,
-    primary_output_emitter: PrimaryOutputEmitter,
-    auxiliary_output_emitter: AuxiliaryOutputEmitter,
-    primary_args: tuple[object, ...] = (),
-    primary_kwargs: dict[str, object] | None = None,
-    auxiliary_args: tuple[object, ...] = (),
-    auxiliary_kwargs: dict[str, object] | None = None,
+    primary_request: PrimaryOutputRequest,
+    auxiliary_request: AuxiliaryOutputRequest,
 ) -> StageOutputResult:
-    rendered = primary_output_emitter(
-        *primary_args,
-        **(primary_kwargs or {}),
-    )
-    auxiliary_output_emitter(
-        *auxiliary_args,
-        **(auxiliary_kwargs or {}),
-    )
+    rendered = primary_request.emit()
+    auxiliary_request.emit()
     checkpoint_state = rendered.get("phase_checkpoint_state", {})
     return StageOutputResult(response=rendered, phase_checkpoint_state=checkpoint_state)

--- a/src/gabion/server_core/stage_contracts.py
+++ b/src/gabion/server_core/stage_contracts.py
@@ -2,23 +2,34 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Mapping, Protocol
+from typing import Callable, Mapping, Protocol
+
+from gabion.json_types import JSONObject
+from gabion.server_core.command_contract import (
+    AnalysisOutcomeContract,
+    ExecutionPayloadOptionsContract,
+    IngressStageMode,
+)
 
 
-JSONValue = object
-JSONObject = dict[str, JSONValue]
+class AnalysisContextContract(Protocol):
+    payload: Mapping[str, object]
+
+
+class AnalysisStateContract(Protocol):
+    latest_collection_progress: Mapping[str, int]
 
 
 @dataclass(frozen=True)
 class StageIngressResult:
     payload: dict[str, object]
-    options: Any
-    mode: str
+    options: ExecutionPayloadOptionsContract
+    mode: IngressStageMode
 
 
 @dataclass(frozen=True)
 class StageAnalysisResult:
-    analysis_outcome: Any
+    analysis_outcome: AnalysisOutcomeContract
     semantic_progress_cumulative: JSONObject | None
     latest_collection_progress: JSONObject
     last_collection_resume_payload: JSONObject | None
@@ -40,27 +51,42 @@ class PayloadNormalizer(Protocol):
 
 
 class PayloadOptionsParser(Protocol):
-    def __call__(self, *, payload: Mapping[str, object], root: Path) -> Any: ...
+    def __call__(
+        self, *, payload: Mapping[str, object], root: Path
+    ) -> ExecutionPayloadOptionsContract: ...
 
 
 class IngressModeSelector(Protocol):
-    def __call__(self, *, payload: Mapping[str, object], options: Any) -> str: ...
+    def __call__(
+        self,
+        *,
+        payload: Mapping[str, object],
+        options: ExecutionPayloadOptionsContract,
+    ) -> IngressStageMode: ...
 
 
 class AnalysisRunner(Protocol):
-    def __call__(self, *, context: Any, state: Any, collection_resume_payload: JSONObject | None) -> Any: ...
+    def __call__(
+        self,
+        *,
+        context: AnalysisContextContract,
+        state: AnalysisStateContract,
+        collection_resume_payload: JSONObject | None,
+    ) -> AnalysisOutcomeContract: ...
 
 
-class PrimaryOutputEmitter(Protocol):
-    def __call__(self, *args: Any, **kwargs: Any) -> dict[str, object]: ...
+@dataclass(frozen=True)
+class PrimaryOutputRequest:
+    emit: Callable[[], dict[str, object]]
 
 
-class AuxiliaryOutputEmitter(Protocol):
-    def __call__(self, *args: Any, **kwargs: Any) -> None: ...
+@dataclass(frozen=True)
+class AuxiliaryOutputRequest:
+    emit: Callable[[], None]
 
 
 class TimeoutCleanupHandler(Protocol):
-    def __call__(self, *, exc: BaseException, context: Any) -> dict[str, object]: ...
+    def __call__(self, *, exc: BaseException, context: object) -> dict[str, object]: ...
 
 
 @dataclass(frozen=True)

--- a/tests/gabion/server_core/test_stage_contract_shapes.py
+++ b/tests/gabion/server_core/test_stage_contract_shapes.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gabion.server_core.command_contract import (
+    ExecutionPayloadOptionsContract,
+    IngressStageMode,
+    ProgressTraceStateContract,
+)
+from gabion.server_core.ingress_stage import default_mode_selector
+from gabion.server_core.output_stage import run_output_stage
+from gabion.server_core.stage_contracts import AuxiliaryOutputRequest, PrimaryOutputRequest
+
+
+@dataclass(frozen=True)
+class _Options:
+    emit_phase_timeline: bool = False
+    progress_heartbeat_seconds: float = 1.0
+
+
+@dataclass(frozen=True)
+class _TraceState:
+    trace_id: str
+
+
+def test_default_mode_selector_returns_stage_mode_enum() -> None:
+    mode = default_mode_selector(payload={"aux_operation": {"domain": "x"}}, options=_Options())
+    assert mode is IngressStageMode.AUX_OPERATION
+
+
+def test_output_stage_uses_typed_emission_requests() -> None:
+    events: list[str] = []
+
+    def _emit_primary() -> dict[str, object]:
+        events.append("primary")
+        return {"phase_checkpoint_state": {"phase": "emit"}}
+
+    def _emit_aux() -> None:
+        events.append("aux")
+
+    result = run_output_stage(
+        primary_request=PrimaryOutputRequest(emit=_emit_primary),
+        auxiliary_request=AuxiliaryOutputRequest(emit=_emit_aux),
+    )
+
+    assert result.phase_checkpoint_state == {"phase": "emit"}
+    assert events == ["primary", "aux"]
+
+
+def test_contract_marker_protocols_accept_dataclass_carriers() -> None:
+    options: ExecutionPayloadOptionsContract = _Options()
+    assert options.progress_heartbeat_seconds == 1.0
+
+    trace: ProgressTraceStateContract = _TraceState(trace_id="t-1")
+    assert isinstance(trace, _TraceState)

--- a/tests/gabion/server_core/test_stage_modules.py
+++ b/tests/gabion/server_core/test_stage_modules.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from gabion.server_core.analysis_stage import run_analysis_stage
+from gabion.server_core.command_contract import IngressStageMode
 from gabion.server_core.ingress_stage import default_mode_selector, run_ingress_stage
 from gabion.server_core.output_stage import run_output_stage
+from gabion.server_core.stage_contracts import AuxiliaryOutputRequest, PrimaryOutputRequest
 from gabion.server_core.timeout_stage import (
     render_timeout_payload,
     run_timeout_stage,
@@ -29,7 +31,7 @@ def test_ingress_stage_normalizes_options_and_mode() -> None:
     )
 
     assert stage.payload["normalized"] is True
-    assert stage.mode == "aux_operation"
+    assert stage.mode is IngressStageMode.AUX_OPERATION
     assert stage.options["root"] == "."
 
 
@@ -55,7 +57,10 @@ def test_output_stage_calls_primary_and_auxiliary_emitters() -> None:
     def _aux(*_args: object, **_kwargs: object) -> None:
         called.append("aux")
 
-    stage = run_output_stage(primary_output_emitter=_primary, auxiliary_output_emitter=_aux)
+    stage = run_output_stage(
+        primary_request=PrimaryOutputRequest(emit=_primary),
+        auxiliary_request=AuxiliaryOutputRequest(emit=_aux),
+    )
 
     assert called == ["primary", "aux"]
     assert stage.phase_checkpoint_state == {"phase": "emit"}


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc `Any`/`object` usage at stage boundaries and make cross-stage handoffs explicit and auditable.
- Promote string-mode plumbing to a typed `IngressStageMode` enum to remove implicit mode values and enable enum-checked logic.
- Replace variadic emitter signatures with typed request carriers so primary/auxiliary emission is a compile-time-visible contract.

### Description
- Reified stage contracts in `src/gabion/server_core/stage_contracts.py` by adding `ExecutionPayloadOptionsContract`, `AnalysisOutcomeContract`, `AnalysisContextContract`, `AnalysisStateContract`, `PrimaryOutputRequest`, and `AuxiliaryOutputRequest`, and switched stage types to use `JSONObject` from `gabion.json_types`.
- Introduced `IngressStageMode` enum and aligned `default_mode_selector` in `src/gabion/server_core/ingress_stage.py` to return the enum instead of raw strings.
- Reworked the output stage API in `src/gabion/server_core/output_stage.py` to accept `PrimaryOutputRequest` and `AuxiliaryOutputRequest` carriers and emit via their `emit` callables instead of `*args/**kwargs` emitter protocols.
- Aligned `src/gabion/server_core/command_contract.py` and `src/gabion/server_core/ingress_primitives.py` to share the new protocol markers (`ExecutionPayloadOptionsContract`, `AnalysisOutcomeContract`, `ProgressTraceStateContract`) and tightened JSON typing (use of `JSONObject`/`JSONValue`).
- Added contract-shape tests in `tests/gabion/server_core/test_stage_contract_shapes.py` and updated `tests/gabion/server_core/test_stage_modules.py` to exercise the enum and new request carriers, and refreshed `out/test_evidence.json` to include the new test entries.

### Testing
- Ran the policy checks with `PYTHONPATH=src mise exec -- python -m scripts.policy.policy_check --workflows` and `--ambiguity-contract`, and both checks completed successfully (the environment emitted a tooling-resolution warning but the checks ran to completion). 
- Executed the targeted pytest run with `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/server_core/test_stage_modules.py tests/gabion/server_core/test_stage_contract_shapes.py` and all tests passed (`7 passed`).
- Ran `PYTHONPATH=src mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` to refresh `out/test_evidence.json`, and the evidence file was updated to include the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97c4fed5083249486240d0ae16843)