### PR TITLE
Refactor CLI composition root helpers into shared services

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -11,7 +11,6 @@ from typing import Callable, Generator, List, Literal, Mapping, MutableMapping, 
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -40,9 +39,9 @@ from gabion.cli_support.shared.payload_builder import (
     build_dataflow_payload as _build_dataflow_payload_impl)
 from gabion.cli_support.shared import dataflow_runtime_common
 from gabion.cli_support.shared.output_emitters import (
-    emit_dataflow_result_outputs as _emit_dataflow_result_outputs_impl, is_stdout_target as _is_stdout_target_impl,
-    normalize_output_target as _normalize_output_target_impl, write_lint_sarif as _write_lint_sarif_impl,
-    write_text_to_target as _write_text_to_target_impl)
+    emit_dataflow_result_outputs as _emit_dataflow_result_outputs_impl, write_lint_sarif as _write_lint_sarif_impl)
+from gabion.cli_support.shared import output_targets as output_target_services
+from gabion.cli_support.shared import sppf_sync as sppf_sync_services
 from gabion.cli_support.shared import result_emitters
 from gabion.cli_support.shared.runtime_deps import (
     CliRuntimeDeps,
@@ -144,15 +143,6 @@ _DEFAULT_TIMEOUT_TICKS = 100
 _DEFAULT_TIMEOUT_TICK_NS = 1_000_000
 _DEFAULT_CHECK_REPORT_REL_PATH = path_policy.DEFAULT_CHECK_REPORT_REL_PATH
 _DEFAULT_STATUS_WATCH_ARTIFACT_ROOT = Path("artifacts/out/ci_watch")
-_SPPF_GH_REF_RE = re.compile(r"\bGH-(\d+)\b", re.IGNORECASE)
-_SPPF_KEYWORD_REF_RE = re.compile(
-    r"\b(?:Closes|Fixes|Resolves|Refs)\s+#(\d+)\b", re.IGNORECASE
-)
-_SPPF_PLACEHOLDER_ISSUE_BY_COMMIT: dict[str, str] = {
-    "683da24bd121524dc48c218d9771dfbdf181d6f0": "214",
-    "61c5d617e7b1d4e734a476adf69bc92c19f35e0f": "214",
-}
-
 _LSP_PROGRESS_NOTIFICATION_METHOD = progress_timeline.LSP_PROGRESS_NOTIFICATION_METHOD
 _LSP_PROGRESS_TOKEN_V2 = progress_timeline.LSP_PROGRESS_TOKEN_V2
 _LSP_PROGRESS_TOKEN = _LSP_PROGRESS_TOKEN_V2
@@ -194,11 +184,7 @@ class CheckStrictnessMode(str, Enum):
     low = "low"
 
 
-@dataclass(frozen=True)
-class SppfSyncCommitInfo:
-    sha: str
-    subject: str
-    body: str
+SppfSyncCommitInfo = sppf_sync_services.SppfSyncCommitInfo
 
 
 def _context_cli_deps(ctx: typer.Context) -> CliRuntimeDeps:
@@ -265,18 +251,14 @@ def _run_sppf_git(
     *,
     check_output_fn: Callable[..., str] = subprocess.check_output,
 ) -> str:
-    return check_output_fn(["git", *args], text=True).strip()
+    return sppf_sync_services.run_sppf_git(args, check_output_fn=check_output_fn)
 
 
 def _default_sppf_rev_range(
     *,
     run_sppf_git_fn: Callable[[list[str]], str] = _run_sppf_git,
 ) -> str:
-    try:
-        run_sppf_git_fn(["rev-parse", "origin/stage"])
-        return "origin/stage..HEAD"
-    except Exception:
-        return "HEAD~20..HEAD"
+    return sppf_sync_services.default_sppf_rev_range(run_sppf_git_fn=run_sppf_git_fn)
 
 
 def _collect_sppf_commits(
@@ -284,74 +266,37 @@ def _collect_sppf_commits(
     *,
     check_output_fn: Callable[..., str] = subprocess.check_output,
 ) -> list[SppfSyncCommitInfo]:
-    try:
-        raw = check_output_fn(
-            [
-                "git",
-                "log",
-                "--format=%H%x1f%s%x1f%B%x1e",
-                rev_range,
-            ],
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        raise typer.BadParameter(f"git log failed for range {rev_range}: {exc}") from exc
-
-    commits: list[SppfSyncCommitInfo] = []
-    for record in raw.split("\x1e"):
-        check_deadline()
-        if not record.strip():
-            continue
-        parts = record.split("\x1f")
-        if len(parts) < 3:
-            continue
-        sha, subject, body = parts[0].strip(), parts[1].strip(), parts[2].strip()
-        commits.append(SppfSyncCommitInfo(sha=sha, subject=subject, body=body))
-    return commits
+    return sppf_sync_services.collect_sppf_commits(
+        rev_range,
+        check_deadline_fn=check_deadline,
+        check_output_fn=check_output_fn,
+    )
 
 
 def _extract_sppf_issue_ids(text: str) -> set[str]:
-    def _canonical(issue_id: str) -> str:
-        normalized = issue_id.lstrip("0")
-        return normalized or "0"
-
-    issues = set(_canonical(match.group(1)) for match in _SPPF_GH_REF_RE.finditer(text))
-    issues.update(_canonical(match.group(1)) for match in _SPPF_KEYWORD_REF_RE.finditer(text))
-    return issues
+    return sppf_sync_services.extract_sppf_issue_ids(text)
 
 
 def _normalize_sppf_issue_ids_for_commit(
     commit: SppfSyncCommitInfo,
     issue_ids: set[str],
 ) -> set[str]:
-    normalized = set(issue_ids)
-    if "0" not in normalized:
-        return normalized
-    normalized.discard("0")
-    replacement = _SPPF_PLACEHOLDER_ISSUE_BY_COMMIT.get(commit.sha)
-    if replacement is not None:
-        normalized.add(replacement)
-    else:
-        normalized.add("0")
-    return normalized
+    return sppf_sync_services.normalize_sppf_issue_ids_for_commit(commit, issue_ids)
 
 
 def _issue_ids_from_sppf_commits(commits: list[SppfSyncCommitInfo]) -> set[str]:
-    issues: set[str] = set()
-    for commit in commits:
-        check_deadline()
-        commit_issue_ids = _extract_sppf_issue_ids(commit.subject)
-        commit_issue_ids.update(_extract_sppf_issue_ids(commit.body))
-        issues.update(_normalize_sppf_issue_ids_for_commit(commit, commit_issue_ids))
-    return issues
+    return sppf_sync_services.issue_ids_from_sppf_commits(
+        commits,
+        check_deadline_fn=check_deadline,
+    )
 
 
 def _build_sppf_comment(rev_range: str, commits: list[SppfSyncCommitInfo]) -> str:
-    lines = [f"SPPF sync from `{rev_range}`:"]
-    for commit in commits:
-        check_deadline()
-        lines.append(f"- {commit.sha[:8]} {commit.subject}")
-    return "\n".join(lines)
+    return sppf_sync_services.build_sppf_comment(
+        rev_range,
+        commits,
+        check_deadline_fn=check_deadline,
+    )
 
 
 def _run_sppf_gh(
@@ -360,10 +305,11 @@ def _run_sppf_gh(
     dry_run: bool,
     run_fn: Callable[..., object] = subprocess.run,
 ) -> None:
-    if dry_run:
-        typer.echo("DRY RUN: " + " ".join(["gh", *args]))
-        return
-    run_fn(["gh", *args], check=True)
+    return sppf_sync_services.run_sppf_gh(
+        args,
+        dry_run=dry_run,
+        run_fn=run_fn,
+    )
 
 
 def _run_sppf_sync(
@@ -377,31 +323,19 @@ def _run_sppf_sync(
     collect_sppf_commits_fn: Callable[[str], list[SppfSyncCommitInfo]] = _collect_sppf_commits,
     run_sppf_gh_fn: Callable[[list[str]], None] | None = None,
 ) -> int:
-    resolved_range = rev_range or default_rev_range_fn()
-    commits = collect_sppf_commits_fn(resolved_range)
-    if not commits:
-        typer.echo("No commits in range; nothing to sync.")
-        return 0
-
-    issue_ids = sort_once(
-        _issue_ids_from_sppf_commits(commits),
-        source="gabion.cli.sppf_sync.issue_ids",
+    return sppf_sync_services.run_sppf_sync(
+        rev_range=rev_range,
+        comment=comment,
+        close=close,
+        label=label,
+        dry_run=dry_run,
+        check_deadline_fn=check_deadline,
+        default_rev_range_fn=default_rev_range_fn,
+        collect_sppf_commits_fn=collect_sppf_commits_fn,
+        run_sppf_gh_fn=run_sppf_gh_fn,
+        sort_once_fn=sort_once,
+        echo_fn=typer.echo,
     )
-    if not issue_ids:
-        typer.echo("No issue references found in commit messages.")
-        return 0
-
-    summary_comment = _build_sppf_comment(resolved_range, commits)
-    gh_runner = run_sppf_gh_fn or (lambda args: _run_sppf_gh(args, dry_run=dry_run))
-    for issue_id in issue_ids:
-        check_deadline()
-        if close:
-            gh_runner(["issue", "close", issue_id, "-c", summary_comment])
-        elif comment:
-            gh_runner(["issue", "comment", issue_id, "-b", summary_comment])
-        if label:
-            gh_runner(["issue", "edit", issue_id, "--add-label", label])
-    return 0
 
 
 def run_sppf_sync_compat(
@@ -461,15 +395,18 @@ def _split_csv(value: str) -> list[str]:
 
 
 def _parse_lint_line(line: str) -> dict[str, object] | None:
-    return result_emitters.parse_lint_line_entry(line)
+    return output_target_services.parse_lint_line(line)
 
 
 def _collect_lint_entries(lines: list[str]) -> list[dict[str, object]]:
-    return result_emitters.collect_lint_entries(lines, check_deadline_fn=check_deadline)
+    return output_target_services.collect_lint_entries(
+        lines,
+        check_deadline_fn=check_deadline,
+    )
 
 
 def _is_stdout_target(target: object) -> bool:
-    return _is_stdout_target_impl(
+    return output_target_services.is_stdout_target(
         target,
         stdout_alias=_STDOUT_ALIAS,
         stdout_path=_STDOUT_PATH,
@@ -477,7 +414,7 @@ def _is_stdout_target(target: object) -> bool:
 
 
 def _normalize_output_target(target: str | Path) -> str:
-    return _normalize_output_target_impl(
+    return output_target_services.normalize_output_target(
         target,
         stdout_alias=_STDOUT_ALIAS,
         stdout_path=_STDOUT_PATH,
@@ -491,8 +428,8 @@ def _write_text_to_target(
     ensure_trailing_newline: bool = False,
     encoding: str = "utf-8",
 ) -> None:
-    _write_text_to_target_impl(
-        _normalize_output_target(target),
+    output_target_services.write_text_to_target(
+        target,
         payload,
         ensure_trailing_newline=ensure_trailing_newline,
         encoding=encoding,
@@ -502,10 +439,10 @@ def _write_text_to_target(
 
 
 def _emit_result_json_to_stdout(*, payload: object) -> None:
-    _write_text_to_target(
-        _STDOUT_PATH,
-        json.dumps(payload, indent=2, sort_keys=False),
-        ensure_trailing_newline=True,
+    output_target_services.emit_result_json_to_stdout(
+        payload=payload,
+        write_text_to_target_fn=_write_text_to_target,
+        stdout_path=_STDOUT_PATH,
     )
 
 

--- a/src/gabion/cli_support/shared/output_targets.py
+++ b/src/gabion/cli_support/shared/output_targets.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+import json
+
+from gabion.cli_support.shared import output_emitters, result_emitters
+
+
+def parse_lint_line(line: str) -> dict[str, object] | None:
+    return result_emitters.parse_lint_line_entry(line)
+
+
+def collect_lint_entries(
+    lines: list[str],
+    *,
+    check_deadline_fn: Callable[[], None],
+) -> list[dict[str, object]]:
+    return result_emitters.collect_lint_entries(lines, check_deadline_fn=check_deadline_fn)
+
+
+def is_stdout_target(
+    target: object,
+    *,
+    stdout_alias: str,
+    stdout_path: str,
+) -> bool:
+    return output_emitters.is_stdout_target(
+        target,
+        stdout_alias=stdout_alias,
+        stdout_path=stdout_path,
+    )
+
+
+def normalize_output_target(
+    target: str | Path,
+    *,
+    stdout_alias: str,
+    stdout_path: str,
+) -> str:
+    return output_emitters.normalize_output_target(
+        target,
+        stdout_alias=stdout_alias,
+        stdout_path=stdout_path,
+    )
+
+
+def write_text_to_target(
+    target: str | Path,
+    payload: str,
+    *,
+    ensure_trailing_newline: bool = False,
+    encoding: str = "utf-8",
+    stdout_alias: str,
+    stdout_path: str,
+) -> None:
+    output_emitters.write_text_to_target(
+        normalize_output_target(target, stdout_alias=stdout_alias, stdout_path=stdout_path),
+        payload,
+        ensure_trailing_newline=ensure_trailing_newline,
+        encoding=encoding,
+        stdout_alias=stdout_alias,
+        stdout_path=stdout_path,
+    )
+
+
+def emit_result_json_to_stdout(
+    *,
+    payload: object,
+    write_text_to_target_fn: Callable[..., None],
+    stdout_path: str,
+) -> None:
+    write_text_to_target_fn(
+        stdout_path,
+        json.dumps(payload, indent=2, sort_keys=False),
+        ensure_trailing_newline=True,
+    )

--- a/src/gabion/cli_support/shared/sppf_sync.py
+++ b/src/gabion/cli_support/shared/sppf_sync.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+import re
+import subprocess
+
+import typer
+
+from gabion.order_contract import sort_once
+
+
+_SPPF_GH_REF_RE = re.compile(r"\bGH-(\d+)\b", re.IGNORECASE)
+_SPPF_KEYWORD_REF_RE = re.compile(
+    r"\b(?:Closes|Fixes|Resolves|Refs)\s+#(\d+)\b", re.IGNORECASE
+)
+_SPPF_PLACEHOLDER_ISSUE_BY_COMMIT: dict[str, str] = {
+    "683da24bd121524dc48c218d9771dfbdf181d6f0": "214",
+    "61c5d617e7b1d4e734a476adf69bc92c19f35e0f": "214",
+}
+
+
+@dataclass(frozen=True)
+class SppfSyncCommitInfo:
+    sha: str
+    subject: str
+    body: str
+
+
+def run_sppf_git(
+    args: list[str],
+    *,
+    check_output_fn: Callable[..., str] = subprocess.check_output,
+) -> str:
+    return check_output_fn(["git", *args], text=True).strip()
+
+
+def default_sppf_rev_range(
+    *,
+    run_sppf_git_fn: Callable[[list[str]], str] = run_sppf_git,
+) -> str:
+    try:
+        run_sppf_git_fn(["rev-parse", "origin/stage"])
+        return "origin/stage..HEAD"
+    except Exception:
+        return "HEAD~20..HEAD"
+
+
+def collect_sppf_commits(
+    rev_range: str,
+    *,
+    check_deadline_fn: Callable[[], None],
+    check_output_fn: Callable[..., str] = subprocess.check_output,
+) -> list[SppfSyncCommitInfo]:
+    try:
+        raw = check_output_fn(
+            [
+                "git",
+                "log",
+                "--format=%H%x1f%s%x1f%B%x1e",
+                rev_range,
+            ],
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise typer.BadParameter(f"git log failed for range {rev_range}: {exc}") from exc
+
+    commits: list[SppfSyncCommitInfo] = []
+    for record in raw.split("\x1e"):
+        check_deadline_fn()
+        if not record.strip():
+            continue
+        parts = record.split("\x1f")
+        if len(parts) < 3:
+            continue
+        sha, subject, body = parts[0].strip(), parts[1].strip(), parts[2].strip()
+        commits.append(SppfSyncCommitInfo(sha=sha, subject=subject, body=body))
+    return commits
+
+
+def extract_sppf_issue_ids(text: str) -> set[str]:
+    def _canonical(issue_id: str) -> str:
+        normalized = issue_id.lstrip("0")
+        return normalized or "0"
+
+    issues = set(_canonical(match.group(1)) for match in _SPPF_GH_REF_RE.finditer(text))
+    issues.update(_canonical(match.group(1)) for match in _SPPF_KEYWORD_REF_RE.finditer(text))
+    return issues
+
+
+def normalize_sppf_issue_ids_for_commit(
+    commit: SppfSyncCommitInfo,
+    issue_ids: set[str],
+) -> set[str]:
+    normalized = set(issue_ids)
+    if "0" not in normalized:
+        return normalized
+    normalized.discard("0")
+    replacement = _SPPF_PLACEHOLDER_ISSUE_BY_COMMIT.get(commit.sha)
+    if replacement is not None:
+        normalized.add(replacement)
+    else:
+        normalized.add("0")
+    return normalized
+
+
+def issue_ids_from_sppf_commits(
+    commits: list[SppfSyncCommitInfo],
+    *,
+    check_deadline_fn: Callable[[], None],
+) -> set[str]:
+    issues: set[str] = set()
+    for commit in commits:
+        check_deadline_fn()
+        commit_issue_ids = extract_sppf_issue_ids(commit.subject)
+        commit_issue_ids.update(extract_sppf_issue_ids(commit.body))
+        issues.update(normalize_sppf_issue_ids_for_commit(commit, commit_issue_ids))
+    return issues
+
+
+def build_sppf_comment(rev_range: str, commits: list[SppfSyncCommitInfo], *, check_deadline_fn: Callable[[], None]) -> str:
+    lines = [f"SPPF sync from `{rev_range}`:"]
+    for commit in commits:
+        check_deadline_fn()
+        lines.append(f"- {commit.sha[:8]} {commit.subject}")
+    return "\n".join(lines)
+
+
+def run_sppf_gh(
+    args: list[str],
+    *,
+    dry_run: bool,
+    echo_fn: Callable[[str], None] = typer.echo,
+    run_fn: Callable[..., object] = subprocess.run,
+) -> None:
+    if dry_run:
+        echo_fn("DRY RUN: " + " ".join(["gh", *args]))
+        return
+    run_fn(["gh", *args], check=True)
+
+
+def run_sppf_sync(
+    *,
+    rev_range: str | None,
+    comment: bool,
+    close: bool,
+    label: str | None,
+    dry_run: bool,
+    check_deadline_fn: Callable[[], None],
+    default_rev_range_fn: Callable[[], str] = default_sppf_rev_range,
+    collect_sppf_commits_fn: Callable[[str], list[SppfSyncCommitInfo]],
+    run_sppf_gh_fn: Callable[[list[str]], None] | None = None,
+    sort_once_fn: Callable[..., list[str]] = sort_once,
+    echo_fn: Callable[[str], None] = typer.echo,
+) -> int:
+    resolved_range = rev_range or default_rev_range_fn()
+    commits = collect_sppf_commits_fn(resolved_range)
+    if not commits:
+        echo_fn("No commits in range; nothing to sync.")
+        return 0
+
+    issue_ids = sort_once_fn(
+        issue_ids_from_sppf_commits(commits, check_deadline_fn=check_deadline_fn),
+        source="gabion.cli.sppf_sync.issue_ids",
+    )
+    if not issue_ids:
+        echo_fn("No issue references found in commit messages.")
+        return 0
+
+    summary_comment = build_sppf_comment(
+        resolved_range,
+        commits,
+        check_deadline_fn=check_deadline_fn,
+    )
+    gh_runner = run_sppf_gh_fn or (
+        lambda args: run_sppf_gh(args, dry_run=dry_run, echo_fn=echo_fn)
+    )
+    for issue_id in issue_ids:
+        check_deadline_fn()
+        if close:
+            gh_runner(["issue", "close", issue_id, "-c", summary_comment])
+        elif comment:
+            gh_runner(["issue", "comment", issue_id, "-b", summary_comment])
+        if label:
+            gh_runner(["issue", "edit", issue_id, "--add-label", label])
+    return 0

--- a/tests/gabion/cli/test_cli_architecture_entrypoint.py
+++ b/tests/gabion/cli/test_cli_architecture_entrypoint.py
@@ -48,3 +48,17 @@ def test_cli_runtime_logic_resides_in_support_modules() -> None:
     assert "result_emitters." in source
     assert "check_runtime_facade." in source
     assert "context_cli_runtime_deps(" in source
+
+
+# gabion:evidence E:call_footprint::tests/test_cli_architecture_entrypoint.py::test_cli_composition_root_avoids_regex_business_logic
+def test_cli_composition_root_avoids_regex_business_logic() -> None:
+    tree = ast.parse(CLI_PATH.read_text(encoding="utf-8"), filename=str(CLI_PATH))
+    assert all(
+        not isinstance(node, ast.Import) or all(alias.name != "re" for alias in node.names)
+        for node in tree.body
+    )
+    assert all(
+        not isinstance(node, ast.ImportFrom) or node.module != "re"
+        for node in tree.body
+    )
+    assert "re.compile(" not in CLI_PATH.read_text(encoding="utf-8")

--- a/tests/gabion/cli_support/shared/test_output_targets.py
+++ b/tests/gabion/cli_support/shared/test_output_targets.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gabion.cli_support.shared import output_targets
+
+
+def test_output_target_normalization_handles_stdout_alias_and_path() -> None:
+    assert output_targets.is_stdout_target("-", stdout_alias="-", stdout_path="/dev/stdout")
+    assert output_targets.is_stdout_target(
+        Path("/dev/stdout"),
+        stdout_alias="-",
+        stdout_path="/dev/stdout",
+    )
+    assert (
+        output_targets.normalize_output_target("-", stdout_alias="-", stdout_path="/dev/stdout")
+        == "/dev/stdout"
+    )
+
+
+def test_write_text_to_target_overwrites_file_payload(tmp_path: Path) -> None:
+    target = tmp_path / "result.txt"
+    output_targets.write_text_to_target(
+        target,
+        "alpha",
+        stdout_alias="-",
+        stdout_path="/dev/stdout",
+    )
+    output_targets.write_text_to_target(
+        target,
+        "beta",
+        stdout_alias="-",
+        stdout_path="/dev/stdout",
+    )
+    assert target.read_text(encoding="utf-8") == "beta"
+
+
+def test_lint_parse_and_collection_adapters_delegate_shared_parser() -> None:
+    parsed = output_targets.parse_lint_line("pkg/mod.py:4:5: GAB001 message")
+    assert parsed is not None
+    assert parsed["path"] == "pkg/mod.py"
+    entries = output_targets.collect_lint_entries(
+        ["pkg/mod.py:4:5: GAB001 message", "broken"],
+        check_deadline_fn=lambda: None,
+    )
+    assert len(entries) == 1

--- a/tests/gabion/cli_support/shared/test_sppf_sync_services.py
+++ b/tests/gabion/cli_support/shared/test_sppf_sync_services.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from gabion.cli_support.shared import sppf_sync
+
+
+def test_extract_sppf_issue_ids_normalizes_patterns() -> None:
+    text = "GH-0011 Refs #12 closes #0013 and fixes #000"
+    assert sppf_sync.extract_sppf_issue_ids(text) == {"11", "12", "13", "0"}
+
+
+def test_normalize_sppf_issue_ids_for_commit_rewrites_placeholder_issue() -> None:
+    commit = sppf_sync.SppfSyncCommitInfo(
+        sha="683da24bd121524dc48c218d9771dfbdf181d6f0",
+        subject="GH-000",
+        body="",
+    )
+    assert sppf_sync.normalize_sppf_issue_ids_for_commit(commit, {"0", "99"}) == {
+        "214",
+        "99",
+    }
+
+
+def test_issue_ids_from_sppf_commits_applies_extraction_and_normalization() -> None:
+    commits = [
+        sppf_sync.SppfSyncCommitInfo(
+            sha="61c5d617e7b1d4e734a476adf69bc92c19f35e0f",
+            subject="Refs #000",
+            body="GH-12",
+        ),
+        sppf_sync.SppfSyncCommitInfo(sha="x", subject="GH-9", body=""),
+    ]
+    assert sppf_sync.issue_ids_from_sppf_commits(
+        commits,
+        check_deadline_fn=lambda: None,
+    ) == {"214", "12", "9"}


### PR DESCRIPTION
### Motivation

- Reduce non-registration responsibilities in `cli.py` by removing SPPF sync helpers, output-target normalization/writing, and lint-entry adapters into focused, testable modules. 
- Keep `cli.py` strictly as a composition root that wires command tree, dependency injection, and thin forwarding adapters. 
- Centralize parsing/regex/business logic so it can be unit-tested and audited outside the composition root. 

### Description

- Added `src/gabion/cli_support/shared/sppf_sync.py` implementing SPPF commit collection, issue-id extraction/normalization, GH invocation, and orchestration (`run_sppf_sync`, `collect_sppf_commits`, `extract_sppf_issue_ids`, etc.).
- Added `src/gabion/cli_support/shared/output_targets.py` to host output-target normalization, `write_text_to_target`, stdout handling adapters, and lint parse/collection adapters.
- Updated `src/gabion/cli.py` to be a thin composition root that delegates SPPF and output/lint responsibilities to the new service modules while preserving existing command wiring and signatures.
- Added module-level tests `tests/gabion/cli_support/shared/test_sppf_sync_services.py` and `tests/gabion/cli_support/shared/test_output_targets.py`, and an architecture assertion in `tests/gabion/cli/test_cli_architecture_entrypoint.py` that ensures `cli.py` does not contain regex/parser business logic.

### Testing

- Ran targeted unit tests: `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/cli_support/shared/test_sppf_sync_services.py tests/gabion/cli_support/shared/test_output_targets.py tests/gabion/cli/test_cli_architecture_entrypoint.py tests/gabion/tooling/sppf/test_sppf_sync_cli.py` and observed all selected tests passed (`17 passed`).
- Ran a focused CLI helper test selection: `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/commands/test_lint_parser.py tests/gabion/cli/cli_output_emitters_cases.py tests/gabion/cli/cli_helpers_cases.py -k 'sppf_sync or write_text_to_target or lint or normalize_optional_output_target'` and observed success (`15 passed`).
- Executed repository policy checks `PYTHONPATH=.:src python scripts/policy/policy_check.py --workflows` and `--ambiguity-contract` and `scripts/misc/extract_test_evidence.py --out out/test_evidence.json` which completed successfully to validate policy/ambiguity artifacts.
- Note: CI-oriented `mise exec` was not used due to local `mise.toml` trust; tests and checks were run with `PYTHONPATH` adjustments and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9815d68248324a92c00c012844844)