### PR TITLE
Type command payload carriers at server ingress and add non-boundary helper-signature policy

### DIFF
--- a/scripts/policy/policy_check.py
+++ b/scripts/policy/policy_check.py
@@ -1645,6 +1645,71 @@ def check_semantic_core_payload_branching() -> None:
         ])
 
 
+
+def _is_dict_object_annotation(annotation: ast.AST) -> bool:
+    text = ast.unparse(annotation).replace(" ", "")
+    return text in {
+        "dict[str,object]",
+        "Mapping[str,object]",
+        "MutableMapping[str,object]",
+        "collections.abc.Mapping[str,object]",
+        "collections.abc.MutableMapping[str,object]",
+    }
+
+
+def _helper_payload_signature_violations(path: Path) -> list[str]:
+    check_deadline()
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{path}: failed to read source ({exc})"]
+    if "gabion:boundary_normalization_module" in source:
+        return []
+    try:
+        module = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}: failed to parse source ({exc})"]
+    violations: list[str] = []
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = str(path)
+    for node in ast.walk(module):
+        check_deadline()
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("_"):
+            continue
+        params = [*node.args.posonlyargs, *node.args.args]
+        if not params:
+            continue
+        first_param = params[0]
+        if first_param.annotation is None:
+            continue
+        if _is_dict_object_annotation(first_param.annotation):
+            line = int(getattr(first_param, "lineno", getattr(node, "lineno", 1)) or 1)
+            violations.append(
+                f"{rel}:{line}: non-boundary helper must not use dict[str, object]-first payload signatures"
+            )
+    return violations
+
+
+def check_non_boundary_payload_signatures() -> None:
+    changed = _changed_repo_paths()
+    errors: list[str] = []
+    for rel in sorted(changed):
+        check_deadline()
+        if not rel.startswith("src/") or not rel.endswith(".py"):
+            continue
+        if rel.startswith("src/gabion/commands/"):
+            continue
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        errors.extend(_helper_payload_signature_violations(path))
+    if errors:
+        _fail(["non-boundary payload signature policy check failed", *errors])
+
 def _dotted_name(node: ast.AST) -> str | None:
     if isinstance(node, ast.Name):
         return node.id
@@ -1719,9 +1784,10 @@ def main():
     parser.add_argument("--adapter-surfaces", action="store_true", help="validate configured adapter surface requirements")
     parser.add_argument("--semantic-core-payload-branching", action="store_true", help="forbid raw Mapping/list payload branching outside boundary decode functions")
     parser.add_argument("--aspf-taint-crosswalk", action="store_true", help="require ASPF/taint crosswalk acknowledgement when relevant files change")
+    parser.add_argument("--non-boundary-payload-signatures", action="store_true", help="forbid dict[str, object]-first helper signatures outside boundary modules")
     args = parser.parse_args()
 
-    if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map and not args.tier2_residue_contract and not args.adapter_surfaces and not args.semantic_core_payload_branching and not args.aspf_taint_crosswalk:
+    if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map and not args.tier2_residue_contract and not args.adapter_surfaces and not args.semantic_core_payload_branching and not args.aspf_taint_crosswalk and not args.non_boundary_payload_signatures:
         args.workflows = True
 
     with _policy_deadline_scope():
@@ -1743,6 +1809,8 @@ def main():
             check_src_script_file_loading_policy()
         if args.aspf_taint_crosswalk or args.workflows:
             check_aspf_taint_crosswalk_ack()
+        if args.non_boundary_payload_signatures or args.workflows:
+            check_non_boundary_payload_signatures()
     return 0
 
 

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Callable, Literal, Mapping, Sequence, cast
+from typing import Callable, Literal, Mapping, Protocol, Sequence, cast
 from urllib.parse import unquote, urlparse
 
 from pygls.lsp.server import LanguageServer
