### PR TITLE
Introduce typed command dispatch registry and refactor server/direct dispatch to use it

### DIFF
--- a/src/gabion/commands/direct_dispatch.py
+++ b/src/gabion/commands/direct_dispatch.py
@@ -3,42 +3,36 @@ from __future__ import annotations
 from typing import Callable
 
 from gabion.commands import command_ids
+from gabion.commands.dispatch_registry import (
+    CommandExecutorRefs,
+    build_command_dispatch_registry,
+    direct_executor_registry as build_direct_executor_registry,
+)
 from gabion.order_contract import sort_once
 
-DirectExecutor = Callable[[object, dict[str, object]], dict]
+DirectExecutor = Callable[[object, dict[str, object] | None], dict]
 
 
-def _server_direct_executor(name: str) -> DirectExecutor:
-    def _executor(ls: object, params: dict[str, object]) -> dict:
-        from gabion import server
+def _server_command_registry() -> dict[str, DirectExecutor]:
+    from gabion import server
 
-        candidate = getattr(server, name)
-        return candidate(ls, params)
-
-    return _executor
-
-
-_UNORDERED_DIRECT_EXECUTORS: dict[str, DirectExecutor] = {
-    command_ids.CHECK_COMMAND: _server_direct_executor("execute_command"),
-    command_ids.DATAFLOW_COMMAND: _server_direct_executor("execute_command"),
-    command_ids.STRUCTURE_DIFF_COMMAND: _server_direct_executor("execute_structure_diff"),
-    command_ids.STRUCTURE_REUSE_COMMAND: _server_direct_executor("execute_structure_reuse"),
-    command_ids.DECISION_DIFF_COMMAND: _server_direct_executor("execute_decision_diff"),
-    command_ids.SYNTHESIS_COMMAND: _server_direct_executor("execute_synthesis"),
-    command_ids.REFACTOR_COMMAND: _server_direct_executor("execute_refactor"),
-    command_ids.IMPACT_COMMAND: _server_direct_executor("execute_impact"),
-    command_ids.LSP_PARITY_GATE_COMMAND: _server_direct_executor(
-        "execute_lsp_parity_gate"
-    ),
-}
+    registry = build_command_dispatch_registry(
+        CommandExecutorRefs(
+            execute_command=server.execute_command,
+            execute_structure_diff=server.execute_structure_diff,
+            execute_structure_reuse=server.execute_structure_reuse,
+            execute_decision_diff=server.execute_decision_diff,
+            execute_synthesis=server.execute_synthesis,
+            execute_refactor=server.execute_refactor,
+            execute_impact=server.execute_impact,
+            execute_lsp_parity_gate=server.execute_lsp_parity_gate,
+        )
+    )
+    return build_direct_executor_registry(registry)
 
 
 def direct_executor_registry() -> dict[str, DirectExecutor]:
-    return {
-        command: _UNORDERED_DIRECT_EXECUTORS[command]
-        for command in command_ids.SEMANTIC_COMMAND_IDS
-        if command in _UNORDERED_DIRECT_EXECUTORS
-    }
+    return _server_command_registry()
 
 
 DIRECT_EXECUTOR_REGISTRY: dict[str, DirectExecutor] = direct_executor_registry()

