### PR TITLE
Add profile-resolved marker-kind mapping and wire into analysis emission

### DIFF
--- a/src/gabion/analysis/foundation/marker_protocol.py
+++ b/src/gabion/analysis/foundation/marker_protocol.py
@@ -18,6 +18,11 @@ class MarkerKind(StrEnum):
     DEPRECATED = "deprecated"
 
 
+class MarkerKindProfile(StrEnum):
+    NATIVE = "native"
+    COLLAPSE_TO_NEVER = "collapse_to_never"
+
+
 class MarkerLifecycleState(StrEnum):
     ACTIVE = "active"
     EXPIRED = "expired"
@@ -77,6 +82,42 @@ DEFAULT_MARKER_ALIASES: dict[MarkerKind, tuple[str, ...]] = {
         "gabion.invariants.deprecated",
     ),
 }
+
+
+@dataclass(frozen=True)
+class MarkerKindMappingConfig:
+    profile: MarkerKindProfile
+    kind_map: Mapping[MarkerKind, MarkerKind]
+
+
+DEFAULT_MARKER_KIND_PROFILE_MAPS: Mapping[MarkerKindProfile, Mapping[MarkerKind, MarkerKind]] = MappingProxyType(
+    {
+        MarkerKindProfile.NATIVE: MappingProxyType({}),
+        MarkerKindProfile.COLLAPSE_TO_NEVER: MappingProxyType(
+            {
+                MarkerKind.TODO: MarkerKind.NEVER,
+                MarkerKind.DEPRECATED: MarkerKind.NEVER,
+            }
+        ),
+    }
+)
+
+DEFAULT_MARKER_KIND_MAPPING_CONFIG = MarkerKindMappingConfig(
+    profile=MarkerKindProfile.NATIVE,
+    kind_map=DEFAULT_MARKER_KIND_PROFILE_MAPS[MarkerKindProfile.NATIVE],
+)
+
+
+def marker_kind_mapping_config(profile: MarkerKindProfile) -> MarkerKindMappingConfig:
+    return MarkerKindMappingConfig(profile=profile, kind_map=DEFAULT_MARKER_KIND_PROFILE_MAPS[profile])
+
+
+def resolve_marker_kind_for_profile(
+    marker_kind: MarkerKind,
+    *,
+    mapping_config: MarkerKindMappingConfig = DEFAULT_MARKER_KIND_MAPPING_CONFIG,
+) -> MarkerKind:
+    return mapping_config.kind_map.get(marker_kind, marker_kind)
 
 
 def normalize_semantic_links(raw_links: Sequence[Mapping[str, str]] = _EMPTY_LINKS) -> tuple[SemanticReference, ...]:

--- a/src/gabion/analysis/indexed_scan/scanners/marker_metadata.py
+++ b/src/gabion/analysis/indexed_scan/scanners/marker_metadata.py
@@ -8,7 +8,15 @@ from typing import cast
 
 from gabion.analysis.foundation.json_types import JSONObject
 from gabion.analysis.foundation.marker_protocol import (
-    DEFAULT_MARKER_ALIASES, MarkerKind, MarkerLifecycleState, marker_identity, normalize_marker_payload)
+    DEFAULT_MARKER_ALIASES,
+    DEFAULT_MARKER_KIND_MAPPING_CONFIG,
+    MarkerKind,
+    MarkerKindMappingConfig,
+    MarkerLifecycleState,
+    marker_identity,
+    normalize_marker_payload,
+    resolve_marker_kind_for_profile,
+)
 
 
 def keyword_string_literal(
@@ -136,10 +144,15 @@ def never_marker_metadata(
     reason: str,
     *,
     marker_kind: MarkerKind,
+    marker_kind_mapping: MarkerKindMappingConfig = DEFAULT_MARKER_KIND_MAPPING_CONFIG,
     check_deadline_fn: Callable[[], None],
     sort_once_fn: Callable[..., object],
 ) -> JSONObject:
     check_deadline_fn()
+    resolved_marker_kind = resolve_marker_kind_for_profile(
+        marker_kind,
+        mapping_config=marker_kind_mapping,
+    )
     owner = keyword_string_literal(call, "owner", check_deadline_fn=check_deadline_fn)
     expiry = keyword_string_literal(call, "expiry", check_deadline_fn=check_deadline_fn)
     links = keyword_links_literal(
@@ -150,14 +163,14 @@ def never_marker_metadata(
     payload = normalize_marker_payload(
         reason=reason,
         env={},
-        marker_kind=marker_kind,
+        marker_kind=resolved_marker_kind,
         owner=owner,
         expiry=expiry,
         lifecycle_state=MarkerLifecycleState.ACTIVE,
         links=tuple(cast(dict[str, str], link) for link in links),
     )
     return {
-        "marker_kind": marker_kind.value,
+        "marker_kind": resolved_marker_kind.value,
         "marker_id": marker_identity(payload),
         "marker_site_id": never_id,
         "owner": owner,

--- a/tests/gabion/analysis/misc_s3/test_marker_protocol.py
+++ b/tests/gabion/analysis/misc_s3/test_marker_protocol.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 
 import pytest
 
 from gabion.analysis.foundation.marker_protocol import (
+    MarkerKind,
+    MarkerKindProfile,
     MarkerReasoning,
     marker_identity,
+    marker_kind_mapping_config,
     normalize_marker_payload,
     normalize_marker_reasoning,
     normalize_semantic_links,
+    resolve_marker_kind_for_profile,
 )
+from gabion.analysis.indexed_scan.scanners import marker_metadata
 from gabion.exceptions import NeverThrown
 from gabion.invariants import deprecated, never, todo
 
@@ -144,3 +150,62 @@ def test_todo_and_deprecated_markers_carry_kind() -> None:
     with pytest.raises(NeverThrown) as deprecated_exc:
         deprecated("legacy", links=[{"kind": "policy_id", "value": "NCI-LSP-FIRST"}])
     assert deprecated_exc.value.marker_kind == "deprecated"
+
+
+def _call(source: str) -> ast.Call:
+    node = ast.parse(source, mode="eval").body
+    assert isinstance(node, ast.Call)
+    return node
+
+
+def _check_deadline() -> None:
+    return None
+
+
+def _sort_once(values, *, key=None, **_kwargs):
+    return sorted(values, key=key)
+
+
+# gabion:evidence E:function_site::marker_protocol.py::gabion.analysis.marker_protocol.resolve_marker_kind_for_profile
+def test_marker_kind_profile_native_preserves_extracted_kind() -> None:
+    profile = marker_kind_mapping_config(MarkerKindProfile.NATIVE)
+    assert resolve_marker_kind_for_profile(MarkerKind.TODO, mapping_config=profile) is MarkerKind.TODO
+    assert resolve_marker_kind_for_profile(MarkerKind.DEPRECATED, mapping_config=profile) is MarkerKind.DEPRECATED
+
+
+# gabion:evidence E:function_site::marker_protocol.py::gabion.analysis.marker_protocol.resolve_marker_kind_for_profile
+def test_marker_kind_profile_collapse_to_never_remaps_non_never_kinds() -> None:
+    profile = marker_kind_mapping_config(MarkerKindProfile.COLLAPSE_TO_NEVER)
+    assert resolve_marker_kind_for_profile(MarkerKind.NEVER, mapping_config=profile) is MarkerKind.NEVER
+    assert resolve_marker_kind_for_profile(MarkerKind.TODO, mapping_config=profile) is MarkerKind.NEVER
+    assert resolve_marker_kind_for_profile(MarkerKind.DEPRECATED, mapping_config=profile) is MarkerKind.NEVER
+
+
+# gabion:evidence E:function_site::indexed_scan/marker_metadata.py::gabion.analysis.indexed_scan.marker_metadata.never_marker_metadata
+def test_marker_metadata_site_identity_fields_stable_across_kind_remaps() -> None:
+    call = _call("todo(reason='defer', owner='team')")
+    native = marker_metadata.never_marker_metadata(
+        call,
+        "never:mod.py:f:1:1",
+        "defer",
+        marker_kind=MarkerKind.TODO,
+        marker_kind_mapping=marker_kind_mapping_config(MarkerKindProfile.NATIVE),
+        check_deadline_fn=_check_deadline,
+        sort_once_fn=_sort_once,
+    )
+    collapsed = marker_metadata.never_marker_metadata(
+        call,
+        "never:mod.py:f:1:1",
+        "defer",
+        marker_kind=MarkerKind.TODO,
+        marker_kind_mapping=marker_kind_mapping_config(MarkerKindProfile.COLLAPSE_TO_NEVER),
+        check_deadline_fn=_check_deadline,
+        sort_once_fn=_sort_once,
+    )
+
+    assert native["marker_kind"] == MarkerKind.TODO.value
+    assert collapsed["marker_kind"] == MarkerKind.NEVER.value
+    assert native["marker_site_id"] == collapsed["marker_site_id"]
+    assert native["owner"] == collapsed["owner"]
+    assert native["expiry"] == collapsed["expiry"]
+    assert native["links"] == collapsed["links"]


### PR DESCRIPTION
### Motivation
- Provide a typed, profile-driven surface to remap extracted marker kinds under governance rules so analysis semantics can be adjusted without changing runtime exception/throw policy.
- Keep alias extraction as a syntax-level concern and apply remapping only where the marker kind is finalized for reporting/evidence emission.

### Description
- Add `MarkerKindProfile`, `MarkerKindMappingConfig`, `DEFAULT_MARKER_KIND_PROFILE_MAPS`, `marker_kind_mapping_config`, and `resolve_marker_kind_for_profile` to `src/gabion/analysis/foundation/marker_protocol.py` to declare profile-to-kind mappings as a typed configuration surface.
- Keep `marker_kind_for_call` unchanged and wire profile resolution into `never_marker_metadata` in `src/gabion/analysis/indexed_scan/scanners/marker_metadata.py` by adding a `marker_kind_mapping` parameter and using the resolved kind when building the payload and `marker_kind`/`marker_id` fields.
- Ensure remapping is decoupled from runtime throw/warn behavior by making the mapping a pure configuration/resolver used only during metadata emission.
- Add focused tests in `tests/gabion/analysis/misc_s3/test_marker_protocol.py` covering native-profile preservation, collapse-to-never remapping, and stability of site metadata/identity fields across remaps.

### Testing
- Ran the new/updated unit tests with `PYTHONPATH=src pytest -q -o addopts='' tests/gabion/analysis/misc_s3/test_marker_protocol.py tests/gabion/analysis/indexed_scan/test_indexed_scan_marker_metadata.py` and observed `12 passed`.
- Attempted repo policy checks via `mise exec -- python scripts/policy/policy_check.py --workflows` and `PYTHONPATH=. mise exec -- python scripts/policy/policy_check.py --ambiguity-contract`, but these runs were blocked by environment/toolchain resolution and import bootstrap issues and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b8289d188324bd67713b0bdcbc12)