### PR TITLE
Refactor governance audit wiring; extract consolidation parsers and thin entrypoint

### DIFF
--- a/src/gabion_governance/consolidation_audit/__init__.py
+++ b/src/gabion_governance/consolidation_audit/__init__.py
@@ -1,0 +1,3 @@
+from .parser import parse_lint_entry, parse_surface_line, parse_surfaces
+
+__all__ = ["parse_lint_entry", "parse_surface_line", "parse_surfaces"]

--- a/src/gabion_governance/consolidation_audit/contracts.py
+++ b/src/gabion_governance/consolidation_audit/contracts.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SurfaceParseResult:
+    path: str
+    qual: str
+    params: tuple[str, ...]
+    meta: str

--- a/src/gabion_governance/consolidation_audit/parser.py
+++ b/src/gabion_governance/consolidation_audit/parser.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from gabion_governance.compliance_render.decision_contracts import DecisionSurface, LintEntry
+
+from .contracts import SurfaceParseResult
+
+PARAM_RE = re.compile(r"param '([^']+)'\s*\(")
+LINT_ENTRY_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$")
+DECISION_RE = re.compile(
+    r"^(?P<path>[^:]+):(?P<qual>\S+) decision surface params: (?P<params>.+) \((?P<meta>[^)]+)\)$"
+)
+VALUE_DECISION_RE = re.compile(
+    r"^(?P<path>[^:]+):(?P<qual>\S+) value-encoded decision params: (?P<params>.+) \((?P<meta>[^)]+)\)$"
+)
+
+
+def parse_lint_entry(line: str) -> LintEntry | None:
+    match = LINT_ENTRY_RE.match(line.strip())
+    if not match:
+        return None
+    try:
+        line_no = int(match.group("line"))
+        col_no = int(match.group("col"))
+    except ValueError:
+        return None
+    remainder = match.group("rest")
+    remainder_parts = remainder.split(" ", 1) if remainder else []
+    if not remainder_parts:
+        return None
+    code = remainder_parts[0]
+    message = remainder_parts[1] if len(remainder_parts) > 1 else ""
+    param_match = PARAM_RE.search(message)
+    return LintEntry(
+        path=match.group("path"),
+        line=line_no,
+        col=col_no,
+        code=code,
+        message=message,
+        param=param_match.group(1) if param_match else None,
+    )
+
+
+def parse_surface_line(line: str, *, value_encoded: bool) -> SurfaceParseResult | None:
+    pattern = VALUE_DECISION_RE if value_encoded else DECISION_RE
+    match = pattern.match(line.strip())
+    if not match:
+        return None
+    params = tuple(p.strip() for p in match.group("params").split(",") if p.strip())
+    return SurfaceParseResult(
+        path=match.group("path"),
+        qual=match.group("qual"),
+        params=params,
+        meta=match.group("meta"),
+    )
+
+
+def parse_surfaces(lines: Iterable[str], *, value_encoded: bool) -> list[DecisionSurface]:
+    parsed: list[DecisionSurface] = []
+    for line in lines:
+        outcome = parse_surface_line(line, value_encoded=value_encoded)
+        if outcome is None:
+            continue
+        parsed.append(
+            DecisionSurface(
+                path=outcome.path,
+                qual=outcome.qual,
+                params=outcome.params,
+                meta=outcome.meta,
+            )
+        )
+    return parsed

--- a/src/gabion_governance/docflow_command.py
+++ b/src/gabion_governance/docflow_command.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from gabion_governance import governance_audit_impl as _impl
-
-run_docflow_cli = _impl.run_docflow_cli
+from gabion_governance.governance_entrypoint import run_docflow_cli
 
 __all__ = ["run_docflow_cli"]

--- a/src/gabion_governance/governance_audit_impl.py
+++ b/src/gabion_governance/governance_audit_impl.py
@@ -35,6 +35,8 @@ from gabion_governance.compliance_render.decision_contracts import (
     DecisionSurface,
     LintEntry,
 )