--- a/src/gabion/commands/dispatch_registry.py
+++ b/src/gabion/commands/dispatch_registry.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from gabion.commands import command_ids
+from gabion.invariants import never
+
+CommandExecutor = Callable[[object, dict[str, object] | None], dict]
+
+
+@dataclass(frozen=True)
+class CommandExecutorRefs:
+    execute_command: CommandExecutor
+    execute_structure_diff: CommandExecutor
+    execute_structure_reuse: CommandExecutor
+    execute_decision_diff: CommandExecutor
+    execute_synthesis: CommandExecutor
+    execute_refactor: CommandExecutor
+    execute_impact: CommandExecutor
+    execute_lsp_parity_gate: CommandExecutor
+
+
+@dataclass(frozen=True)
+class CommandDispatchRegistration:
+    executor: CommandExecutor
+    transport_lsp: bool
+    transport_direct: bool
+
+
+def _validate_registry_coverage(registry: dict[str, CommandDispatchRegistration]) -> None:
+    semantic = set(command_ids.SEMANTIC_COMMAND_IDS)
+    registered = set(registry)
+    missing = tuple(command for command in command_ids.SEMANTIC_COMMAND_IDS if command not in registered)
+    extras = tuple(command for command in registry if command not in semantic)
+    if missing:
+        never(
+            "command dispatch registry missing semantic command ids",
+            missing=missing,
+        )
+    if extras:
+        never(
+            "command dispatch registry has non-semantic command ids",
+            extras=extras,
+        )
+
+
+def build_command_dispatch_registry(
+    refs: CommandExecutorRefs,
+) -> dict[str, CommandDispatchRegistration]:
+    registry: dict[str, CommandDispatchRegistration] = {
+        command_ids.CHECK_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_command,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.DATAFLOW_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_command,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.STRUCTURE_DIFF_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_structure_diff,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.STRUCTURE_REUSE_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_structure_reuse,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.DECISION_DIFF_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_decision_diff,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.SYNTHESIS_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_synthesis,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.REFACTOR_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_refactor,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.IMPACT_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_impact,
+            transport_lsp=True,
+            transport_direct=True,
+        ),
+        command_ids.LSP_PARITY_GATE_COMMAND: CommandDispatchRegistration(
+            executor=refs.execute_lsp_parity_gate,
+            transport_lsp=False,
+            transport_direct=True,
+        ),
+    }
+    _validate_registry_coverage(registry)
+    return registry
+
+
+def executor_for_transport(
+    *,
+    registry: dict[str, CommandDispatchRegistration],
+    command: str,
+    transport: Literal["lsp", "direct"],
+) -> CommandExecutor | None:
+    registration = registry.get(command)
+    if registration is None:
+        return None
+    if transport == "lsp" and not registration.transport_lsp:
+        return None
+    if transport == "direct" and not registration.transport_direct:
+        return None
+    return registration.executor
+
+
+def direct_executor_registry(
+    registry: dict[str, CommandDispatchRegistration],
+) -> dict[str, CommandExecutor]:
+    return {
+        command: registry[command].executor
+        for command in command_ids.SEMANTIC_COMMAND_IDS
+        if command in registry and registry[command].transport_direct
+    }

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -26,6 +26,12 @@ from lsprotocol.types import (
 from gabion.json_types import JSONObject, JSONValue
 from gabion.commands import (
     boundary_order, command_ids, payload_codec, progress_contract as progress_timeline)
+from gabion.commands.dispatch_registry import (
+    CommandDispatchRegistration,
+    CommandExecutorRefs,
+    build_command_dispatch_registry,
+    executor_for_transport,
+)
 from gabion.commands.lint_parser import parse_lint_line
 from gabion.commands.check_contract import LintEntriesDecision
 from gabion.plan import (
@@ -2606,103 +2612,69 @@ def _impact_overlap(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
     return not (a_end < b_start or b_end < a_start)
 
 
-@dataclass(frozen=True)
-class CommandDispatchRegistration:
-    executor_name: str
-    transport_lsp: bool
-    transport_direct: bool
+_COMMAND_DISPATCH_REGISTRY: dict[str, CommandDispatchRegistration] | None = None
 
 
-_COMMAND_DISPATCH_REGISTRY: dict[str, CommandDispatchRegistration] = {
-    CHECK_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_command",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    DATAFLOW_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_command",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    STRUCTURE_DIFF_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_structure_diff",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    STRUCTURE_REUSE_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_structure_reuse",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    DECISION_DIFF_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_decision_diff",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    SYNTHESIS_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_synthesis",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    REFACTOR_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_refactor",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    IMPACT_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_impact",
-        transport_lsp=True,
-        transport_direct=True,
-    ),
-    LSP_PARITY_GATE_COMMAND: CommandDispatchRegistration(
-        executor_name="execute_lsp_parity_gate",
-        transport_lsp=False,
-        transport_direct=True,
-    ),
-}
-
-
-def _validate_command_dispatch_registry_coverage() -> None:
-    registered = set(_COMMAND_DISPATCH_REGISTRY)
-    semantic = set(command_ids.SEMANTIC_COMMAND_IDS)
-    missing = tuple(
-        sort_once(
-            semantic - registered,
-            source="server.command_dispatch_registry.missing",
+def _command_dispatch_registry() -> dict[str, CommandDispatchRegistration]:
+    global _COMMAND_DISPATCH_REGISTRY
+    if _COMMAND_DISPATCH_REGISTRY is None:
+        _COMMAND_DISPATCH_REGISTRY = build_command_dispatch_registry(
+            CommandExecutorRefs(
+                execute_command=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_command,
+                ),
+                execute_structure_diff=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_structure_diff,
+                ),
+                execute_structure_reuse=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_structure_reuse,
+                ),
+                execute_decision_diff=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_decision_diff,
+                ),
+                execute_synthesis=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_synthesis,
+                ),
+                execute_refactor=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_refactor,
+                ),
+                execute_impact=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_impact,
+                ),
+                execute_lsp_parity_gate=cast(
+                    Callable[[object, dict[str, object] | None], dict],
+                    execute_lsp_parity_gate,
+                ),
+            )
         )
