### PR TITLE
Refactor check aux command building around typed spec/payload carriers

### DIFF
--- a/src/gabion/cli_support/check/check_command_runtime.py
+++ b/src/gabion/cli_support/check/check_command_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping
 
@@ -37,6 +38,83 @@ DeadlineLoopIterFn = Callable[[list[str]], list[str] | tuple[str, ...] | object]
 RawProfileUnsupportedFlagsFn = Callable[[typer.Context], list[str]]
 CheckRawProfileArgsFn = Callable[..., list[str]]
 RunDataflowRawArgvFn = Callable[[list[str]], None]
+
+
+@dataclass(frozen=True)
+class CheckRunForwardingPayload:
+    ctx: typer.Context
+    paths: list[Path] | None
+    report: Path | None
+    root: Path
+    config: Path | None
+    decision_snapshot: Path | None
+    allow_external: bool | None
+    strictness: object
+    analysis_budget_checks: int | None
+    aspf_state_json: Path | None
+    aspf_import_state: list[Path] | None
+    aspf_delta_jsonl: Path | None
+    aux_operation: CheckAuxOperation
+
+    def validate(self) -> None:
+        if not self.aux_operation.domain:
+            raise typer.BadParameter("aux operation domain is required")
+        if not self.aux_operation.action:
+            raise typer.BadParameter("aux operation action is required")
+
+
+@dataclass(frozen=True)
+class CheckAuxRuntimePayload:
+    forwarding: CheckRunForwardingPayload
+
+    def validate(self) -> None:
+        self.forwarding.validate()
+
+    def run(
+        self,
+        *,
+        run_check_command_fn: RunCheckCommandFn,
+        default_check_artifact_flags_fn: DefaultCheckArtifactFlagsFn,
+        default_check_delta_options_fn: DefaultCheckDeltaOptionsFn,
+        dataflow_filter_bundle_ctor: DataflowFilterBundleCtor,
+        gate_none: object,
+        lint_mode_none: object,
+    ) -> None:
+        self.validate()
+        strictness_value = getattr(self.forwarding.strictness, "value", self.forwarding.strictness)
+        run_check_command_fn(
+            ctx=self.forwarding.ctx,
+            paths=self.forwarding.paths,
+            report=self.forwarding.report,
+            root=self.forwarding.root,
+            config=self.forwarding.config,
+            baseline=None,
+            baseline_write=False,
+            decision_snapshot=self.forwarding.decision_snapshot,
+            artifact_flags=default_check_artifact_flags_fn(),
+            delta_options=default_check_delta_options_fn(),
+            exclude=None,
+            filter_bundle=dataflow_filter_bundle_ctor(
+                ignore_params_csv=None,
+                transparent_decorators_csv=None,
+            ),
+            allow_external=self.forwarding.allow_external,
+            strictness=str(strictness_value),
+            analysis_budget_checks=self.forwarding.analysis_budget_checks,
+            gate=gate_none,
+            lint_mode=lint_mode_none,
+            lint_jsonl_out=None,
+            lint_sarif_out=None,
+            aspf_trace_json=None,
+            aspf_import_trace=None,
+            aspf_equivalence_against=None,
+            aspf_opportunities_json=None,
+            aspf_state_json=self.forwarding.aspf_state_json,
+            aspf_import_state=self.forwarding.aspf_import_state,
+            aspf_delta_jsonl=self.forwarding.aspf_delta_jsonl,
+            aspf_semantic_surface=None,
+            aux_operation=self.forwarding.aux_operation,
+        )
 
 
 def run_check_command(
@@ -213,47 +291,37 @@ def run_check_aux_operation(
     gate_none: object,
     lint_mode_none: object,
 ) -> None:
-    strictness_value = getattr(strictness, "value", strictness)
-    aux_operation = CheckAuxOperation(
-        domain=domain,
-        action=action,
-        baseline_path=baseline,
-        state_in_path=state_in,
-        out_json=out_json,
-        out_md=out_md,
+    payload = CheckAuxRuntimePayload(
+        forwarding=CheckRunForwardingPayload(
+            ctx=ctx,
+            paths=paths,
+            report=report,
+            root=root,
+            config=config,
+            decision_snapshot=decision_snapshot,
+            allow_external=allow_external,
+            strictness=strictness,
+            analysis_budget_checks=analysis_budget_checks,
+            aspf_state_json=aspf_state_json,
+            aspf_import_state=aspf_import_state,
+            aspf_delta_jsonl=aspf_delta_jsonl,
+            aux_operation=CheckAuxOperation(
+                domain=domain,
+                action=action,
+                baseline_path=baseline,
+                state_in_path=state_in,
+                out_json=out_json,
+                out_md=out_md,
+            ),
+        )
     )
-    run_check_command_fn(
-        ctx=ctx,
-        paths=paths,
-        report=report,
-        root=root,
-        config=config,
-        baseline=None,
-        baseline_write=False,
-        decision_snapshot=decision_snapshot,
-        artifact_flags=default_check_artifact_flags_fn(),
-        delta_options=default_check_delta_options_fn(),
-        exclude=None,
-        filter_bundle=dataflow_filter_bundle_ctor(
-            ignore_params_csv=None,
-            transparent_decorators_csv=None,
-        ),
-        allow_external=allow_external,
-        strictness=str(strictness_value),
-        analysis_budget_checks=analysis_budget_checks,
-        gate=gate_none,
-        lint_mode=lint_mode_none,
-        lint_jsonl_out=None,
-        lint_sarif_out=None,
-        aspf_trace_json=None,
-        aspf_import_trace=None,
-        aspf_equivalence_against=None,
-        aspf_opportunities_json=None,
-        aspf_state_json=aspf_state_json,
-        aspf_import_state=aspf_import_state,
-        aspf_delta_jsonl=aspf_delta_jsonl,
-        aspf_semantic_surface=None,
-        aux_operation=aux_operation,
+    payload.run(
+        run_check_command_fn=run_check_command_fn,
+        default_check_artifact_flags_fn=default_check_artifact_flags_fn,
+        default_check_delta_options_fn=default_check_delta_options_fn,
+        dataflow_filter_bundle_ctor=dataflow_filter_bundle_ctor,
+        gate_none=gate_none,
+        lint_mode_none=lint_mode_none,
     )
 
 

--- a/src/gabion/cli_support/check/check_commands.py
+++ b/src/gabion/cli_support/check/check_commands.py
@@ -22,12 +22,94 @@ class CheckAuxCommandRegistration:
     action: str
     option_profile: "CheckAuxOptionProfile"
 
+    @property
+    def identity(self) -> str:
+        return f"{self.domain}:{self.action}"
+
 
 @dataclass(frozen=True)
 class CheckAuxOptionProfile:
     name: str
     baseline_required: bool
     out_md_allowed: bool
+
+
+@dataclass(frozen=True)
+class CheckAuxCommandSpec:
+    registration: CheckAuxCommandRegistration
+
+    def validate(self) -> None:
+        profile = self.registration.option_profile
+        if profile.baseline_required and self.registration.action not in {"delta", "baseline-write"}:
+            raise typer.BadParameter("baseline_required profile only supports delta/baseline-write actions")
+        if not profile.out_md_allowed and self.registration.action == "report":
+            raise typer.BadParameter("report actions require out_md_allowed profile")
+
+    @property
+    def option_profile(self) -> CheckAuxOptionProfile:
+        return self.registration.option_profile
+
+    @property
+    def domain(self) -> str:
+        return self.registration.domain
+
+    @property
+    def action(self) -> str:
+        return self.registration.action
+
+    @property
+    def identity(self) -> str:
+        return self.registration.identity
+
+
+@dataclass(frozen=True)
+class CheckAuxOperationPayload:
+    ctx: typer.Context
+    spec: CheckAuxCommandSpec
+    paths: list[Path]
+    root: Path
+    config: Path | None
+    strictness: object
+    allow_external: bool | None
+    baseline: Path | None
+    state_in: Path | None
+    out_json: Path | None
+    out_md: Path | None
+    report: Path | None
+    decision_snapshot: Path | None
+    analysis_budget_checks: int | None
+    aspf_state_json: Path | None
+    aspf_import_state: list[Path] | None
+
+    def validate(self) -> None:
+        self.spec.validate()
+        profile = self.spec.option_profile
+        if profile.baseline_required and self.baseline is None:
+            raise typer.BadParameter("--baseline is required for this command profile")
+        if not profile.out_md_allowed and self.out_md is not None:
+            raise typer.BadParameter("--out-md is not allowed for this command profile")
+
+    def to_runtime_kwargs(self) -> dict[str, object]:
+        self.validate()
+        return {
+            "ctx": self.ctx,
+            "domain": self.spec.domain,
+            "action": self.spec.action,
+            "paths": self.paths,
+            "root": self.root,
+            "config": self.config,
+            "strictness": self.strictness,
+            "allow_external": self.allow_external,
+            "baseline": self.baseline,
+            "state_in": self.state_in,
+            "out_json": self.out_json,
+            "out_md": self.out_md,
+            "report": self.report,
+            "decision_snapshot": self.decision_snapshot,
+            "analysis_budget_checks": self.analysis_budget_checks,
+            "aspf_state_json": self.aspf_state_json,
+            "aspf_import_state": self.aspf_import_state,
+        }
 
 
 CHECK_AUX_OPTION_PROFILE_REPORT = CheckAuxOptionProfile(
@@ -75,26 +157,24 @@ def register_check_aux_commands(
 ) -> dict[str, Callable[..., None]]:
     commands: dict[str, Callable[..., None]] = {}
     for registration in command_registrations:
+        spec = CheckAuxCommandSpec(registration=registration)
+        spec.validate()
         command_app = command_domains[registration.domain]
         command = _build_check_aux_command(
             command_app=command_app,
             command_name=registration.action,
-            domain=registration.domain,
-            action=registration.action,
-            option_profile=registration.option_profile,
+            spec=spec,
             check_strictness_mode=check_strictness_mode,
             run_check_aux_operation_fn=run_check_aux_operation_fn,
         )
-        commands[f"{registration.domain}:{registration.action}"] = command
+        commands[spec.identity] = command
     return commands
 
 
-def _build_check_aux_operation_kwargs(
+def _build_check_aux_operation_payload(
     *,
-    option_profile: CheckAuxOptionProfile,
     ctx: typer.Context,
-    domain: str,
-    action: str,
+    spec: CheckAuxCommandSpec,
     paths: list[Path],
     root: Path,
     config: Path | None,
@@ -109,97 +189,38 @@ def _build_check_aux_operation_kwargs(
     analysis_budget_checks: int | None,
     aspf_state_json: Path | None,
     aspf_import_state: list[Path] | None,
-) -> dict[str, object]:
-    if option_profile.baseline_required and baseline is None:
-        raise typer.BadParameter("--baseline is required for this command profile")
-    return {
-        "ctx": ctx,
-        "domain": domain,
-        "action": action,
-        "paths": paths,
-        "root": root,
-        "config": config,
-        "strictness": strictness,
-        "allow_external": allow_external,
-        "baseline": baseline,
-        "state_in": state_in,
-        "out_json": out_json,
-        "out_md": out_md if option_profile.out_md_allowed else None,
-        "report": report,
-        "decision_snapshot": decision_snapshot,
-        "analysis_budget_checks": analysis_budget_checks,
-        "aspf_state_json": aspf_state_json,
-        "aspf_import_state": aspf_import_state,
-    }
+) -> CheckAuxOperationPayload:
+    payload = CheckAuxOperationPayload(
+        ctx=ctx,
+        spec=spec,
+        paths=paths,
+        root=root,
+        config=config,
+        strictness=strictness,
+        allow_external=allow_external,
+        baseline=baseline,
+        state_in=state_in,
+        out_json=out_json,
+        out_md=out_md,
+        report=report,
+        decision_snapshot=decision_snapshot,
+        analysis_budget_checks=analysis_budget_checks,
+        aspf_state_json=aspf_state_json,
+        aspf_import_state=aspf_import_state,
+    )
+    payload.validate()
+    return payload
 
 
 def _build_check_aux_command(
     *,
     command_app: typer.Typer,
     command_name: str,
-    domain: str,
-    action: str,
-    option_profile: CheckAuxOptionProfile,
+    spec: CheckAuxCommandSpec,
     check_strictness_mode: type,
     run_check_aux_operation_fn: RunCheckAuxOperationFn,
 ) -> Callable[..., None]:
-    if option_profile.out_md_allowed:
-
-        @command_app.command(command_name)
-        def command(
-            ctx: typer.Context,
-            paths: list[Path] = typer.Argument(None),
-            root: Path = typer.Option(Path("."), "--root"),
-            config: Path | None = typer.Option(None, "--config"),
-            strictness: check_strictness_mode = typer.Option(check_strictness_mode.high, "--strictness"),
-            allow_external: bool | None = typer.Option(
-                None, "--allow-external/--no-allow-external"
-            ),
-            baseline: Path | None = typer.Option(
-                ..., "--baseline"
-            )
-            if option_profile.baseline_required
-            else typer.Option(None, "--baseline"),
-            state_in: Path | None = typer.Option(None, "--state-in"),
-            out_json: Path | None = typer.Option(None, "--out-json"),
-            out_md: Path | None = typer.Option(None, "--out-md"),
-            report: Path | None = typer.Option(None, "--report"),
-            decision_snapshot: Path | None = typer.Option(None, "--decision-snapshot"),
-            analysis_budget_checks: int | None = typer.Option(
-                None,
-                "--analysis-budget-checks",
-                min=1,
-            ),
-            aspf_state_json: Path | None = typer.Option(None, "--aspf-state-json"),
-            aspf_import_state: list[Path] | None = typer.Option(
-                None,
-                "--aspf-import-state",
-            ),
-        ) -> None:
-            run_check_aux_operation_fn(
-                **_build_check_aux_operation_kwargs(
-                    option_profile=option_profile,
-                    ctx=ctx,
-                    domain=domain,
-                    action=action,
-                    paths=paths,
-                    root=root,
-                    config=config,
-                    strictness=strictness,
-                    allow_external=allow_external,
-                    baseline=baseline,
-                    state_in=state_in,
-                    out_json=out_json,
-                    out_md=out_md,
-                    report=report,
-                    decision_snapshot=decision_snapshot,
-                    analysis_budget_checks=analysis_budget_checks,
-                    aspf_state_json=aspf_state_json,
-                    aspf_import_state=aspf_import_state,
-                )
-            )
-
-        return command
+    option_profile = spec.option_profile
 
     @command_app.command(command_name)
     def command(
@@ -225,33 +246,33 @@ def _build_check_aux_command(
             "--analysis-budget-checks",
             min=1,
         ),
+        out_md: Path | None = typer.Option(None, "--out-md", hidden=not option_profile.out_md_allowed),
         aspf_state_json: Path | None = typer.Option(None, "--aspf-state-json"),
         aspf_import_state: list[Path] | None = typer.Option(
             None,
             "--aspf-import-state",
         ),
     ) -> None:
+        payload = _build_check_aux_operation_payload(
+            ctx=ctx,
+            spec=spec,
+            paths=paths,
+            root=root,
+            config=config,
+            strictness=strictness,
+            allow_external=allow_external,
+            baseline=baseline,
+            state_in=state_in,
+            out_json=out_json,
+            out_md=out_md,
+            report=report,
+            decision_snapshot=decision_snapshot,
+            analysis_budget_checks=analysis_budget_checks,
+            aspf_state_json=aspf_state_json,
+            aspf_import_state=aspf_import_state,
+        )
         run_check_aux_operation_fn(
-            **_build_check_aux_operation_kwargs(
-                option_profile=option_profile,
-                ctx=ctx,
-                domain=domain,
-                action=action,
-                paths=paths,
-                root=root,
-                config=config,
-                strictness=strictness,
-                allow_external=allow_external,
-                baseline=baseline,
-                state_in=state_in,
-                out_json=out_json,
-                out_md=None,
-                report=report,
-                decision_snapshot=decision_snapshot,
-                analysis_budget_checks=analysis_budget_checks,
-                aspf_state_json=aspf_state_json,
-                aspf_import_state=aspf_import_state,
-            )
+            **payload.to_runtime_kwargs()
         )
 
     return command

--- a/tests/gabion/cli/cli_commands_cases.py
+++ b/tests/gabion/cli/cli_commands_cases.py
@@ -752,6 +752,86 @@ def test_cli_refactor_protocol_emits_rewrite_plan_metadata(tmp_path: Path) -> No
     assert payload["rewrite_plans"][0]["kind"] == "AMBIENT_REWRITE"
 
 
+def test_check_aux_registration_matrix_matches_expected_identities() -> None:
+    expected = {
+        "obsolescence:report",
+        "obsolescence:state",
+        "obsolescence:delta",
+        "obsolescence:baseline-write",
+        "annotation-drift:report",
+        "annotation-drift:state",
+        "annotation-drift:delta",
+        "annotation-drift:baseline-write",
+        "ambiguity:state",
+        "ambiguity:delta",
+        "ambiguity:baseline-write",
+        "taint:state",
+        "taint:delta",
+        "taint:baseline-write",
+        "taint:lifecycle",
+    }
+    observed = {entry.identity for entry in check_commands.CHECK_AUX_COMMAND_REGISTRATIONS}
+    assert observed == expected
+
+
+def test_check_aux_command_spec_rejects_invalid_profile_mapping() -> None:
+    spec = check_commands.CheckAuxCommandSpec(
+        registration=check_commands.CheckAuxCommandRegistration(
+            domain="obsolescence",
+            action="report",
+            option_profile=check_commands.CHECK_AUX_OPTION_PROFILE_DELTA,
+        )
+    )
+    with pytest.raises(typer.BadParameter, match="baseline_required profile"):
+        spec.validate()
+
+
+def test_check_aux_profile_validation_errors() -> None:
+    runner = CliRunner()
+    app = typer.Typer()
+    apps = {
+        "obsolescence": typer.Typer(),
+        "annotation-drift": typer.Typer(),
+        "ambiguity": typer.Typer(),
+        "taint": typer.Typer(),
+    }
+    check_commands.register_check_aux_commands(
+        command_domains=apps,
+        check_strictness_mode=cli.CheckStrictnessMode,
+        run_check_aux_operation_fn=lambda **_kwargs: None,
+    )
+    for domain, domain_app in apps.items():
+        app.add_typer(domain_app, name=domain)
+
+    missing_baseline = runner.invoke(app, ["obsolescence", "delta", "sample.py"])
+    assert missing_baseline.exit_code != 0
+    assert "Missing option '--baseline'" in missing_baseline.output
+
+    out_md_disallowed = runner.invoke(
+        app,
+        ["taint", "state", "sample.py", "--out-md", "state.md"],
+    )
+    assert out_md_disallowed.exit_code != 0
+    assert "--out-md is not allowed for this command profile" in out_md_disallowed.output
+
+
+def test_check_aux_help_snapshot_representative_commands() -> None:
+    runner = CliRunner()
+    report_help = _invoke(runner, ["check", "obsolescence", "report", "--help"])
+    assert report_help.exit_code == 0
+    assert "--out-md" in report_help.output
+
+    state_help = _invoke(runner, ["check", "taint", "state", "--help"])
+    assert state_help.exit_code == 0
+    assert "--out-md" not in state_help.output
+    assert "--baseline" in state_help.output
+
+    delta_help = _invoke(runner, ["check", "annotation-drift", "delta", "--help"])
+    assert delta_help.exit_code == 0
+    assert "--baseline" in delta_help.output
+    assert "[required]" in delta_help.output
+
+
 def test_register_check_aux_commands_uses_registration_table() -> None:
     observed: list[tuple[str, str]] = []
 


### PR DESCRIPTION
### Motivation
- Consolidate repeated command-builder branches and centralize profile validation for check aux subcommands to reduce duplication and make decision surfaces explicit. 
- Enforce dataflow-bundle reification guidance by promoting cross-boundary option bundles into typed carriers (dataclasses) and validate them at the boundary. 
- Mirror existing `check_contract` decision-protocol patterns by returning structural/validated payloads instead of ad-hoc kwargs and sentinel branches. 

### Description
- Introduced typed spec and payload carriers in `src/gabion/cli_support/check/check_commands.py`: `CheckAuxCommandSpec` models `domain:action` identity and profile constraints, and `CheckAuxOperationPayload` centralizes validated aux runtime inputs and `to_runtime_kwargs()` conversion. 
- Collapsed dual-command-definition paths into a single builder in `_build_check_aux_command`, hiding `--out-md` when disallowed and validating `--baseline`/`--out-md` semantics via `CheckAuxCommandSpec`/`CheckAuxOperationPayload`. 
- Replaced ad-hoc runtime forwarding kwargs with structured runtime carriers in `src/gabion/cli_support/check/check_command_runtime.py`: `CheckRunForwardingPayload` and `CheckAuxRuntimePayload` encapsulate forwarding state and expose a single `run()` dispatch to `run_check_command_fn`. 
- Removed `_build_check_aux_operation_kwargs` in favor of `_build_check_aux_operation_payload` which returns a validated `CheckAuxOperationPayload`. 
- Added targeted tests in `tests/gabion/cli/cli_commands_cases.py` covering the registration matrix (`domain:action` identities), invalid spec/profile mapping validation, profile runtime validation errors (missing `--baseline` and disallowed `--out-md`), and representative Typer help-output snapshots for `report/state/delta` commands. 
- Modified files: `src/gabion/cli_support/check/check_commands.py`, `src/gabion/cli_support/check/check_command_runtime.py`, and `tests/gabion/cli/cli_commands_cases.py`. 

### Testing
- Ran policy checks: `PYTHONPATH=.:src python scripts/policy/policy_check.py --workflows` succeeded. 
- Ran policy ambiguity contract check: `PYTHONPATH=.:src python scripts/policy/policy_check.py --ambiguity-contract` succeeded. 
- Ran targeted CLI tests: `PYTHONPATH=src python -m pytest -q -o addopts='' tests/gabion/cli/cli_commands_cases.py -k "check_aux"` passed (6 tests). 
- Verified command forwarding surface test: `PYTHONPATH=src python -m pytest -q -o addopts='' tests/gabion/cli/cli_check_surface_edges_cases.py -k "test_check_aux_subcommands_forward_domain_and_action"` passed (15 tests). 
- Note: running the entire `cli_commands_cases.py` in this environment exposed one unrelated, pre-existing LSP-dependent failure (`test_cli_check_and_legacy_dataflow_monolith`), which is unrelated to the aux-command refactor; targeted check-aux tests and surface coverage passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9814cd92c832486d993e6aa7eb89a)