### PR TITLE
Add regression tests for payload-boundary narrowing across server, core, CLI, and policy

### DIFF
--- a/tests/gabion/cli/cli_helpers_cases.py
+++ b/tests/gabion/cli/cli_helpers_cases.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import urllib.error
 import zipfile
+from typing import Mapping
 
 import pytest
 import typer
@@ -4009,3 +4010,68 @@ def test_governance_commands_include_optional_cli_args(tmp_path: Path) -> None:
     )
     assert any(name == "lint" and "--json" in argv and "--top" in argv for name, argv in calls)
     assert any(name == "lint" and "--lint" not in argv and "--json" not in argv for name, argv in calls)
+
+
+def test_run_dataflow_raw_argv_progress_ingress_parses_once_then_feeds_emitters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_path = tmp_path / "sample.py"
+    module_path.write_text("def sample():\n    return 1\n", encoding="utf-8")
+
+    parsed_payload = {
+        "phase": "collection",
+        "work_done": 1,
+        "work_total": 2,
+        "completed_files": 1,
+        "remaining_files": 1,
+        "total_files": 2,
+        "event_seq": 7,
+    }
+    parse_calls: list[object] = []
+    timeline_inputs: list[Mapping[str, object]] = []
+    emitted_rows: list[tuple[str | None, str]] = []
+
+    def _parse_once(notification: Mapping[str, object]) -> dict[str, object] | None:
+        parse_calls.append(notification)
+        return dict(parsed_payload)
+
+    def _timeline_from_phase_progress(payload: Mapping[str, object]) -> dict[str, str]:
+        timeline_inputs.append(payload)
+        return {"header": "| h |", "row": "| collection |"}
+
+    def _emit_timeline(*, header: str | None, row: str) -> None:
+        emitted_rows.append((header, row))
+
+    def _fake_runner(_request, *, root=None, notification_callback=None):
+        _ = root
+        assert callable(notification_callback)
+        notification_callback({"method": "$/progress", "params": {"token": "t", "value": {}}})
+        return {"exit_code": 0}
+
+    monkeypatch.setattr(cli, "_phase_progress_from_progress_notification", _parse_once)
+    monkeypatch.setattr(
+        cli.progress_timeline,
+        "phase_timeline_from_phase_progress",
+        _timeline_from_phase_progress,
+    )
+    monkeypatch.setattr(cli, "_emit_phase_timeline_progress", _emit_timeline)
+    monkeypatch.setattr(cli, "_emit_dataflow_result_outputs", lambda _result, _opts: None)
+    monkeypatch.setattr(cli, "_emit_analysis_resume_summary", lambda _result: None)
+    monkeypatch.setattr(cli, "_emit_nonzero_exit_causes", lambda _result: None)
+
+    with pytest.raises(typer.Exit) as exc:
+        cli._run_dataflow_raw_argv(
+            [
+                str(module_path),
+                "--root",
+                str(tmp_path),
+            ],
+            runner=_fake_runner,
+        )
+
+    assert exc.value.exit_code == 0
+    assert len(parse_calls) == 1
+    assert len(timeline_inputs) == 1
+    assert timeline_inputs[0] == parsed_payload
+    assert emitted_rows == [("| h |", "| collection |")]

--- a/tests/gabion/server/server_execute_command_edges_cases.py
+++ b/tests/gabion/server/server_execute_command_edges_cases.py
@@ -11,6 +11,7 @@ from types import MappingProxyType
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
 from gabion import server
 from gabion.analysis.foundation.timeout_context import TimeoutContext, pack_call_stack
@@ -91,6 +92,50 @@ def test_require_payload_coerces_mapping_proxy() -> None:
     normalized = server._require_payload(proxy_payload, command="unit")
     assert normalized == {"answer": 42}
     assert isinstance(normalized, dict)
+
+
+def test_normalize_dataflow_response_envelope_rejects_malformed_lint_entry_shape() -> None:
+    with pytest.raises(ValidationError):
+        server._normalize_dataflow_response_envelope(
+            {
+                "exit_code": 0,
+                "timeout": False,
+                "errors": [],
+                "lint_lines": [],
+                "lint_entries": [{"path": 1, "line": "x"}],
+            }
+        )
+
+
+def test_execute_dataflow_boundary_passes_typed_payload_carrier_to_core(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_total(ls, payload, *, deps=None):
+        _ = ls, deps
+        captured["payload_type"] = type(payload)
+        assert isinstance(payload, server.DataflowCommandPayload)
+        return server._normalize_dataflow_response_envelope(
+            {
+                "exit_code": 0,
+                "timeout": False,
+                "errors": [],
+                "lint_lines": [],
+                "lint_entries": [],
+            }
+        )
+
+    original = server._execute_command_total
+    try:
+        server._execute_command_total = _fake_total
+        result = server._execute_dataflow_command_boundary(
+            _DummyServer(str(tmp_path)),
+            {"root": str(tmp_path), "paths": []},
+        )
+    finally:
+        server._execute_command_total = original
+
+    assert captured["payload_type"] is server.DataflowCommandPayload
+    assert result.get("exit_code") == 0
 
 
 def _write_bundle_module(path: Path) -> None:

--- a/tests/gabion/server_core/command_orchestrator_edges_cases.py
+++ b/tests/gabion/server_core/command_orchestrator_edges_cases.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 from types import SimpleNamespace
+import inspect
 
 import pytest
 
@@ -597,6 +598,25 @@ def test_parse_execution_payload_options_aux_operation_invalid_paths_raise() -> 
             },
             root=Path("."),
         )