+from gabion_governance.consolidation_audit import parse_lint_entry as _parse_lint_entry
+from gabion_governance.consolidation_audit import parse_surface_line
 from gabion_governance.docflow_audit import (
     AgentDirective,
     Doc,
@@ -148,18 +150,6 @@ MAP_FIELDS = {
     "doc_section_reviews",
 }
 
-# --- Lint parsing helpers ---
-
-PARAM_RE = re.compile(r"param '([^']+)'\s*\(")
-
-# --- Consolidation regex helpers ---
-
-DECISION_RE = re.compile(
-    r"^(?P<path>[^:]+):(?P<qual>\S+) decision surface params: (?P<params>.+) \((?P<meta>[^)]+)\)$"
-)
-VALUE_DECISION_RE = re.compile(
-    r"^(?P<path>[^:]+):(?P<qual>\S+) value-encoded decision params: (?P<params>.+) \((?P<meta>[^)]+)\)$"
-)
 FOREST_FALLBACK_MARKER = "FOREST_FALLBACK_USED"
 FOREST_FALLBACK_WARNING_CLASS = "consolidation.forest_fallback"
 CONSOLIDATION_SOURCE_FOREST_NATIVE = "forest-native"
@@ -225,36 +215,6 @@ def _load_consolidation_config(root: Path) -> ConsolidationConfig:
         min_files=_coerce_int("min_files", 2),
         max_examples=_coerce_int("max_examples", 5),
         require_forest=_coerce_bool("require_forest", True),
-    )
-
-
-def _parse_lint_entry(line: str) -> LintEntry | None:
-    match = re.match(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<rest>.*)$", line.strip())
-    if not match:
-        return None
-    path = match.group("path")
-    try:
-        line_no = int(match.group("line"))
-        col_no = int(match.group("col"))
-    except ValueError:
-        return None
-    remainder = match.group("rest")
-    remainder_parts = remainder.split(" ", 1) if remainder else []
-    if not remainder_parts:
-        return None
-    code = remainder_parts[0]
-    message = remainder_parts[1] if len(remainder_parts) > 1 else ""
-    param = None
-    param_match = PARAM_RE.search(message)
-    if param_match:
-        param = param_match.group(1)
-    return LintEntry(
-        path=path,
-        line=line_no,
-        col=col_no,
-        code=code,
-        message=message,
-        param=param,
     )
 
 
@@ -4077,19 +4037,17 @@ def _decision_tier_candidates(lint_path: Path, *, tier: int, output_format: str)
 
 def _parse_surfaces(lines: Iterable[str], *, value_encoded: bool) -> list[DecisionSurface]:
     surfaces: list[DecisionSurface] = []
-    pattern = VALUE_DECISION_RE if value_encoded else DECISION_RE
     for line in lines:
         check_deadline()
-        match = pattern.match(line.strip())
-        if not match:
+        outcome = parse_surface_line(line, value_encoded=value_encoded)
+        if outcome is None:
             continue
-        params = [p.strip() for p in match.group("params").split(",") if p.strip()]
         surfaces.append(
             DecisionSurface(
-                path=match.group("path"),
-                qual=match.group("qual"),
-                params=tuple(params),
-                meta=match.group("meta"),
+                path=outcome.path,
+                qual=outcome.qual,
+                params=outcome.params,
+                meta=outcome.meta,
             )
         )
     return surfaces

--- a/src/gabion_governance/governance_entrypoint.py
+++ b/src/gabion_governance/governance_entrypoint.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+
+from gabion.analysis.foundation.timeout_context import check_deadline
+from gabion.tooling.runtime.deadline_runtime import deadline_scope_from_ticks
+
+from gabion_governance import governance_audit_impl as impl
+
+
+def parse_single_command_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gabion governance audit")
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+    impl._add_docflow_args(subparsers)
+    impl._add_decision_tier_args(subparsers)
+    impl._add_consolidation_args(subparsers)
+    impl._add_lint_summary_args(subparsers)
+    impl._add_sppf_graph_args(subparsers)
+    impl._add_status_consistency_args(subparsers)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    with deadline_scope_from_ticks(
+        budget=impl._DEFAULT_AUDIT_TIMEOUT_BUDGET,
+        gas_limit=impl._audit_gas_limit(),
+    ):
+        args = parse_single_command_args(impl._coerce_argv(argv))
+        check_deadline()
+        cmd = args.cmd
+        if cmd == "docflow":
+            return impl._docflow_command(args)
+        if cmd == "decision-tiers":
+            return impl._decision_tiers_command(args)
+        if cmd == "consolidation":
+            return impl._consolidation_command(args)
+        if cmd == "lint-summary":
+            return impl._lint_summary_command(args)
+        if cmd == "sppf-graph":
+            return impl._sppf_graph_command(args)
+        if cmd == "status-consistency":
+            return impl._status_consistency_command(args)
+        return 2
+
+
+def run_docflow_cli(argv: list[str] | None = None) -> int:
+    args = ["docflow", *(argv or [])]
+    return main(args)
+
+
+def run_decision_tiers_cli(argv: list[str] | None = None) -> int:
+    args = ["decision-tiers", *(argv or [])]
+    return main(args)
+
+
+def run_consolidation_cli(argv: list[str] | None = None) -> int:
+    args = ["consolidation", *(argv or [])]
+    return main(args)
+
+
+def run_lint_summary_cli(argv: list[str] | None = None) -> int:
+    args = ["lint-summary", *(argv or [])]
+    return main(args)
+
+
+def run_sppf_graph_cli(argv: list[str] | None = None) -> int:
+    args = ["sppf-graph", *(argv or [])]
+    return main(args)
+
+
+def run_status_consistency_cli(argv: list[str] | None = None) -> int:
+    args = ["status-consistency", *(argv or [])]
+    return main(args)

