### PR TITLE
Refactor dataflow normalization to use typed response envelopes

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -696,6 +696,7 @@ def _emit_dataflow_result_outputs(result: JSONObject, opts: argparse.Namespace) 
         stdout_path=_STDOUT_PATH,
         check_deadline_fn=check_deadline,
         normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
     )
 
 

--- a/src/gabion/cli_support/shared/output_emitters.py
+++ b/src/gabion/cli_support/shared/output_emitters.py
@@ -11,6 +11,7 @@ from typing import Callable
 import typer
 
 from gabion.json_types import JSONObject
+from gabion.schema import DataflowResponseEnvelopeDTO
 from gabion.runtime import path_policy
 
 DeadlineScopeFactory = Callable[[], AbstractContextManager[object]]
@@ -20,7 +21,8 @@ WriteTextToTargetFn = Callable[..., None]
 EmitResultJsonToStdoutFn = Callable[..., None]
 CheckDeadlineFn = Callable[[], None]
 SortOnceFn = Callable[..., list[str]]
-NormalizeDataflowResponseFn = Callable[[JSONObject], dict[str, object]]
+NormalizeDataflowResponseFn = Callable[[JSONObject], DataflowResponseEnvelopeDTO]
+SerializeDataflowResponseFn = Callable[[DataflowResponseEnvelopeDTO], dict[str, object]]
 
 
 def normalize_output_target(
@@ -101,10 +103,13 @@ def emit_dataflow_result_outputs(
     stdout_path: str,
     check_deadline_fn: CheckDeadlineFn,
     normalize_dataflow_response_fn: NormalizeDataflowResponseFn,
+    serialize_dataflow_response_fn: SerializeDataflowResponseFn,
 ) -> None:
     with cli_deadline_scope_factory():
-        normalized_result = normalize_dataflow_response_fn(result)
-        lint_lines = normalized_result.get("lint_lines", []) or []
+        normalized_envelope = normalize_dataflow_response_fn(result)
+        canonical = normalized_envelope.canonical
+        normalized_result = serialize_dataflow_response_fn(normalized_envelope)
+        lint_lines = list(canonical.lint_lines)
         lint_entries_raw = normalized_result.get("lint_entries")
         lint_entries = lint_entries_raw if isinstance(lint_entries_raw, list) else None
         emit_lint_outputs_fn(

--- a/src/gabion/schema.py
+++ b/src/gabion/schema.py
@@ -330,6 +330,30 @@ class LegacyDataflowMonolithResponseDTO(BaseModel):
     payload: Dict[str, Any] = {}
 
 
+class DataflowCanonicalResponseDTO(BaseModel):
+    exit_code: int = 0
+    timeout: bool = False
+    analysis_state: Optional[str] = None
+    classification: Optional[str] = None
+    error_kind: Optional[str] = None
+    errors: List[str] = []
+    lint_lines: List[str] = []
+    lint_entries: List[LintEntryDTO] = []
+    selected_adapter: Optional[str] = None
+    supported_analysis_surfaces: List[str] = []
+    disabled_surface_reasons: Dict[str, str] = {}
+    aspf_trace: Optional[AspfTraceDTO] = None
+    aspf_equivalence: Optional[AspfEquivalenceDTO] = None
+    aspf_opportunities: Optional[AspfOpportunitiesDTO] = None
+    aspf_delta_ledger: Optional[AspfDeltaLedgerDTO] = None
+    aspf_state: Optional[AspfStateDTO] = None
+
+
+class DataflowResponseEnvelopeDTO(BaseModel):
+    canonical: DataflowCanonicalResponseDTO
+    payload: Dict[str, Any] = {}
+
+
 class SynthesisPlanResponseDTO(SynthesisResponse):
     pass
 

--- a/src/gabion/server.py
+++ b/src/gabion/server.py
@@ -69,7 +69,7 @@ from gabion.refactor import (
     FieldSpec, LoopGeneratorRequest as LoopGeneratorRequestModel, RefactorEngine, RefactorCompatibilityShimConfig, RefactorRequest as RefactorRequestModel)
 from gabion.refactor.rewrite_plan import normalize_rewrite_plan_order, validate_rewrite_plan_payload
 from gabion.schema import (
-    LegacyDataflowMonolithResponseDTO, DecisionDiffResponseDTO, LspParityGateResponseDTO, LintEntryDTO, RefactorProtocolResponseDTO, RefactorRequest, RefactorResponse, RewritePlanEntryDTO, StructureDiffResponseDTO, StructureReuseResponseDTO, SynthesisPlanResponseDTO, SynthesisResponse, SynthesisRequest, TextEditDTO)
+    DataflowResponseEnvelopeDTO, LegacyDataflowMonolithResponseDTO, DecisionDiffResponseDTO, LspParityGateResponseDTO, LintEntryDTO, RefactorProtocolResponseDTO, RefactorRequest, RefactorResponse, RewritePlanEntryDTO, StructureDiffResponseDTO, StructureReuseResponseDTO, SynthesisPlanResponseDTO, SynthesisResponse, SynthesisRequest, TextEditDTO)
 from gabion.server_core import command_orchestrator_primitives as orchestrator_primitives
 from gabion.server_core import dataflow_runtime_contract as runtime_contract
 from gabion.synthesis import NamingContext, SynthesisConfig, Synthesizer
@@ -1616,8 +1616,14 @@ def _normalize_dataflow_boundary_controls(
     )
 
 
-def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:
+def _normalize_dataflow_response_envelope(response: Mapping[str, object]) -> DataflowResponseEnvelopeDTO:
     return orchestrator_primitives._normalize_dataflow_response(response)
+
+
+def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:
+    return orchestrator_primitives._serialize_dataflow_response(
+        _normalize_dataflow_response_envelope(response)
+    )
 
 
 def _truthy_flag(value: object) -> bool:
@@ -1918,7 +1924,7 @@ def _invariant_failure_dataflow_response(
     command: str,
     error: NeverThrown,
 ) -> dict[str, object]:
-    normalized = _normalize_dataflow_response(
+    envelope = _normalize_dataflow_response_envelope(
         {
             "exit_code": 2,
             "timeout": False,
@@ -1930,7 +1936,10 @@ def _invariant_failure_dataflow_response(
             "lint_entries": [],
         }
     )
-    return _ordered_command_response(normalized, command=command)
+    return _ordered_command_response(
+        orchestrator_primitives._serialize_dataflow_response(envelope),
+        command=command,
+    )
 
 
 @decision_protocol
@@ -1944,7 +1953,7 @@ def _execute_dataflow_command_boundary(
         command_payload = _parse_dataflow_command_payload(payload)
         normalized_result = _execute_command_total(ls, command_payload, deps=deps)
         return _ordered_command_response(
-            normalized_result,
+            orchestrator_primitives._serialize_dataflow_response(normalized_result),
             command=DATAFLOW_COMMAND,
         )
     except NeverThrown as error:
@@ -1977,7 +1986,7 @@ def _execute_command_total(
     payload: DataflowCommandPayload | Mapping[str, object],
     *,
     deps: ExecuteCommandDeps | None = None,
-) -> dict:
+) -> DataflowResponseEnvelopeDTO:
     from gabion.server_core.command_orchestrator import execute_command_total
 
     command_payload = payload if isinstance(payload, DataflowCommandPayload) else DataflowCommandPayload(payload=_require_payload(payload, command=DATAFLOW_COMMAND))

--- a/src/gabion/server_core/command_orchestrator.py
+++ b/src/gabion/server_core/command_orchestrator.py
@@ -97,7 +97,7 @@ from gabion.invariants import never
 from gabion.json_types import JSONObject, JSONValue
 from gabion.order_contract import OrderPolicy, sort_once
 from gabion.plan import ExecutionPlan, write_execution_plan_artifact
-from gabion.schema import CanonicalProgressEventPayloadDTO
+from gabion.schema import CanonicalProgressEventPayloadDTO, DataflowResponseEnvelopeDTO
 from gabion.server_core.command_contract import CommandRuntimeInput, CommandRuntimeState
 from gabion.server_core.command_effects import CommandEffects
 from gabion.server_core.command_reducers import (
@@ -3905,7 +3905,7 @@ class _SuccessResponseContext:
 
 @dataclass(frozen=True)
 class _SuccessResponseOutcome:
-    response: dict
+    response: DataflowResponseEnvelopeDTO
     phase_checkpoint_state: JSONObject
 
 
@@ -4569,7 +4569,7 @@ def execute_command_total(
     payload: dict[str, object],
     *,
     deps: ExecuteCommandDeps | None = None,
-) -> dict:
+) -> DataflowResponseEnvelopeDTO:
     ingress_stage = _stage_ingress(ls=ls, payload=payload, deps=deps)
     execute_deps = ingress_stage.stage_deps.execute_deps
     execution_plan = ingress_stage.execution_plan

--- a/src/gabion/server_core/command_orchestrator_primitives.py
+++ b/src/gabion/server_core/command_orchestrator_primitives.py
@@ -40,7 +40,7 @@ from gabion.order_contract import sort_once
 from gabion.config import (dataflow_defaults, dataflow_deadline_roots, decision_defaults, decision_ignore_list, decision_require_tiers, decision_tier_map, exception_defaults, exception_never_list, fingerprint_defaults, taint_boundary_registry, taint_defaults, taint_profile, merge_payload)
 from gabion.analysis.core.type_fingerprints import (Fingerprint, PrimeRegistry, TypeConstructorRegistry, build_fingerprint_registry)
 from gabion.refactor.rewrite_plan import (normalize_rewrite_plan_order, validate_rewrite_plan_payload)
-from gabion.schema import (LegacyDataflowMonolithResponseDTO, LintEntryDTO)
+from gabion.schema import (DataflowCanonicalResponseDTO, DataflowResponseEnvelopeDTO, LintEntryDTO)
 from gabion.server_core.ingress_primitives import AnalysisDeps, ExecuteCommandDeps, OutputDeps, ProgressDeps
 from gabion.server_core import dataflow_runtime_contract as runtime_contract
 
@@ -1767,7 +1767,7 @@ def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:
     entry = _parse_lint_line(line)
     return entry.model_dump() if entry is not None else None
 
-def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, object]:
+def _normalize_dataflow_response(response: Mapping[str, object]) -> DataflowResponseEnvelopeDTO:
     lint_decision = LintEntriesDecision.from_response(response)
     lint_lines = list(lint_decision.lint_lines)
     lint_entries = lint_decision.normalize_entries(
@@ -1799,7 +1799,7 @@ def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, ob
         if isinstance(disabled_surface_reasons_raw, Mapping)
         else {}
     )
-    base = LegacyDataflowMonolithResponseDTO(
+    canonical = DataflowCanonicalResponseDTO(
         exit_code=int(response.get("exit_code", 0) or 0),
         timeout=bool(response.get("timeout", False)),
         analysis_state=(str(response.get("analysis_state")) if response.get("analysis_state") is not None else None),
@@ -1826,9 +1826,8 @@ def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, ob
             aspf_delta_ledger_raw if isinstance(aspf_delta_ledger_raw, Mapping) else None
         ),
         aspf_state=aspf_state_raw if isinstance(aspf_state_raw, Mapping) else None,
-        payload={str(key): response[key] for key in response},
     )
-    normalized = dict(base.payload)
+    normalized = {str(key): response[key] for key in response}
     rewrite_plans = normalized.get("fingerprint_rewrite_plans")
     if isinstance(rewrite_plans, list):
         ordered_plans = normalize_rewrite_plan_order(
@@ -1845,39 +1844,58 @@ def _normalize_dataflow_response(response: Mapping[str, object]) -> dict[str, ob
         if rewrite_plan_schema_errors:
             normalized["rewrite_plan_schema_errors"] = rewrite_plan_schema_errors
 
-    normalized["exit_code"] = base.exit_code
-    normalized["timeout"] = base.timeout
-    normalized["analysis_state"] = base.analysis_state
-    normalized["errors"] = base.errors
-    normalized["lint_lines"] = base.lint_lines
-    normalized["selected_adapter"] = base.selected_adapter
+    normalized["exit_code"] = canonical.exit_code
+    normalized["timeout"] = canonical.timeout
+    normalized["analysis_state"] = canonical.analysis_state
+    normalized["errors"] = canonical.errors
+    normalized["lint_lines"] = canonical.lint_lines
+    normalized["selected_adapter"] = canonical.selected_adapter
     normalized["supported_analysis_surfaces"] = list(
-        base.supported_analysis_surfaces
+        canonical.supported_analysis_surfaces
     )
-    normalized["disabled_surface_reasons"] = dict(base.disabled_surface_reasons)
-    normalized["lint_entries"] = [entry.model_dump() for entry in base.lint_entries]
+    normalized["disabled_surface_reasons"] = dict(canonical.disabled_surface_reasons)
+    normalized["lint_entries"] = [entry.model_dump() for entry in canonical.lint_entries]
     payload = normalized.get("payload")
     if isinstance(payload, Mapping):
         payload_updates: dict[str, object] = {
-            "selected_adapter": base.selected_adapter,
-            "supported_analysis_surfaces": list(base.supported_analysis_surfaces),
-            "disabled_surface_reasons": dict(base.disabled_surface_reasons),
+            "selected_adapter": canonical.selected_adapter,
+            "supported_analysis_surfaces": list(canonical.supported_analysis_surfaces),
+            "disabled_surface_reasons": dict(canonical.disabled_surface_reasons),
         }
         normalized["payload"] = boundary_order.apply_boundary_updates_once(
             {str(key): payload[key] for key in payload},
             payload_updates,
             source="server._normalize_dataflow_response.payload_capabilities",
         )
-    if base.aspf_trace is not None:
-        normalized["aspf_trace"] = base.aspf_trace.model_dump()
-    if base.aspf_equivalence is not None:
-        normalized["aspf_equivalence"] = base.aspf_equivalence.model_dump()
-    if base.aspf_opportunities is not None:
-        normalized["aspf_opportunities"] = base.aspf_opportunities.model_dump()
-    if base.aspf_delta_ledger is not None:
-        normalized["aspf_delta_ledger"] = base.aspf_delta_ledger.model_dump()
-    if base.aspf_state is not None:
-        normalized["aspf_state"] = base.aspf_state.model_dump()
+    return DataflowResponseEnvelopeDTO(canonical=canonical, payload=normalized)
+
+
+def _serialize_dataflow_response(
+    response: DataflowResponseEnvelopeDTO,
+) -> dict[str, object]:
+    normalized = dict(response.payload)
+    canonical = response.canonical
+    normalized["exit_code"] = canonical.exit_code
+    normalized["timeout"] = canonical.timeout
+    normalized["analysis_state"] = canonical.analysis_state
+    normalized["errors"] = list(canonical.errors)
+    normalized["lint_lines"] = list(canonical.lint_lines)
+    normalized["selected_adapter"] = canonical.selected_adapter
+    normalized["supported_analysis_surfaces"] = list(
+        canonical.supported_analysis_surfaces
+    )
+    normalized["disabled_surface_reasons"] = dict(canonical.disabled_surface_reasons)
+    normalized["lint_entries"] = [entry.model_dump() for entry in canonical.lint_entries]
+    if canonical.aspf_trace is not None:
+        normalized["aspf_trace"] = canonical.aspf_trace.model_dump()
+    if canonical.aspf_equivalence is not None:
+        normalized["aspf_equivalence"] = canonical.aspf_equivalence.model_dump()
+    if canonical.aspf_opportunities is not None:
+        normalized["aspf_opportunities"] = canonical.aspf_opportunities.model_dump()
+    if canonical.aspf_delta_ledger is not None:
+        normalized["aspf_delta_ledger"] = canonical.aspf_delta_ledger.model_dump()
+    if canonical.aspf_state is not None:
+        normalized["aspf_state"] = canonical.aspf_state.model_dump()
     return boundary_order.canonicalize_boundary_mapping(
         normalized,
         source="server._normalize_dataflow_response",

--- a/src/gabion/server_core/ingress_contracts.py
+++ b/src/gabion/server_core/ingress_contracts.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable
 
+from gabion.schema import DataflowResponseEnvelopeDTO
 from gabion.server_core.ingress_primitives import ExecuteCommandDeps
 from gabion.server_core import command_orchestrator_primitives as legacy
 
 
 @dataclass(frozen=True)
 class IngressStageDeps:
-    normalize_dataflow_response_fn: Callable[[dict[str, object]], dict[str, object]]
+    normalize_dataflow_response_fn: Callable[[dict[str, object]], DataflowResponseEnvelopeDTO]
     materialize_execution_plan_fn: Callable[[dict[str, object]], object]
     default_execute_command_deps_fn: Callable[[], ExecuteCommandDeps]
 

--- a/tests/gabion/cli/cli_output_emitters_cases.py
+++ b/tests/gabion/cli/cli_output_emitters_cases.py
@@ -61,6 +61,7 @@ def test_emit_dataflow_outputs_uses_canonical_lint_entry_normalization() -> None
         stdout_path="-",
         check_deadline_fn=lambda: None,
         normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
     )
 
     lint_entries = captured["lint_entries"]
@@ -96,6 +97,7 @@ def test_emit_dataflow_outputs_respects_canonical_aspf_presence_rules() -> None:
         stdout_path="-",
         check_deadline_fn=lambda: None,
         normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
     )
 
     assert any(isinstance(payload, dict) and payload.get("trace_id") == "aspf-trace:abc123" for payload in emitted)
@@ -106,9 +108,9 @@ def test_emit_dataflow_outputs_respects_canonical_aspf_presence_rules() -> None:
 def test_emit_dataflow_outputs_uses_canonical_capability_field_normalization() -> None:
     captured: dict[str, object] = {}
 
-    def _normalize(response: dict[str, object]) -> dict[str, object]:
+    def _normalize(response: dict[str, object]):
         normalized = command_orchestrator_primitives._normalize_dataflow_response(response)
-        captured["normalized"] = normalized
+        captured["normalized"] = command_orchestrator_primitives._serialize_dataflow_response(normalized)
         return normalized
 
     emit_dataflow_result_outputs(
@@ -127,6 +129,7 @@ def test_emit_dataflow_outputs_uses_canonical_capability_field_normalization() -
         stdout_path="-",
         check_deadline_fn=lambda: None,
         normalize_dataflow_response_fn=_normalize,
+        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
     )
 
     normalized = captured["normalized"]

--- a/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
+++ b/tests/gabion/server/server_orchestrator_primitive_parity_cases.py
@@ -37,7 +37,9 @@ def test_normalize_dataflow_response_parity() -> None:
         "payload_capabilities": {"report_projection": 1, "resume": True},
     }
     assert server._normalize_dataflow_response(payload) == (
-        command_orchestrator_primitives._normalize_dataflow_response(payload)
+        command_orchestrator_primitives._serialize_dataflow_response(
+            command_orchestrator_primitives._normalize_dataflow_response(payload)
+        )
     )
 
 


### PR DESCRIPTION
### Motivation

- Preserve a strongly-typed canonical view of dataflow responses for as long as possible so internal code can rely on typed fields and ASPF node identity instead of opaque dicts.
- Separate canonical DTO fields from an opaque `payload` to ensure orchestrator/CLI boundaries only serialize at transport exit and to reduce accidental payload mutation across stages.

### Description

- Added `DataflowCanonicalResponseDTO` and `DataflowResponseEnvelopeDTO` in `src/gabion/schema.py` to hold canonical typed fields and an opaque `payload` respectively.
- Refactored `_normalize_dataflow_response` in `src/gabion/server_core/command_orchestrator_primitives.py` to return a `DataflowResponseEnvelopeDTO` and added `_serialize_dataflow_response` to perform final `model_dump()`/serialization at transport boundaries and apply canonical ordering.
- Updated server and orchestrator callsites to consume typed envelopes internally and serialize only when returning to transport CLI/LSP: changes in `src/gabion/server.py`, `src/gabion/server_core/command_orchestrator.py`, `src/gabion/server_core/ingress_contracts.py` and `src/gabion/cli_support/shared/output_emitters.py` (CLI wiring updated in `src/gabion/cli.py`).
- Adjusted unit test helpers and test expectations to use the normalization+serialization split and refreshed the evidence artifact `out/test_evidence.json` to reflect updated line mappings.

### Testing

- Ran `python -m py_compile` across modified modules (no syntax errors).
- Ran targeted pytest selection: `tests/gabion/cli/cli_output_emitters_cases.py`, `tests/gabion/server/server_orchestrator_primitive_parity_cases.py`, and `tests/gabion/ingest/test_adapter_contract.py`, yielding `15 passed`.
- Executed policy checks and evidence extraction: `scripts/policy/policy_check.py --workflows`, `scripts/policy/policy_check.py --ambiguity-contract`, and `scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json`, which completed; the environment emitted tooling-resolution warnings from `mise` but the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a983a796e4832494dc910b45d581af)