### PR TITLE
docs/tests: preserve never-invariant `marker_kind` labels in reports and add test + audit note

### DIFF
--- a/docs/audits/dataflow_legacy_monolith_test_replacement_matrix.md
+++ b/docs/audits/dataflow_legacy_monolith_test_replacement_matrix.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 3
+doc_revision: 4
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: legacy_dataflow_monolith_test_replacement_matrix
 doc_role: audit
@@ -17,7 +17,7 @@ doc_reviewed_as_of:
   AGENTS.md#agent_obligations: 2
   glossary.md#contract: 1
 doc_review_notes:
-  POLICY_SEED.md#policy_seed: "Matrix initializes prune+replace coverage mapping for runtime-retirement correction units."
+  POLICY_SEED.md#policy_seed: "Matrix tracks marker-kind labeling parity in report/lint replacement surfaces and fallback semantics for historical rows."
   AGENTS.md#agent_obligations: "Rows track runtime-coupled test surfaces for same-CU replacement migration."
   glossary.md#contract: "Capability replacement rows are tracked as explicit commutation evidence placeholders."
 doc_change_protocol: "POLICY_SEED.md#change_protocol"
@@ -84,3 +84,9 @@ Rows are initialized from current `tests/` imports of `gabion.analysis.legacy_da
 | `tests/test_visitors_edges.py` | `D1/D2/D3/D4/D5/D6` | `owner-module replacement coverage` | `dataflow_indexed_file_scan; owner modules` | `CU-RT-FINAL-2` | `retargeted` | Retargeted to direct owner imports. |
 | `tests/test_visitors_unit.py` | `D1/D2/D3/D4/D5/D6` | `owner-module replacement coverage` | `dataflow_indexed_file_scan; owner modules` | `CU-RT-FINAL-2` | `retargeted` | Retargeted to direct owner imports. |
 | `tests/test_wildcard_forwarding.py` | `D1/D2/D3/D4/D5/D6` | `owner-module replacement coverage` | `dataflow_indexed_file_scan; owner modules` | `CU-RT-FINAL-2` | `retargeted` | Retargeted to direct owner imports. |
+
+## Marker-kind report/lint parity note
+
+For the report and lint replacement surfaces, never-invariant line labels now preserve each row's `marker_kind` value (`never`, `todo`, `deprecated`) instead of collapsing to `never()` unconditionally.
+When a historical row omits `marker_kind` (or provides an empty value), rendering intentionally defaults to `never()` so older artifacts remain interpretable.
+

--- a/tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py
+++ b/tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py
@@ -79,11 +79,21 @@ def test_summarize_never_invariants_uses_marker_kind_per_row() -> None:
             {
                 "status": "A",
                 "site": {"path": "b.py", "function": "fb", "suite_kind": "function"},
+                "marker_kind": "never",
             },
             {
                 "status": "A",
                 "site": {"path": "c.py", "function": "fc", "suite_kind": "function"},
                 "marker_kind": "deprecated",
+            },
+            {
+                "status": "A",
+                "site": {"path": "d.py", "function": "fd", "suite_kind": "function"},
+            },
+            {
+                "status": "A",
+                "site": {"path": "e.py", "function": "fe", "suite_kind": "function"},
+                "marker_kind": "",
             },
         ]
     )
@@ -91,6 +101,8 @@ def test_summarize_never_invariants_uses_marker_kind_per_row() -> None:
         "a.py:fa[function] todo() (status=A)",
         "b.py:fb[function] never() (status=A)",
         "c.py:fc[function] deprecated() (status=A)",
+        "d.py:fd[function] never() (status=A)",
+        "e.py:fe[function] never() (status=A)",
     ]
 
 # gabion:evidence E:call_footprint::tests/test_dataflow_report_helpers.py::test_emit_report_parse_failure_witnesses::dataflow_indexed_file_scan.py::gabion.analysis.dataflow_indexed_file_scan._emit_report::test_dataflow_report_helpers.py::tests.test_dataflow_report_helpers._load


### PR DESCRIPTION
### Motivation

- Clarify and record the current behavior that report and lint outputs preserve each never-invariant row's `marker_kind` (e.g. `never`, `todo`, `deprecated`) rather than collapsing them to `never()` unconditionally. 
- Explicitly document the historical fallback rule that when a row omits `marker_kind` (or provides an empty value) the renderer intentionally defaults to showing `never()` so older artifacts remain interpretable.

### Description

- Extended the focused reporting test `test_summarize_never_invariants_uses_marker_kind_per_row` in `tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py` to include mixed `marker_kind` rows and assert preserved labels and fallback-to-`never()` for missing/empty values. 
- Updated the audit matrix `docs/audits/dataflow_legacy_monolith_test_replacement_matrix.md` by bumping `doc_revision`, revising the `doc_review_notes` to mention marker-kind parity, and adding a `Marker-kind report/lint parity note` that documents the preservation and fallback semantics. 
- No core runtime code changes were required because the reporting and lint helpers already read and render `marker_kind` per-row; this change is a documentation+test alignment to the existing behavior.

### Testing

- Ran the focused pytest assertions with `PYTHONPATH=src:. mise exec -- python -m pytest -o addopts='' tests/gabion/analysis/dataflow_s1/test_dataflow_report_helpers.py::test_summarize_never_invariants_uses_marker_kind_per_row tests/gabion/analysis/misc_s3/test_never_invariants.py::test_never_invariant_lint_lines_use_marker_kind_and_fallback` and both tests passed. 
- Executed the ambiguity-contract policy check with `PYTHONPATH=src:. mise exec -- python scripts/policy/policy_check.py --ambiguity-contract` and it completed successfully in the repo environment used for validation. 
- Verified that evidence artifacts did not change with `git diff -- out/test_evidence.json --exit-code` which returned clean (no diff).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1ac10f088324ac752881a12e7254)