-    )
-    if missing:
-        never(
-            "command dispatch registry missing semantic command ids",
-            missing=missing,
-        )
-
-
-_validate_command_dispatch_registry_coverage()
-
-def _command_executor_from_registration(
-    registration: CommandDispatchRegistration,
-) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
-    candidate = globals().get(registration.executor_name)
-    if not callable(candidate):
-        return None
-    return cast(Callable[[LanguageServer, dict[str, object] | None], dict], candidate)
+    return _COMMAND_DISPATCH_REGISTRY
 
 
 def _lsp_command_executor(command: str) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
-    registration = _COMMAND_DISPATCH_REGISTRY.get(command)
-    if registration is None or not registration.transport_lsp:
-        return None
-    return _command_executor_from_registration(registration)
+    executor = executor_for_transport(
+        registry=_command_dispatch_registry(),
+        command=command,
+        transport="lsp",
+    )
+    return cast(Callable[[LanguageServer, dict[str, object] | None], dict] | None, executor)
 
 
 def _direct_command_executor(
     command: str,
 ) -> Callable[[LanguageServer, dict[str, object] | None], dict] | None:
-    registration = _COMMAND_DISPATCH_REGISTRY.get(command)
-    if registration is None or not registration.transport_direct:
-        return None
-    return _command_executor_from_registration(registration)
+    executor = executor_for_transport(
+        registry=_command_dispatch_registry(),
+        command=command,
+        transport="direct",
+    )
+    return cast(Callable[[LanguageServer, dict[str, object] | None], dict] | None, executor)
 
 
 def _strip_parity_ignored_keys(

--- a/tests/gabion/commands/test_command_dispatch_registry.py
+++ b/tests/gabion/commands/test_command_dispatch_registry.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from gabion import server
 from gabion.commands import command_ids, direct_dispatch
+from gabion.commands.dispatch_registry import (
+    CommandDispatchRegistration,
+    executor_for_transport,
+)
 
 
 # gabion:evidence E:call_footprint::tests/test_command_dispatch_registry.py::test_semantic_command_ids_sorted::command_ids.py::gabion.commands.command_ids
@@ -21,3 +26,24 @@ def test_direct_dispatch_registry_sorted_and_complete() -> None:
         assert callable(direct_dispatch.direct_executor(command))
     assert direct_dispatch.direct_executor(command_ids.CHECK_COMMAND) is not None
     assert direct_dispatch.direct_executor(command_ids.DATAFLOW_COMMAND) is not None
+
+
+# gabion:evidence E:call_footprint::tests/test_command_dispatch_registry.py::test_semantic_command_transport_behavior_is_consistent::dispatch_registry.py::gabion.commands.dispatch_registry.executor_for_transport
+def test_semantic_command_transport_behavior_is_consistent() -> None:
+    registry = server._command_dispatch_registry()
+    for command in command_ids.SEMANTIC_COMMAND_IDS:
+        registration = registry[command]
+        assert isinstance(registration, CommandDispatchRegistration)
+        lsp_executor = executor_for_transport(
+            registry=registry,
+            command=command,
+            transport="lsp",
+        )
+        direct_executor = executor_for_transport(
+            registry=registry,
+            command=command,
+            transport="direct",
+        )
+        assert (lsp_executor is not None) is registration.transport_lsp
+        assert (direct_executor is not None) is registration.transport_direct
+        assert (direct_dispatch.direct_executor(command) is not None) is registration.transport_direct

--- a/tests/gabion/lsp_client/lsp_parity_gate_cases.py
+++ b/tests/gabion/lsp_client/lsp_parity_gate_cases.py
@@ -101,7 +101,7 @@ def test_command_executor_transport_filtering_is_stable() -> None:
 
 # gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_command_dispatch_registry_covers_semantic_command_ids::server.py::gabion.server._validate_command_dispatch_registry_coverage
 def test_command_dispatch_registry_covers_semantic_command_ids() -> None:
-    assert set(server._COMMAND_DISPATCH_REGISTRY) == set(server.command_ids.SEMANTIC_COMMAND_IDS)
+    assert set(server._command_dispatch_registry()) == set(server.command_ids.SEMANTIC_COMMAND_IDS)
 
 
 # gabion:evidence E:call_footprint::tests/test_lsp_parity_gate.py::test_strip_parity_ignored_keys_filters_requested_fields::server.py::gabion.server._strip_parity_ignored_keys


### PR DESCRIPTION
### Motivation
- Replace fragile string-based `globals().get(...)` executor lookups with a single typed registry to make command dispatch explicit and statically verifiable.
- Ensure `SEMANTIC_COMMAND_IDS` (in `command_ids.py`) is the single source of truth and that transport coverage is validated in one place.
- Remove ad-hoc indirection in direct dispatch so direct executors are derived from the same shared registry as the server.

### Description
- Added `src/gabion/commands/dispatch_registry.py` which defines `CommandExecutorRefs`, `CommandDispatchRegistration`, `build_command_dispatch_registry(...)`, `executor_for_transport(...)`, and `direct_executor_registry(...)`, and validates coverage against `command_ids.SEMANTIC_COMMAND_IDS` in one place.
- Refactored `src/gabion/server.py` to lazily build the typed registry via `_command_dispatch_registry()` and resolve executors with `executor_for_transport(... )`, removing `globals().get(...)` and string executor names.
- Refactored `src/gabion/commands/direct_dispatch.py` to construct `DIRECT_EXECUTOR_REGISTRY` from the shared registry (via `CommandExecutorRefs`), eliminating `_server_direct_executor(name: str)` string indirection.
- Kept `src/gabion/commands/command_ids.py` as the canonical command-id list and updated tests and evidence to assert transport-consistent behavior across all `SEMANTIC_COMMAND_IDS`.

### Testing
- Ran the repository policy checks with `PYTHONPATH=src:. mise exec -- python scripts/policy/policy_check.py --workflows` and `--ambiguity-contract`, which completed while emitting a `mise` tool-version resolution warning and otherwise passed.
- Ran the focused tests with `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/gabion/commands/test_command_dispatch_registry.py tests/gabion/lsp_client/lsp_parity_gate_cases.py -q`, which succeeded (`19 passed`).
- Re-generated evidence with `PYTHONPATH=src:. mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json`, which completed and refreshed `out/test_evidence.json` to include the new transport-consistency assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97aeaa26c832494710e3fe619256e)