### PR TITLE
Deduplicate server helper primitives into orchestrator_primitives and add duplicate-name policy scan

### DIFF
--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -115,19 +115,6 @@ def _is_stdout_target(target: object) -> bool:
     return runtime_contract.is_stdout_target(target)
 
 
-def _analysis_resume_cache_verdict(
-    *,
-    status: str | None,
-    reused_files: int,
-    compatibility_status: str | None,
-) -> Literal["hit", "miss", "invalidated", "seeded"]:
-    return orchestrator_primitives._analysis_resume_cache_verdict(
-        status=status,
-        reused_files=reused_files,
-        compatibility_status=compatibility_status,
-    )
-
-
 def _deadline_tick_budget_allows_check(clock: object) -> bool:
     return runtime_contract.deadline_tick_budget_allows_check(clock)
 
@@ -142,6 +129,14 @@ _analysis_input_manifest_digest = (
 _collection_semantic_progress = orchestrator_primitives._collection_semantic_progress
 _materialize_execution_plan = orchestrator_primitives._materialize_execution_plan
 _default_execute_command_deps = orchestrator_primitives._default_execute_command_deps
+_analysis_resume_cache_verdict = orchestrator_primitives._analysis_resume_cache_verdict
+_phase_timeline_md_path = orchestrator_primitives._phase_timeline_md_path
+_phase_timeline_jsonl_path = orchestrator_primitives._phase_timeline_jsonl_path
+_phase_timeline_header_columns = orchestrator_primitives._phase_timeline_header_columns
+_phase_timeline_header_block = orchestrator_primitives._phase_timeline_header_block
+_normalize_dataflow_response = orchestrator_primitives._normalize_dataflow_response
+_analysis_timeout_total_ns = orchestrator_primitives._analysis_timeout_total_ns
+_analysis_timeout_budget_ns = orchestrator_primitives._analysis_timeout_budget_ns
 
 
 def _collection_checkpoint_flush_due(
@@ -1146,14 +1141,6 @@ def _render_incremental_report(
     return "\n".join(lines).rstrip() + "\n", pending_reasons
 
 
-def _phase_timeline_md_path(*, root: Path) -> Path:
-    return root / _DEFAULT_PHASE_TIMELINE_MD
-
-
-def _phase_timeline_jsonl_path(*, root: Path) -> Path:
-    return root / _DEFAULT_PHASE_TIMELINE_JSONL
-
-
 def _progress_heartbeat_seconds(payload: Mapping[str, JSONValue]) -> float:
     return runtime_contract.progress_heartbeat_seconds(payload)
 
@@ -1219,14 +1206,6 @@ def _append_phase_timeline_event(
     with jsonl_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(progress_value, sort_keys=False) + "\n")
     return header_block, row_line
-
-
-def _phase_timeline_header_columns() -> list[str]:
-    return progress_timeline.phase_timeline_header_columns()
-
-
-def _phase_timeline_header_block() -> str:
-    return progress_timeline.phase_timeline_header_block()
 
 
 def _collection_progress_intro_lines(
@@ -1585,10 +1564,6 @@ def _normalize_dataflow_boundary_controls(
     )
 
 
-def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:
-    return orchestrator_primitives._normalize_dataflow_response(response)
-
-
 def _truthy_flag(value: object) -> bool:
     return orchestrator_primitives._truthy_flag(value)
 
@@ -1604,10 +1579,6 @@ def _server_deadline_overhead_ns(
     )
 
 
-def _analysis_timeout_total_ns(payload: dict[str, object]) -> int:
-    return orchestrator_primitives._analysis_timeout_total_ns(payload)
-
-
 def _analysis_timeout_total_ticks(payload: dict[str, object]) -> int:
     return orchestrator_primitives._analysis_timeout_total_ticks(payload)
 
@@ -1621,12 +1592,6 @@ def _analysis_timeout_grace_ns(
         payload,
         total_ns=total_ns,
     )
-
-
-def _analysis_timeout_budget_ns(
-    payload: dict[str, object],
-) -> tuple[int, int, int]:
-    return orchestrator_primitives._analysis_timeout_budget_ns(payload)
 
 
 def _deadline_profile_sample_interval(

--- a/src/gabion/tooling/runtime/policy_scanner_suite.py
+++ b/src/gabion/tooling/runtime/policy_scanner_suite.py
@@ -22,6 +22,69 @@ _ORCHESTRATOR_PRIMITIVE_MAX_LINES = 2400
 _ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS = 220
 
 
+
+_SERVER_MODULE_PATH = Path("src/gabion/server.py")
+_ORCHESTRATOR_DUPLICATE_HELPERS = frozenset(
+    {
+        "_analysis_resume_cache_verdict",
+        "_phase_timeline_md_path",
+        "_phase_timeline_jsonl_path",
+        "_phase_timeline_header_columns",
+        "_phase_timeline_header_block",
+        "_normalize_dataflow_response",
+        "_analysis_timeout_total_ns",
+        "_analysis_timeout_budget_ns",
+    }
+)
+
+
+def _module_function_names(*, root: Path, module_path: Path) -> set[str]:
+    path = root / module_path
+    if not path.exists():
+        return set()
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            names.add(node.name)
+    return names
+
+
+def _scan_server_orchestrator_helper_duplicates(*, root: Path) -> list[dict[str, object]]:
+    server_names = _module_function_names(root=root, module_path=_SERVER_MODULE_PATH)
+    if not server_names:
+        return []
+    orchestrator_names = _module_function_names(root=root, module_path=_ORCHESTRATOR_PRIMITIVE_BARREL_PATH)
+    if not orchestrator_names:
+        return []
+    duplicate_names = sorted(
+        _ORCHESTRATOR_DUPLICATE_HELPERS.intersection(server_names).intersection(orchestrator_names)
+    )
+    violations: list[dict[str, object]] = []
+    for helper_name in duplicate_names:
+        violations.append(
+            {
+                "path": _SERVER_MODULE_PATH.as_posix(),
+                "line": 1,
+                "column": 1,
+                "kind": "duplicate_helper",
+                "qualname": helper_name,
+                "message": (
+                    "server helper duplicates command_orchestrator_primitives helper; "
+                    "import from server_core authority"
+                ),
+                "render": (
+                    f"{_SERVER_MODULE_PATH.as_posix()}:1:1: duplicate_helper: "
+                    f"{helper_name} also defined in {_ORCHESTRATOR_PRIMITIVE_BARREL_PATH.as_posix()}"
+                ),
+            }
+        )
+    return violations
+
 def _scan_orchestrator_primitive_barrel(*, root: Path) -> list[dict[str, object]]:
     path = root / _ORCHESTRATOR_PRIMITIVE_BARREL_PATH
     if not path.exists():
@@ -143,6 +206,7 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
         "defensive_fallback": [],
         "no_legacy_monolith_import": [],
         "orchestrator_primitive_barrel": [],
+        "server_orchestrator_helper_duplicates": [],
     }
 
     legacy_module_path = resolved_root / _LEGACY_MONOLITH_MODULE_PATH
@@ -161,6 +225,9 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
 
     violations_by_rule["orchestrator_primitive_barrel"].extend(
         _scan_orchestrator_primitive_barrel(root=resolved_root)
+    )
+    violations_by_rule["server_orchestrator_helper_duplicates"].extend(
+        _scan_server_orchestrator_helper_duplicates(root=resolved_root)
     )
 
     for path in inventory:
@@ -255,9 +322,11 @@ def _violations_from_payload(payload: dict[str, object]) -> dict[str, list[dict[
             "branchless": [],
             "defensive_fallback": [],
             "no_legacy_monolith_import": [],
+            "orchestrator_primitive_barrel": [],
+            "server_orchestrator_helper_duplicates": [],
         }
     normalized: dict[str, list[dict[str, object]]] = {}
-    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel"):
+    for rule in ("no_monkeypatch", "branchless", "defensive_fallback", "no_legacy_monolith_import", "orchestrator_primitive_barrel", "server_orchestrator_helper_duplicates"):
         raw_items = violations_raw.get(rule)
         if not isinstance(raw_items, list):
             normalized[rule] = []
@@ -296,6 +365,7 @@ def _rule_set_hash() -> str:
             "defensive_fallback:v1",
             "no_legacy_monolith_import:v1",
             "orchestrator_primitive_barrel:v1",
+            "server_orchestrator_helper_duplicates:v1",
         ]
     )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()

--- a/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
+++ b/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
@@ -90,3 +90,36 @@ def test_progress_heartbeat_seconds_parity() -> None:
     assert server._progress_heartbeat_seconds(payload) == (
         command_orchestrator_primitives._progress_heartbeat_seconds(payload)
     )
+
+
+
+def test_phase_timeline_path_and_header_parity(tmp_path: Path) -> None:
+    assert server._phase_timeline_md_path(root=tmp_path) == (
+        command_orchestrator_primitives._phase_timeline_md_path(root=tmp_path)
+    )
+    assert server._phase_timeline_jsonl_path(root=tmp_path) == (
+        command_orchestrator_primitives._phase_timeline_jsonl_path(root=tmp_path)
+    )
+    assert server._phase_timeline_header_columns() == (
+        command_orchestrator_primitives._phase_timeline_header_columns()
+    )
+    assert server._phase_timeline_header_block() == (
+        command_orchestrator_primitives._phase_timeline_header_block()
+    )
+
+
+def test_analysis_resume_cache_verdict_parity() -> None:
+    kwargs = {
+        "status": "hit",
+        "reused_files": 5,
+        "compatibility_status": "stable",
+    }
+    assert server._analysis_resume_cache_verdict(**kwargs) == (
+        command_orchestrator_primitives._analysis_resume_cache_verdict(**kwargs)
+    )
+
+
+def test_server_authoritative_helper_aliases() -> None:
+    assert server._normalize_dataflow_response is command_orchestrator_primitives._normalize_dataflow_response
+    assert server._analysis_timeout_total_ns is command_orchestrator_primitives._analysis_timeout_total_ns
+    assert server._analysis_timeout_budget_ns is command_orchestrator_primitives._analysis_timeout_budget_ns

--- a/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
+++ b/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
@@ -45,6 +45,7 @@ def test_policy_scanner_suite_scan_and_cache(tmp_path: Path) -> None:
     assert policy_scanner_suite.violations_for_rule(first, rule="no_monkeypatch")
     assert policy_scanner_suite.violations_for_rule(first, rule="no_legacy_monolith_import")
     assert policy_scanner_suite.violations_for_rule(first, rule="orchestrator_primitive_barrel") == []
+    assert policy_scanner_suite.violations_for_rule(first, rule="server_orchestrator_helper_duplicates") == []
 
     second = policy_scanner_suite.load_or_scan_policy_suite(
         root=root,
@@ -120,6 +121,7 @@ def test_policy_scanner_suite_private_cache_and_payload_branches(
     )
     assert normalized["no_monkeypatch"] == []
     assert normalized["orchestrator_primitive_barrel"] == []
+    assert normalized["server_orchestrator_helper_duplicates"] == []
 
 
 # gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_scan_with_explicit_nonstandard_files::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
@@ -292,6 +294,7 @@ def test_policy_scanner_suite_respects_branch_and_fallback_baselines(tmp_path: P
     assert policy_scanner_suite.violations_for_rule(result, rule="no_monkeypatch") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="no_legacy_monolith_import") == []
     assert policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel") == []
+    assert policy_scanner_suite.violations_for_rule(result, rule="server_orchestrator_helper_duplicates") == []
 
 
 def test_policy_scanner_suite_flags_wide_orchestrator_primitive_barrel(tmp_path: Path) -> None:
@@ -304,3 +307,25 @@ def test_policy_scanner_suite_flags_wide_orchestrator_primitive_barrel(tmp_path:
     violations = policy_scanner_suite.violations_for_rule(result, rule="orchestrator_primitive_barrel")
     assert violations
     assert any(item.get("kind") == "line_threshold" for item in violations)
+
+
+
+def test_policy_scanner_suite_flags_duplicate_server_orchestrator_helpers(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(
+        root / "src/gabion/server.py",
+        "def _normalize_dataflow_response(response):\n    return response\n",
+    )
+    _write(
+        root / "src/gabion/server_core/command_orchestrator_primitives.py",
+        "def _normalize_dataflow_response(response):\n    return response\n",
+    )
+
+    result = policy_scanner_suite.scan_policy_suite(root=root)
+    violations = policy_scanner_suite.violations_for_rule(
+        result,
+        rule="server_orchestrator_helper_duplicates",
+    )
+    assert len(violations) == 1
+    assert violations[0]["kind"] == "duplicate_helper"
+    assert violations[0]["qualname"] == "_normalize_dataflow_response"


### PR DESCRIPTION
### Motivation

- Centralize shared dataflow/check helper logic in `src/gabion/server_core/command_orchestrator_primitives.py` so `server.py` keeps only boundary-facing behavior (LSP registration, decorators, transport dispatch). 
- Prevent accidental divergence of duplicated helpers by adding a lightweight policy check that detects duplicate helper names between `server.py` and the orchestrator primitives barrel.

### Description

- Replaced local helper implementations in `src/gabion/server.py` with authoritative aliases to `orchestrator_primitives` for the shared helpers: `_normalize_dataflow_response`, `_analysis_timeout_total_ns`, `_analysis_timeout_budget_ns`, `_analysis_resume_cache_verdict`, and `_phase_timeline_*` (md/jsonl path and header helpers). 
- Removed redundant function bodies from `server.py` and added boundary-preserving alias assignments so the server import/test surface remains stable (e.g. `_normalize_dataflow_response = orchestrator_primitives._normalize_dataflow_response`).
- Added duplicate-helper detection in `src/gabion/tooling/runtime/policy_scanner_suite.py` that scans `src/gabion/server.py` and `src/gabion/server_core/command_orchestrator_primitives.py` for overlapping function names in a targeted helper set and wires the new rule into the policy-suite aggregation and hashing as `server_orchestrator_helper_duplicates`.
- Extended tests: added parity assertions in `tests/gabion/server/server_orchestrator_primitive_parity_cases.py` (phase-timeline path/header parity, resume-cache verdict parity, and alias identity checks) and extended `tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py` to validate the new duplicate-helper rule; updated `out/test_evidence.json` to reflect test additions/line shifts.

### Testing

- Ran the workflow policy checks with `mise exec -- python -m scripts.policy.policy_check --workflows` and `PYTHONPATH=src mise exec -- python -m scripts.policy.policy_check --ambiguity-contract`, both succeeded.
- Ran the focused pytest suites and they passed: `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/server/server_orchestrator_primitive_parity_cases.py` (passed) and `PYTHONPATH=src mise exec -- python -m pytest -o addopts='' tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py` (passed).
- Regenerated test-evidence with `PYTHONPATH=src mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97ade525c8324ada459a1e66687b1)