@@ -1535,6 +1535,31 @@ def _require_optional_payload(
     return _require_payload(payload, command=command)
 
 
+def _parse_dataflow_command_payload(
+    payload: Mapping[str, object] | None,
+) -> DataflowCommandPayload:
+    normalized_payload = _require_optional_payload(payload, command=DATAFLOW_COMMAND)
+    normalized_payload = _normalize_dataflow_boundary_controls(normalized_payload)
+    return DataflowCommandPayload(payload=normalized_payload)
+
+
+def _parse_lsp_parity_gate_payload(
+    payload: Mapping[str, object] | None,
+) -> LspParityGatePayload:
+    normalized_payload = _require_optional_payload(
+        payload,
+        command=LSP_PARITY_GATE_COMMAND,
+    )
+    return LspParityGatePayload(payload=normalized_payload)
+
+
+def _parse_impact_command_payload(
+    payload: Mapping[str, object] | None,
+) -> ImpactCommandPayload:
+    normalized_payload = _require_optional_payload(payload, command=IMPACT_COMMAND)
+    return ImpactCommandPayload(payload=normalized_payload)
+
+
 def _ordered_command_response(
     response: Mapping[str, object],
     *,
@@ -1604,43 +1629,43 @@ def _server_deadline_overhead_ns(
     )
 
 
-def _analysis_timeout_total_ns(payload: dict[str, object]) -> int:
-    return orchestrator_primitives._analysis_timeout_total_ns(payload)
+def _analysis_timeout_total_ns(payload: Mapping[str, object] | MappingPayloadCarrier) -> int:
+    return orchestrator_primitives._analysis_timeout_total_ns(dict(_payload_mapping(payload)))
 
 
-def _analysis_timeout_total_ticks(payload: dict[str, object]) -> int:
-    return orchestrator_primitives._analysis_timeout_total_ticks(payload)
+def _analysis_timeout_total_ticks(payload: Mapping[str, object] | MappingPayloadCarrier) -> int:
+    return orchestrator_primitives._analysis_timeout_total_ticks(dict(_payload_mapping(payload)))
 
 
 def _analysis_timeout_grace_ns(
-    payload: dict[str, object],
+    payload: Mapping[str, object] | MappingPayloadCarrier,
     *,
     total_ns: int,
 ) -> int:
     return orchestrator_primitives._analysis_timeout_grace_ns(
-        payload,
+        dict(_payload_mapping(payload)),
         total_ns=total_ns,
     )
 
 
 def _analysis_timeout_budget_ns(
-    payload: dict[str, object],
+    payload: Mapping[str, object] | MappingPayloadCarrier,
 ) -> tuple[int, int, int]:
-    return orchestrator_primitives._analysis_timeout_budget_ns(payload)
+    return orchestrator_primitives._analysis_timeout_budget_ns(dict(_payload_mapping(payload)))
 
 
 def _deadline_profile_sample_interval(
-    payload: dict[str, object],
+    payload: Mapping[str, object] | MappingPayloadCarrier,
     *,
     default_interval: int = 16,
 ) -> int:
     return orchestrator_primitives._deadline_profile_sample_interval(
-        payload,
+        dict(_payload_mapping(payload)),
         default_interval=default_interval,
     )
 
 
-def _deadline_from_payload(payload: dict[str, object]) -> Deadline:
+def _deadline_from_payload(payload: Mapping[str, object] | MappingPayloadCarrier) -> Deadline:
     total_ns = _analysis_timeout_total_ns(payload)
     overhead_ns = _server_deadline_overhead_ns(total_ns)
     analysis_ns = max(1, total_ns - overhead_ns)
@@ -1648,10 +1673,11 @@ def _deadline_from_payload(payload: dict[str, object]) -> Deadline:
 
 
 @contextmanager
-def _deadline_scope_from_payload(payload: Mapping[str, object]):
-    normalized_payload = _require_payload(payload, command="deadline_scope")
-    deadline = _deadline_from_payload(normalized_payload)
-    base_ticks = _analysis_timeout_total_ticks(normalized_payload)
+def _deadline_scope_from_payload(payload: Mapping[str, object] | MappingPayloadCarrier):
+    normalized_payload = _require_payload(_payload_mapping(payload), command="deadline_scope")
+    normalized_carrier = DataflowCommandPayload(payload=normalized_payload)
+    deadline = _deadline_from_payload(normalized_carrier)
+    base_ticks = _analysis_timeout_total_ticks(normalized_carrier)
     tick_limit = base_ticks
     tick_limit_value = normalized_payload.get("analysis_tick_limit")
     if tick_limit_value not in (None, ""):
@@ -1909,9 +1935,8 @@ def _execute_dataflow_command_boundary(
     deps: ExecuteCommandDeps | None = None,
 ) -> dict:
     try:
-        normalized_payload = _require_optional_payload(payload, command=DATAFLOW_COMMAND)
-        normalized_payload = _normalize_dataflow_boundary_controls(normalized_payload)
-        normalized_result = _execute_command_total(ls, normalized_payload, deps=deps)
+        command_payload = _parse_dataflow_command_payload(payload)
+        normalized_result = _execute_command_total(ls, command_payload, deps=deps)
         return _ordered_command_response(
             normalized_result,
             command=DATAFLOW_COMMAND,
@@ -1943,13 +1968,14 @@ def execute_command_with_deps(
 
 def _execute_command_total(
     ls: LanguageServer,
-    payload: dict[str, object],
+    payload: DataflowCommandPayload | Mapping[str, object],
     *,
     deps: ExecuteCommandDeps | None = None,
 ) -> dict:
     from gabion.server_core.command_orchestrator import execute_command_total
 
-    return execute_command_total(ls, payload, deps=deps)
+    command_payload = payload if isinstance(payload, DataflowCommandPayload) else DataflowCommandPayload(payload=_require_payload(payload, command=DATAFLOW_COMMAND))
+    return execute_command_total(ls, command_payload.payload, deps=deps)
 
 
 @server.command(SYNTHESIS_COMMAND)
@@ -2290,6 +2316,36 @@ class ImpactEdgeBuckets:
     unresolved_edges: tuple[dict[str, object], ...]
 
 
+@dataclass(frozen=True)
+class DataflowCommandPayload:
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class LspParityGatePayload:
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ImpactCommandPayload:
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ParityProbePayload:
+    payload: dict[str, object]
+
+
+class MappingPayloadCarrier(Protocol):
+    payload: Mapping[str, object]
+
+
+def _payload_mapping(payload: Mapping[str, object] | MappingPayloadCarrier) -> Mapping[str, object]:
+    if isinstance(payload, Mapping):
+        return payload
+    return payload.payload
+
+
 class ParityProbeError(RuntimeError):
     pass
 
@@ -2385,11 +2441,11 @@ def _probe_lsp_executor(
     *,
     ls: LanguageServer,
     command: str,
-    probe_payload: Mapping[str, object],
+    probe_payload: ParityProbePayload,
 ) -> dict[str, object]:
     try:
         return boundary_order.normalize_boundary_mapping_once(
-            executor(ls, dict(probe_payload)),
+            executor(ls, dict(probe_payload.payload)),
             source=f"server.lsp_parity_gate.{command}.lsp_result",
         )
     except NeverThrown:
@@ -2403,11 +2459,11 @@ def _probe_direct_executor(
     *,
     ls: LanguageServer,
     command: str,
-    probe_payload: Mapping[str, object],
+    probe_payload: ParityProbePayload,
 ) -> dict[str, object]:
     try:
         return boundary_order.normalize_boundary_mapping_once(
-            executor(ls, dict(probe_payload)),
+            executor(ls, dict(probe_payload.payload)),
             source=f"server.lsp_parity_gate.{command}.direct_result",
         )
     except NeverThrown:
@@ -2721,7 +2777,7 @@ def _normalize_probe_payload(
     *,
     root: Path,
     command: str,
-) -> dict[str, object]:
+) -> ParityProbePayload:
     payload = boundary_order.normalize_boundary_mapping_once(
         probe_payload,
         source=f"server.lsp_parity_gate.{command}.probe_payload",
@@ -2742,12 +2798,12 @@ def _normalize_probe_payload(
             {"analysis_timeout_ticks": 100, "analysis_timeout_tick_ns": 1_000_000},
             source=f"server.lsp_parity_gate.{command}.probe_payload_timeout",
         )
-    return payload
+    return ParityProbePayload(payload=payload)
 
 
 def _execute_lsp_parity_gate_total(
     ls: LanguageServer,
-    payload: dict[str, object],
+    payload: LspParityGatePayload | Mapping[str, object],
     *,
     load_rules: Callable[[], GovernanceRules] = load_governance_rules,
     lsp_executor_for_command: Callable[
@@ -2770,8 +2826,9 @@ def _execute_lsp_parity_gate_total(
         if direct_executor_for_command is None
         else direct_executor_for_command
     )
-    root = Path(str(payload.get("root") or ls.workspace.root_path or "."))
-    selected_commands = list(payload_codec.normalized_command_id_list(payload, key="commands"))
+    command_payload = payload if isinstance(payload, LspParityGatePayload) else LspParityGatePayload(payload=_require_payload(payload, command=LSP_PARITY_GATE_COMMAND))
+    root = Path(str(command_payload.payload.get("root") or ls.workspace.root_path or "."))
+    selected_commands = list(payload_codec.normalized_command_id_list(command_payload.payload, key="commands"))
     if not selected_commands:
         selected_commands = list(sort_once(rules.command_policies.keys(), source="server.lsp_parity_gate.selected_default"))
     checked_commands: list[dict[str, object]] = []
@@ -2849,9 +2906,9 @@ def execute_lsp_parity_gate(
     ls: LanguageServer,
     payload: dict | None = None,
 ) -> dict:
-    normalized_payload = _require_optional_payload(payload, command=LSP_PARITY_GATE_COMMAND)
+    command_payload = _parse_lsp_parity_gate_payload(payload)
     return _ordered_command_response(
-        _execute_lsp_parity_gate_total(ls, normalized_payload),
+        _execute_lsp_parity_gate_total(ls, command_payload),
         command=LSP_PARITY_GATE_COMMAND,
     )
 
@@ -2861,17 +2918,18 @@ def execute_impact(
     ls: LanguageServer,
     payload: dict[str, object] | None = None,
 ) -> dict:
-    normalized_payload = _require_optional_payload(payload, command=IMPACT_COMMAND)
+    command_payload = _parse_impact_command_payload(payload)
     return _ordered_command_response(
-        _execute_impact_total(ls, normalized_payload),
+        _execute_impact_total(ls, command_payload),
         command=IMPACT_COMMAND,
     )
 
 
-def _execute_impact_total(ls: LanguageServer, payload: dict[str, object]) -> dict:
-    with _deadline_scope_from_payload(payload):
+def _execute_impact_total(ls: LanguageServer, payload: ImpactCommandPayload | Mapping[str, object]) -> dict:
+    command_payload = payload if isinstance(payload, ImpactCommandPayload) else ImpactCommandPayload(payload=_require_payload(payload, command=IMPACT_COMMAND))
+    with _deadline_scope_from_payload(command_payload):
         try:
-            options = _normalize_impact_payload(payload, workspace_root=ls.workspace.root_path)
+            options = _normalize_impact_payload(command_payload.payload, workspace_root=ls.workspace.root_path)
         except ValueError as exc:
             return {"exit_code": 2, "errors": [str(exc)]}
         root = options.root

--- a/tests/gabion/tooling/ci/test_ci_governance_scripts.py
+++ b/tests/gabion/tooling/ci/test_ci_governance_scripts.py
@@ -408,6 +408,36 @@ def semantic(value: object) -> object:
     assert violations
 
 
+# gabion:evidence E:function_site::test_ci_governance_scripts.py::tests.test_ci_governance_scripts.test_non_boundary_payload_signature_policy_flags_helper
+def test_non_boundary_payload_signature_policy_flags_helper(tmp_path: Path) -> None:
+    module = tmp_path / "helper_bad.py"
+    module.write_text(
+        """
+def _helper(payload: dict[str, object]) -> None:
+    return None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    violations = policy_check._helper_payload_signature_violations(module)
+    assert violations
+
+
+# gabion:evidence E:function_site::test_ci_governance_scripts.py::tests.test_ci_governance_scripts.test_non_boundary_payload_signature_policy_ignores_boundary_module
+def test_non_boundary_payload_signature_policy_ignores_boundary_module(tmp_path: Path) -> None:
+    module = tmp_path / "helper_ok.py"
+    module.write_text(
+        """
+# gabion:boundary_normalization_module
+def _helper(payload: dict[str, object]) -> None:
+    return None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    assert policy_check._helper_payload_signature_violations(module) == []
+
+
 # gabion:evidence E:function_site::policy_check.py::scripts.policy_check._check_aspf_crosswalk
 def test_policy_check_aspf_crosswalk_validates_repo_map() -> None:
     original_changed = policy_check._changed_repo_paths


### PR DESCRIPTION
### Motivation
- Converge command-boundary handling by normalizing payloads exactly once at ingress and passing typed carriers through orchestrator/stages instead of raw map-shaped payloads.
- Reduce implicit `dict[str, object]`/`Mapping[str, object]` coupling in helper surfaces and prevent new non-boundary helpers from adopting dict-first signatures.
- Improve parity-probe safety by making probe payloads explicit carriers and preserving boundary normalization semantics.

### Description
- Added typed command payload carriers (`DataflowCommandPayload`, `LspParityGatePayload`, `ImpactCommandPayload`, `ParityProbePayload`) and `MappingPayloadCarrier` protocol to `src/gabion/server.py`, and a small `_payload_mapping` adapter helper so internals can accept either carriers or legacy mappings.
- Introduced ingress parse helpers (`_parse_dataflow_command_payload`, `_parse_lsp_parity_gate_payload`, `_parse_impact_command_payload`) and threaded the typed carriers through command handlers and executor entry points while preserving existing boundary normalization behavior.
- Adjusted timeout/deadline helper surfaces to accept carriers (via the adapter) and updated LSP parity probe execution to use `ParityProbePayload` when invoking LSP/direct executors.
- Added policy checks in `scripts/policy/policy_check.py` that detect non-boundary helper functions using `dict[str, object]`/`Mapping[str, object]` as the first parameter, wired a `--non-boundary-payload-signatures` CLI flag and included the check in the `--workflows` path.
- Added CI governance tests in `tests/gabion/tooling/ci/test_ci_governance_scripts.py` that cover the new payload-signature policy (violation case and boundary-module allow case).

### Testing
- Ran static compile: `python -m py_compile src/gabion/server.py scripts/policy/policy_check.py tests/gabion/tooling/ci/test_ci_governance_scripts.py` (succeeded).
- Ran targeted pytest for policy checks: `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/tooling/ci/test_ci_governance_scripts.py -k "payload_branching or non_boundary_payload_signature"` (4 selected tests passed).
- Ran targeted server tests: `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/server/server_execute_command_edges_cases.py -k "execute_impact_requires_payload or execute_impact_total_rejects_reverse_edge_with_missing_caller"` (2 selected tests passed).
- Executed policy script runs: `PYTHONPATH=src:. python -m scripts.policy.policy_check --workflows` and `--ambiguity-contract` (both executed without errors in this environment).
- All automated checks exercised above completed successfully after minor iteration; changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97c5f46848324a4e36b5432128067)