--- a/src/gabion_governance/sppf_graph_command.py
+++ b/src/gabion_governance/sppf_graph_command.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from gabion_governance import governance_audit_impl as _impl
-
-run_sppf_graph_cli = _impl.run_sppf_graph_cli
+from gabion_governance.governance_entrypoint import run_sppf_graph_cli
 
 __all__ = ["run_sppf_graph_cli"]

--- a/tests/gabion/tooling/governance/test_consolidation_parser.py
+++ b/tests/gabion/tooling/governance/test_consolidation_parser.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from gabion_governance.consolidation_audit.parser import parse_lint_entry, parse_surface_line
+
+
+def test_parse_surface_line_decision() -> None:
+    line = "src/x.py:foo decision surface params: flag, mode (tier=2)"
+    parsed = parse_surface_line(line, value_encoded=False)
+    assert parsed is not None
+    assert parsed.path == "src/x.py"
+    assert parsed.qual == "foo"
+    assert parsed.params == ("flag", "mode")
+    assert parsed.meta == "tier=2"
+
+
+def test_parse_surface_line_value_encoded() -> None:
+    line = "src/x.py:foo value-encoded decision params: encoded_flag (tier=2)"
+    parsed = parse_surface_line(line, value_encoded=True)
+    assert parsed is not None
+    assert parsed.params == ("encoded_flag",)
+
+
+def test_parse_surface_line_rejects_malformed() -> None:
+    assert parse_surface_line("src/x.py:foo params: x", value_encoded=False) is None
+
+
+def test_parse_lint_entry_extracts_param() -> None:
+    line = "src/x.py:10:2: GABION_DECISION_SURFACE param 'flag' (decision surface)"
+    parsed = parse_lint_entry(line)
+    assert parsed is not None
+    assert parsed.code == "GABION_DECISION_SURFACE"
+    assert parsed.param == "flag"
+
+
+def test_parse_lint_entry_rejects_non_lint_shape() -> None:
+    assert parse_lint_entry("not-a-lint-line") is None

--- a/tests/gabion/tooling/governance/test_governance_entrypoint_structure.py
+++ b/tests/gabion/tooling/governance/test_governance_entrypoint_structure.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_governance_entrypoint_remains_thin() -> None:
+    entrypoint = Path("src/gabion_governance/governance_entrypoint.py")
+    lines = entrypoint.read_text(encoding="utf-8").splitlines()
+    assert len(lines) <= 140


### PR DESCRIPTION
### Motivation
- Reduce the size and regex/parse surface area of the monolithic `governance_audit_impl.py` by moving parsing and CLI wiring into focused domain modules. 
- Introduce explicit typed carriers for parsed surfaces so inter-module communication uses structured dataclasses instead of ad-hoc tuples/dicts.
- Prevent future business-logic creep in the CLI entrypoint by keeping a single thin wiring module and adding an enforcement test.

### Description
- Extracted a new consolidation parsing package `src/gabion_governance/consolidation_audit/` with a typed carrier `SurfaceParseResult` and parser helpers: `parse_lint_entry`, `parse_surface_line`, and `parse_surfaces`.
- Replaced inline regex parsing in `src/gabion_governance/governance_audit_impl.py` with imports from the new parser (`_parse_lint_entry`, `parse_surface_line`) and updated `_parse_surfaces` to delegate to the parser.
- Added a thin runtime/CLI entrypoint `src/gabion_governance/governance_entrypoint.py` that wires subcommands and delegates to existing domain command handlers with no business logic.
- Migrated command wrapper modules (`docflow_command.py`, `sppf_graph_command.py`, `consolidation_command.py`, `decision_tiers_command.py`, `lint_summary_command.py`, `status_consistency_command.py`) to import CLI runners from the thin entrypoint.
- Added unit tests for the new parser (`tests/gabion/tooling/governance/test_consolidation_parser.py`) covering representative and malformed lines, and added an organization test (`tests/gabion/tooling/governance/test_governance_entrypoint_structure.py`) that enforces the entrypoint remains small (<=140 lines).
- Updated the test evidence output `out/test_evidence.json` to reflect the new test surface.

### Testing
- Ran the repository policy checks: `PYTHONPATH=src:. mise exec -- python scripts/policy/policy_check.py --workflows` (succeeded) and `--ambiguity-contract` (succeeded).
- Ran targeted pytest suites: `PYTHONPATH=src:. mise exec -- python -m pytest -c /dev/null tests/gabion/tooling/governance/test_consolidation_parser.py tests/gabion/tooling/governance/test_governance_entrypoint_structure.py tests/gabion/tooling/governance/test_governance_audit_adapter.py` (all passed).
- Ran the CLI integration tests: `PYTHONPATH=src:. mise exec -- python -m pytest -c /dev/null tests/gabion/cli/cli_helpers_cases.py` (all tests in that module passed).
- Ran the test-evidence extraction: `PYTHONPATH=src:. mise exec -- python scripts/misc/extract_test_evidence.py --out out/test_evidence.json` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a981396b1c83249fc10b9602601365)