+
+
+def test_core_orchestrator_entrypoints_use_dict_payload_carriers() -> None:
+    execute_payload_ann = inspect.signature(orchestrator.execute_command_total).parameters[
+        "payload"
+    ].annotation
+    ingress_payload_ann = inspect.signature(orchestrator._stage_ingress).parameters[
+        "payload"
+    ].annotation
+    normalize_payload_ann = inspect.signature(
+        orchestrator._normalize_command_payload_ingress
+    ).parameters["payload"].annotation
+
+    assert str(execute_payload_ann) == "dict[str, object]"
+    assert str(ingress_payload_ann) == "dict[str, object]"
+    assert str(normalize_payload_ann) == "dict[str, object]"
+    assert "Mapping" not in str(execute_payload_ann)
+    assert "Mapping" not in str(ingress_payload_ann)
+    assert "Mapping" not in str(normalize_payload_ann)
 
 
 # gabion:evidence E:function_site::tests/test_server_core_orchestrator_edges.py::test_emit_test_obsolescence_outputs_ignores_non_mapping_active_summary

--- a/tests/gabion/tooling/runtime_policy/test_semantic_core_payload_branching_policy_check.py
+++ b/tests/gabion/tooling/runtime_policy/test_semantic_core_payload_branching_policy_check.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.policy import policy_check
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_raw_payload_branching_flags_semantic_core_isinstance_and_cast(tmp_path: Path) -> None:
+    sample = tmp_path / "src" / "gabion" / "analysis" / "sample_semantic_core.py"
+    _write(
+        sample,
+        "from typing import Mapping, cast\n\n"
+        "def run(payload: object) -> int:\n"
+        "    narrowed = cast(Mapping[str, object], payload)\n"
+        "    if isinstance(narrowed, Mapping):\n"
+        "        return 1\n"
+        "    return 0\n",
+    )
+
+    violations = policy_check._raw_payload_branching_violations(sample)
+    assert violations
+    assert any("isinstance Mapping/list branch outside boundary decode" in item for item in violations)
+
+
+def test_raw_payload_branching_allows_decode_boundary_adapter(tmp_path: Path) -> None:
+    adapter = tmp_path / "src" / "gabion" / "analysis" / "sample_adapter.py"
+    _write(
+        adapter,
+        "from typing import Mapping\n\n"
+        "def _decode_payload(raw: object) -> Mapping[str, object] | None:\n"
+        "    if isinstance(raw, Mapping):\n"
+        "        return raw\n"
+        "    return None\n",
+    )
+
+    assert policy_check._raw_payload_branching_violations(adapter) == []


### PR DESCRIPTION
### Motivation

- Prevent regressions where malformed boundary payloads bypass DTO validation and reach core logic. 
- Lock down core orchestrator entrypoints to concrete `dict[str, object]` carriers instead of raw `Mapping` unions to preserve typed contracts. 
- Ensure the runtime policy scanner flags narrowing/branching (e.g. `cast` + `isinstance`) in semantic-core modules while allowing approved `_decode_` adapters, and verify CLI progress parsing is performed once and fed downstream emitters.

### Description

- Added server-level tests in `tests/gabion/server/server_execute_command_edges_cases.py` that assert malformed `lint_entries` are rejected via DTO validation and that the dataflow boundary passes a `DataflowCommandPayload` carrier into core execution. 
- Added core-orchestrator signature tests in `tests/gabion/server_core/command_orchestrator_edges_cases.py` that assert `execute_command_total`, `_stage_ingress`, and `_normalize_command_payload_ingress` use concrete `dict[str, object]` annotations and do not expose `Mapping` unions. 
- Added runtime-policy tests in `tests/gabion/tooling/runtime_policy/test_semantic_core_payload_branching_policy_check.py` to assert violations are reported when `cast`/`isinstance` narrowing appears in semantic-core sample modules and no violation is reported for `_decode_` boundary adapters. 
- Added a CLI progress-path test in `tests/gabion/cli/cli_helpers_cases.py` verifying a single ingress parse step (`_phase_progress_from_progress_notification`) is invoked once and its parsed payload feeds the timeline conversion and emitter (`_emit_phase_timeline_progress`). 
- Updated `out/test_evidence.json` to reflect new test evidence and added minimal imports (`pydantic.ValidationError`, `inspect`, `Mapping`) required by the new tests.

### Testing

- Ran the runtime policy checks with `PYTHONPATH=. python scripts/policy/policy_check.py --workflows` and `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract`, both completed successfully in this environment. 
- Ran the targeted pytest run with `PYTHONPATH=src:. pytest -o addopts='' tests/gabion/server/server_execute_command_edges_cases.py tests/gabion/server_core/command_orchestrator_edges_cases.py tests/gabion/tooling/runtime_policy/test_semantic_core_payload_branching_policy_check.py tests/gabion/cli/cli_helpers_cases.py -q` and the suite passed: `376 passed, 1 warning`.
- Regenerated evidence using `PYTHONPATH=src:. python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` which produced the updated `out/test_evidence.json` included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e1479e7883248ab212d5ff2dd242)