### PR TITLE
Use per-row marker_kind labels in never invariant summaries

### DIFF
--- a/docs/aspf_taint_isomorphism_no_change.yaml
+++ b/docs/aspf_taint_isomorphism_no_change.yaml
@@ -496,3 +496,5 @@ justification: marker protocol generalization now classifies todo/deprecated mar
 # CU: runtime policy profile extension for invariant behavior + marker-kind mapping is ambient config plumbing only; ASPF taint crosswalk identifiers and in-step coverage unchanged.
 # CU: invariant runtime profile reification (`strict`/`diagnostic`/`debt_gate`/`sunset_gate`), warning-key rate caps, and runtime policy env migration to `GABION_INVARIANT_PROFILE` change runtime marker behavior plumbing only and preserve ASPF taint crosswalk identifiers and in-step obligations.
 # CU: never() legacy string deprecation preflight detection now keys on reasoning-shape presence (`"reasoning" not in env`) instead of empty metadata env, so metadata-only kwargs still trigger migration warnings while structured reasoning payload calls remain exempt; marker kinds and ASPF taint crosswalk identifiers are unchanged.
+
+# CU: dataflow reporting helper marker-kind label propagation (summarize_never_invariants reads row marker_kind with legacy default never and emits marker-specific labels) is formatting-only output stabilization; ASPF taint crosswalk identifiers remain unchanged.

--- a/src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py
+++ b/src/gabion/analysis/dataflow/io/dataflow_reporting_helpers.py
@@ -397,11 +397,15 @@ def summarize_never_invariants(entries: list[JSONObject]) -> list[str]:
         span = _format_span_fields(*_span4(entry.get("span")))
         status = str(entry.get("status", "UNKNOWN") or "UNKNOWN")
         reason = str(entry.get("reason", "") or "")
+        marker_kind = str(entry.get("marker_kind", "never") or "never")
         suffix = f"@{span}" if span else ""
         bits = [f"status={status}"]
         if reason:
             bits.append(f"reason={reason}")
-        lines.append(f"{path}:{function}[{suite_kind}]{suffix} never() ({'; '.join(bits)})")
+        lines.append(
+            f"{path}:{function}[{suite_kind}]{suffix} "
+            f"{marker_kind}() ({'; '.join(bits)})"
+        )
     return lines
 
 

--- a/tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py
+++ b/tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py
@@ -20,6 +20,7 @@ def _load():
     )
     from gabion.analysis.dataflow.io.dataflow_reporting import emit_report
     from gabion.analysis.dataflow.io.dataflow_reporting_helpers import (
+        summarize_never_invariants,
         render_mermaid_component,
     )
     from gabion.analysis.dataflow.engine.dataflow_projection_materialization import (
@@ -35,6 +36,7 @@ def _load():
         _merge_counts_by_knobs=_merge_counts_by_knobs,
         _populate_bundle_forest=_populate_bundle_forest,
         _render_mermaid_component=render_mermaid_component,
+        _summarize_never_invariants=summarize_never_invariants,
         _report_section_spec=_report_section_spec,
         _topologically_order_report_projection_specs=_topologically_order_report_projection_specs,
     )
@@ -63,6 +65,33 @@ def test_emit_report_empty_groups() -> None:
     )
     assert "No bundle components detected." in report
     assert violations == []
+
+
+def test_summarize_never_invariants_uses_marker_kind_per_row() -> None:
+    da = _load()
+    summary = da._summarize_never_invariants(
+        [
+            {
+                "status": "A",
+                "site": {"path": "a.py", "function": "fa", "suite_kind": "function"},
+                "marker_kind": "todo",
+            },
+            {
+                "status": "A",
+                "site": {"path": "b.py", "function": "fb", "suite_kind": "function"},
+            },
+            {
+                "status": "A",
+                "site": {"path": "c.py", "function": "fc", "suite_kind": "function"},
+                "marker_kind": "deprecated",
+            },
+        ]
+    )
+    assert summary == [
+        "a.py:fa[function] todo() (status=A)",
+        "b.py:fb[function] never() (status=A)",
+        "c.py:fc[function] deprecated() (status=A)",
+    ]
 
 # gabion:evidence E:call_footprint::tests/test_dataflow_report_helpers.py::test_emit_report_parse_failure_witnesses::dataflow_indexed_file_scan.py::gabion.analysis.dataflow_indexed_file_scan._emit_report::test_dataflow_report_helpers.py::tests.test_dataflow_report_helpers._load
 def test_emit_report_parse_failure_witnesses() -> None:


### PR DESCRIPTION
### Motivation
- Make never-invariant reporting reflect per-row marker identity (e.g. `todo`, `deprecated`) while remaining backward compatible with existing rows.
- Preserve existing ordering and status/reason formatting so output/diff stability is retained.

### Description
- Updated `summarize_never_invariants()` to read `marker_kind` from each entry and default to `"never"` for legacy rows, and render the label as `"{marker_kind}()"` instead of the hardcoded `never()`.
- Kept the original sort key and the `status`/`reason` bits unchanged to avoid changing output ordering or diff behavior.
- Added a unit test `test_summarize_never_invariants_uses_marker_kind_per_row` in `tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py` to cover mixed marker rows (`todo`, implicit `never`, `deprecated`) and assert the expected labels.
- Recorded the change in the ASPF no-change acknowledgement doc and refreshed `out/test_evidence.json` to reflect the new test mapping.

### Testing
- Ran `pytest` for the modified reporting helper tests: `PYTHONPATH=src:. python -m pytest -o addopts='' tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py -q` and all tests passed (`23 passed`).
- Ran repository policy checks `PYTHONPATH=src:. python scripts/policy/policy_check.py --workflows` and `--ambiguity-contract` and they completed successfully.
- Ran test evidence extraction `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and refreshed `out/test_evidence.json` to include the new test entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e083fe708324a6ed99e8c403e318)