### PR TITLE
Add NCI-RUNTIME-NARROWING-BOUNDARY policy and contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 113
+doc_revision: 114
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide
@@ -108,6 +108,7 @@ valid.
 - **Controller drift + override lifecycle:** [`NCI-CONTROLLER-DRIFT-LIFECYCLE`](docs/normative_clause_index.md#clause-controller-drift-lifecycle).
 - **Maturity/transport policy:** [`NCI-COMMAND-MATURITY-PARITY`](docs/normative_clause_index.md#clause-command-maturity-parity).
 - **Temporal dual-sensor correction loop:** [`NCI-DUAL-SENSOR-CORRECTION-LOOP`](docs/normative_clause_index.md#clause-dual-sensor-correction-loop) (mandatory for agents; recommendation-level interoperability guidance for contributors).
+- **Runtime narrowing boundary contract:** [`NCI-RUNTIME-NARROWING-BOUNDARY`](docs/normative_clause_index.md#clause-runtime-narrowing-boundary).
 - **Semantic ownership boundary:** user-facing semantics must live in server command handlers and be exposed as `gabion` subcommands. `scripts/` are orchestration wrappers (CI/bootstrap/audit), never canonical semantic engines.
 - **Single source of truth:** diagnostics and code actions must be derived from
   the server, not duplicated in client code.
@@ -172,6 +173,44 @@ sequence in order:
 - If an internal state is impossible after ingress validation, enforce it with `never()`.
 - `# pragma: no cover` is permitted only on branches protected by `never(...)`.
 - For enum exhaustiveness, prefer an explicit `never(...)` fallback with `# pragma: no cover` on the dead path so drift is immediately attributable.
+
+## Runtime narrowing boundary contract (normative)
+Canonical rule: [`NCI-RUNTIME-NARROWING-BOUNDARY`](docs/normative_clause_index.md#clause-runtime-narrowing-boundary).
+
+Runtime narrowing is allowed only at named boundary ingress surfaces.
+
+Allowed (boundary ingress allowlist):
+
+- `src/gabion/server.py::_require_payload`
+- `src/gabion/server.py::_parse_dataflow_command_payload`
+- DTO adapters that canonicalize inbound payloads with `*.model_validate(...)`
+  before semantic-core execution.
+
+Forbidden (semantic-core narrowing):
+
+- `src/gabion/analysis/**`
+- `src/gabion/server_core/**`
+- post-normalization command execution paths in `src/gabion/server.py`.
+
+Examples:
+
+Allowed:
+
+```py
+payload = _require_payload(params)
+command_payload = _parse_dataflow_command_payload(payload)
+request = SynthesisRequest.model_validate(payload)
+```
+
+Disallowed:
+
+```py
+# semantic-core module (e.g., src/gabion/analysis/**)
+if isinstance(payload, dict) and "lint_entries" in payload:
+    entries = payload["lint_entries"]
+elif isinstance(payload, dict) and "lint_lines" in payload:
+    entries = _parse_lines(payload["lint_lines"])
+```
 
 ## Sortedness Disclosure Ratchet (normative)
 When sortedness is enforced, it must be treated as part of semantic behavior.

--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 52
+doc_revision: 53
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -560,6 +560,53 @@ Forward-remediation order (normative):
    of preserving dual paths.
 3. Rollback is allowed only when forward remediation cannot preserve behavior
    or cannot converge.
+
+### 4.8.1 Runtime narrowing boundary contract
+Canonical clause: [`NCI-RUNTIME-NARROWING-BOUNDARY`](docs/normative_clause_index.md#clause-runtime-narrowing-boundary).
+
+Runtime narrowing (shape discrimination, `isinstance`/`Union` alternation,
+dict-key probing used to choose schema variants, and compatibility fallback
+selection) is permitted only in named boundary ingress surfaces.
+
+Allowed narrowing ingress surfaces (allowlist):
+
+- `src/gabion/server.py::_require_payload`
+- `src/gabion/server.py::_parse_dataflow_command_payload`
+- DTO ingress adapters that canonicalize inbound payloads with
+  `*.model_validate(...)` before semantic-core execution.
+
+Narrowing-forbidden semantic-core surfaces:
+
+- `src/gabion/analysis/**`
+- `src/gabion/server_core/**`
+- command-execution logic after payload normalization in
+  `src/gabion/server.py` handlers.
+
+Required behavior:
+
+1. Ingress narrowing happens once, then downstream code consumes
+   deterministic DTO/Protocol carriers.
+2. Semantic-core modules must not add repeated runtime narrowing or
+   compatibility fallback branches.
+3. Adding any new narrowing ingress location requires a same-change policy and
+   contributor-guide update before merge.
+
+Allowed pattern:
+
+```py
+payload = _require_payload(params)
+request = SynthesisRequest.model_validate(payload)
+```
+
+Disallowed semantic-core pattern:
+
+```py
+# inside src/gabion/analysis/** or src/gabion/server_core/**
+if isinstance(payload, dict) and "lint_lines" in payload:
+    ...
+elif isinstance(payload, dict) and "lint_entries" in payload:
+    ...
+```
 
 ### 4.9 Sort-Disclosure Ratchet
 

--- a/docs/normative_clause_index.md
+++ b/docs/normative_clause_index.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 10
+doc_revision: 11
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: normative_clause_index
 doc_role: normative_index
@@ -117,6 +117,14 @@ link to clause IDs instead of duplicating long-form normative prose.
 - `# pragma: no cover` is allowed only when the branch is protected by a `never()` invariant.
 - Enum exhaustiveness fallbacks should pair `never(...)` with `# pragma: no cover` so drift is explicit and correction is local.
 - Canonical sources: `POLICY_SEED.md#policy_seed` (§4.8), `CONTRIBUTING.md#contributing_contract`, `AGENTS.md#agent_obligations`.
+
+<a id="clause-runtime-narrowing-boundary"></a>
+### `NCI-RUNTIME-NARROWING-BOUNDARY` — Runtime narrowing only at named ingress boundaries
+- Runtime narrowing is permitted only in named boundary ingress surfaces.
+- Allowlisted ingress surfaces: `src/gabion/server.py::_require_payload`, `src/gabion/server.py::_parse_dataflow_command_payload`, and DTO adapters that canonicalize payloads via `*.model_validate(...)` before semantic-core execution.
+- Narrowing-forbidden semantic-core surfaces include `src/gabion/analysis/**`, `src/gabion/server_core/**`, and post-normalization command execution paths in `src/gabion/server.py`.
+- New runtime narrowing locations require policy + contributor guidance updates in the same change-set.
+- Canonical sources: `POLICY_SEED.md#policy_seed` (§4.8.1), `CONTRIBUTING.md#contributing_contract`.
 
 <a id="clause-baseline-ratchet"></a>
 ### `NCI-BASELINE-RATCHET` — Baseline ratchet integrity


### PR DESCRIPTION
### Motivation
- Prevent ad-hoc runtime shape-narrowing from creeping into semantic core modules by making runtime narrowing an explicit, auditable boundary responsibility.
- Make enforcement unambiguous by listing allowlisted ingress surfaces and naming modules that are narrowing-forbidden.
- Provide concrete examples using existing repo identifiers so contributors and policy checks can reliably detect allowed vs disallowed patterns.

### Description
- Added a new normative subsection `4.8.1 Runtime narrowing boundary contract` to `POLICY_SEED.md` that defines `NCI-RUNTIME-NARROWING-BOUNDARY` and prescribes that runtime narrowing (e.g., `isinstance`/`Union` discrimination, dict-key probing, compatibility fallbacks) is permitted only at named boundary ingress surfaces such as `src/gabion/server.py::_require_payload`, `src/gabion/server.py::_parse_dataflow_command_payload`, and DTO adapters via `*.model_validate(...)`.
- Added `NCI-RUNTIME-NARROWING-BOUNDARY` to `docs/normative_clause_index.md` with the allowlist, narrowing-forbidden semantic-core surfaces (`src/gabion/analysis/**`, `src/gabion/server_core/**`, and post-normalization handlers), and the requirement that new ingress locations must be added alongside policy and contributor-guide updates.
- Updated `CONTRIBUTING.md` to cross-link the new clause in the architectural invariants and to include an explicit “Runtime narrowing boundary contract” section with allowed and disallowed code examples using `_require_payload`, `_parse_dataflow_command_payload`, and `*.model_validate(...)`.
- Example snippets in the policy document illustrate allowed ingress usage (e.g., `payload = _require_payload(params)` then `SynthesisRequest.model_validate(payload)`) and a disallowed semantic-core narrowing pattern.

### Testing
- Ran `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` which completed successfully in this environment.
- Ran `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` which completed successfully and reported no ambiguity-contract violations after the change.
- Ran `PYTHONPATH=src:. python scripts/policy/policy_check.py --normative-map` which completed successfully and validated clause-to-enforcement mapping.
- Attempted `mise exec -- python ...` runs as the preferred pinned tool invocation but those failed due to environment/toolchain resolution and trust constraints; equivalent checks were executed directly with `PYTHONPATH` as above and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e10ab1788324ae6055ecd398f2c6)