### PR TITLE
Add unified policy result schema and emit adapters, aggregate into policy scanner suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 115
+doc_revision: 116
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: contributing
 doc_role: guide

--- a/docs/enforceable_rules_cheat_sheet.md
+++ b/docs/enforceable_rules_cheat_sheet.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 10
+doc_revision: 11
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: enforceable_rules_cheat_sheet
 doc_role: reference
@@ -130,6 +130,12 @@ No rule in this cheat sheet is valid unless it is traceable to canonical
 clauses in the source documents above.
 
 Gate-level control-loop mapping lives in `docs/governance_loop_matrix.md#governance_loop_matrix`.
+
+### Consolidated policy artifact (audit source of truth)
+
+- `artifacts/out/policy_suite_results.json` is the machine-readable source of truth for policy-family audits.
+- The artifact now carries per-rule policy-result envelopes (`rule_id`, `status`, `violations`, `baseline_mode`, `source_tool`, `timestamp_utc`, `input_scope`) for gate-only families (workflow policy check, structural-hash policy, deprecated non-erasability) alongside scanner-suite families.
+- Fallback behavior: if a gate-only wrapper cannot materialize its dedicated artifact, the suite records a fallback envelope (status derived from return code) so audit bundles remain complete even when a per-rule producer misbehaves.
 
 ## Rule Matrix (Traceable)
 

--- a/scripts/policy/deprecated_nonerasability_policy_check.py
+++ b/scripts/policy/deprecated_nonerasability_policy_check.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Mapping
 
+from gabion.tooling.runtime.policy_result_schema import make_policy_result, write_policy_result
+
 from gabion.analysis.core.deprecated_substrate import (
     DeprecatedFiber, enforce_non_erasability_policy)
 
@@ -25,18 +27,39 @@ def _load_rows(path: Path) -> list[DeprecatedFiber]:
     return fibers
 
 
+def _serialize_errors(errors: list[str]) -> list[dict[str, object]]:
+    return [{"message": error, "render": error} for error in errors]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Enforce non-erasable deprecated fibers")
     parser.add_argument("--baseline", type=Path, required=True)
     parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
     baseline = _load_rows(args.baseline)
     current = _load_rows(args.current)
     result = enforce_non_erasability_policy(previous_fibers=baseline, current_fibers=current)
+    errors = list(result.errors)
+    if args.output is not None:
+        write_policy_result(
+            path=args.output.resolve(),
+            result=make_policy_result(
+                rule_id="deprecated_nonerasability",
+                status="pass" if result.ok else "fail",
+                violations=_serialize_errors(errors),
+                baseline_mode="baseline_compare",
+                source_tool="scripts/policy/deprecated_nonerasability_policy_check.py",
+                input_scope={
+                    "baseline": str(args.baseline),
+                    "current": str(args.current),
+                },
+            ),
+        )
     if result.ok:
         return 0
-    for error in result.errors:
+    for error in errors:
         print(error)
     return 1
 

--- a/scripts/policy/policy_check.py
+++ b/scripts/policy/policy_check.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from gabion.tooling.runtime.policy_result_schema import make_policy_result, write_policy_result
+
 from scripts.deadline.deadline_runtime import DeadlineBudget, deadline_scope_from_ticks
 from gabion.analysis.foundation.timeout_context import Deadline, check_deadline, deadline_clock_scope, deadline_scope
 from gabion.invariants import never
@@ -338,7 +340,11 @@ class JobContext:
     path: Path
 
 
+_LAST_FAIL_ERRORS: list[str] = []
+
 def _fail(errors):
+    global _LAST_FAIL_ERRORS
+    _LAST_FAIL_ERRORS = [str(err) for err in errors]
     for err in errors:
         check_deadline()
         print(f"policy-check: {err}", file=sys.stderr)
@@ -1774,7 +1780,11 @@ def check_adapter_surface_policy() -> None:
     if errors:
         _fail(errors)
 
-def main():
+def _serialize_policy_check_errors(errors: list[str]) -> list[dict[str, object]]:
+    return [{"message": item, "render": item} for item in errors]
+
+
+def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(description="POLICY_SEED guardrails")
     parser.add_argument("--workflows", action="store_true", help="lint workflows")
     parser.add_argument("--posture", action="store_true", help="check GitHub posture")
@@ -1785,32 +1795,71 @@ def main():
     parser.add_argument("--semantic-core-payload-branching", action="store_true", help="forbid raw Mapping/list payload branching outside boundary decode functions")
     parser.add_argument("--aspf-taint-crosswalk", action="store_true", help="require ASPF/taint crosswalk acknowledgement when relevant files change")
     parser.add_argument("--non-boundary-payload-signatures", action="store_true", help="forbid dict[str, object]-first helper signatures outside boundary modules")
-    args = parser.parse_args()
+    parser.add_argument("--output", type=Path, help="write machine-readable policy result artifact")
+    args = parser.parse_args(argv)
 
     if not args.workflows and not args.posture and not args.ambiguity_contract and not args.normative_map and not args.tier2_residue_contract and not args.adapter_surfaces and not args.semantic_core_payload_branching and not args.aspf_taint_crosswalk and not args.non_boundary_payload_signatures:
         args.workflows = True
 
-    with _policy_deadline_scope():
-        if args.workflows:
-            check_workflows()
-        if args.posture:
-            check_posture()
-        if args.ambiguity_contract:
-            check_ambiguity_contract()
-        if args.normative_map:
-            check_normative_enforcement_map()
-        if args.tier2_residue_contract:
-            check_tier2_residue_contract()
-        if args.adapter_surfaces:
-            check_adapter_surface_policy()
-        if args.semantic_core_payload_branching:
-            check_semantic_core_payload_branching()
-        if args.workflows:
-            check_src_script_file_loading_policy()
-        if args.aspf_taint_crosswalk or args.workflows:
-            check_aspf_taint_crosswalk_ack()
-        if args.non_boundary_payload_signatures or args.workflows:
-            check_non_boundary_payload_signatures()
+    selected_checks = {
+        "workflows": bool(args.workflows),
+        "posture": bool(args.posture),
+        "ambiguity_contract": bool(args.ambiguity_contract),
+        "normative_map": bool(args.normative_map),
+        "tier2_residue_contract": bool(args.tier2_residue_contract),
+        "adapter_surfaces": bool(args.adapter_surfaces),
+        "semantic_core_payload_branching": bool(args.semantic_core_payload_branching),
+        "aspf_taint_crosswalk": bool(args.aspf_taint_crosswalk),
+        "non_boundary_payload_signatures": bool(args.non_boundary_payload_signatures),
+    }
+    try:
+        with _policy_deadline_scope():
+            if args.workflows:
+                check_workflows()
+            if args.posture:
+                check_posture()
+            if args.ambiguity_contract:
+                check_ambiguity_contract()
+            if args.normative_map:
+                check_normative_enforcement_map()
+            if args.tier2_residue_contract:
+                check_tier2_residue_contract()
+            if args.adapter_surfaces:
+                check_adapter_surface_policy()
+            if args.semantic_core_payload_branching:
+                check_semantic_core_payload_branching()
+            if args.workflows:
+                check_src_script_file_loading_policy()
+            if args.aspf_taint_crosswalk or args.workflows:
+                check_aspf_taint_crosswalk_ack()
+            if args.non_boundary_payload_signatures or args.workflows:
+                check_non_boundary_payload_signatures()
+    except SystemExit as exc:
+        if args.output is not None:
+            write_policy_result(
+                path=args.output.resolve(),
+                result=make_policy_result(
+                    rule_id="policy_check",
+                    status="fail",
+                    violations=_serialize_policy_check_errors(_LAST_FAIL_ERRORS),
+                    baseline_mode="none",
+                    source_tool="scripts/policy/policy_check.py",
+                    input_scope={"checks": selected_checks},
+                ),
+            )
+        raise
+    if args.output is not None:
+        write_policy_result(
+            path=args.output.resolve(),
+            result=make_policy_result(
+                rule_id="policy_check",
+                status="pass",
+                violations=[],
+                baseline_mode="none",
+                source_tool="scripts/policy/policy_check.py",
+                input_scope={"checks": selected_checks},
+            ),
+        )
     return 0
 
 

--- a/scripts/policy/policy_scanner_suite.py
+++ b/scripts/policy/policy_scanner_suite.py
@@ -2,16 +2,98 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
+import sys
 from pathlib import Path
 
-from gabion.tooling.runtime import policy_scanner_suite
+from gabion.tooling.runtime import policy_result_schema, policy_scanner_suite
+
+
+def _run_external_policy_results(*, root: Path, out: Path) -> dict[str, dict[str, object]]:
+    checks: tuple[tuple[str, list[str]], ...] = (
+        (
+            "policy_check",
+            [
+                "scripts/policy/policy_check.py",
+                "--workflows",
+                "--output",
+                str(out.parent / "policy_check_result.json"),
+            ],
+        ),
+        (
+            "structural_hash",
+            [
+                "scripts/policy/structural_hash_policy_check.py",
+                "--root",
+                str(root),
+                "--output",
+                str(out.parent / "structural_hash_result.json"),
+            ],
+        ),
+        (
+            "deprecated_nonerasability",
+            [
+                "scripts/policy/deprecated_nonerasability_policy_check.py",
+                "--baseline",
+                str(root / "out" / "deprecated_fibers_baseline.json"),
+                "--current",
+                str(root / "out" / "deprecated_fibers_current.json"),
+                "--output",
+                str(out.parent / "deprecated_nonerasability_result.json"),
+            ],
+        ),
+    )
+    results: dict[str, dict[str, object]] = {}
+    for rule_id, command in checks:
+        if rule_id == "deprecated_nonerasability":
+            baseline = Path(command[2])
+            current = Path(command[4])
+            if not baseline.exists() or not current.exists():
+                results[rule_id] = policy_result_schema.make_policy_result(
+                    rule_id=rule_id,
+                    status="skip",
+                    violations=[
+                        {
+                            "message": "baseline/current payload missing; rule skipped in suite aggregation",
+                            "render": f"missing baseline={baseline.exists()} current={current.exists()}",
+                        }
+                    ],
+                    baseline_mode="baseline_compare",
+                    source_tool="scripts/policy/policy_scanner_suite.py",
+                    input_scope={"baseline": str(baseline), "current": str(current)},
+                )
+                continue
+        completed = subprocess.run([sys.executable, *command], cwd=root, check=False)
+        artifact = Path(command[-1])
+        loaded = policy_result_schema.load_policy_result(artifact)
+        if loaded is not None:
+            results[rule_id] = loaded
+            continue
+        status = "pass" if completed.returncode == 0 else "fail"
+        results[rule_id] = policy_result_schema.make_policy_result(
+            rule_id=rule_id,
+            status=status,
+            violations=[{"message": f"fallback result from return code {completed.returncode}", "render": f"returncode={completed.returncode}"}] if completed.returncode != 0 else [],
+            baseline_mode="fallback",
+            source_tool="scripts/policy/policy_scanner_suite.py",
+            input_scope={"command": command[:-2]},
+        )
+    return results
 
 
 def run(*, root: Path, out: Path) -> int:
-    result = policy_scanner_suite.load_or_scan_policy_suite(root=root, artifact_path=out)
+    policy_results = _run_external_policy_results(root=root, out=out)
+    result = policy_scanner_suite.load_or_scan_policy_suite(
+        root=root,
+        artifact_path=out,
+        policy_results=policy_results,
+    )
     total = result.total_violations()
     print(f"policy-suite scan: cached={result.cached} total_violations={total} out={out}")
     if total == 0:
+        for rule_id in ("policy_check", "structural_hash", "deprecated_nonerasability"):
+            status = str(result.policy_results.get(rule_id, {}).get("status", "unknown"))
+            print(f"{rule_id} status: {status}")
         return 0
     for rule in (
         "no_monkeypatch",

--- a/scripts/policy/structural_hash_policy_check.py
+++ b/scripts/policy/structural_hash_policy_check.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from gabion.tooling.runtime.policy_result_schema import make_policy_result, write_policy_result
+
 
 _DERIVATION_IDENTITY_FILES = (
     Path("src/gabion/analysis/derivation_contract.py"),
@@ -151,8 +153,31 @@ def collect_violations(*, root: Path) -> list[Violation]:
     return violations
 
 
-def run(*, root: Path) -> int:
+def _serialize_violation(violation: Violation) -> dict[str, object]:
+    return {
+        "path": violation.path,
+        "line": violation.line,
+        "call": violation.call,
+        "reason": violation.reason,
+        "render": f"{violation.path}:{violation.line}: {violation.call}: {violation.reason}",
+    }
+
+
+def run(*, root: Path, output: Path | None = None) -> int:
     violations = collect_violations(root=root)
+    status = "pass" if not violations else "fail"
+    if output is not None:
+        write_policy_result(
+            path=output,
+            result=make_policy_result(
+                rule_id="structural_hash",
+                status=status,
+                violations=[_serialize_violation(item) for item in violations],
+                baseline_mode="none",
+                source_tool="scripts/policy/structural_hash_policy_check.py",
+                input_scope={"root": str(root)},
+            ),
+        )
     if not violations:
         print("structural-hash policy check passed")
         return 0
@@ -167,8 +192,9 @@ def run(*, root: Path) -> int:
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=".")
+    parser.add_argument("--output", type=Path)
     args = parser.parse_args(list(argv) if argv is not None else None)
-    return run(root=Path(args.root).resolve())
+    return run(root=Path(args.root).resolve(), output=args.output.resolve() if args.output else None)
 
 
 if __name__ == "__main__":

--- a/src/gabion/tooling/policy_rules/no_monkeypatch_rule.py
+++ b/src/gabion/tooling/policy_rules/no_monkeypatch_rule.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from gabion.tooling.runtime.policy_result_schema import make_policy_result, write_policy_result
+
 TARGET_GLOBS = (
     "tests/**/*.py",
     "src/**/*.py",
@@ -199,8 +201,31 @@ def collect_violations(*, root: Path) -> list[Violation]:
     return violations
 
 
-def run(*, root: Path) -> int:
+def _serialize_violation(violation: Violation) -> dict[str, object]:
+    return {
+        "path": violation.path,
+        "line": violation.line,
+        "column": violation.column,
+        "message": violation.message,
+        "render": violation.render(),
+    }
+
+
+def run(*, root: Path, output: Path | None = None) -> int:
     violations = collect_violations(root=root)
+    status = "pass" if not violations else "fail"
+    if output is not None:
+        write_policy_result(
+            path=output,
+            result=make_policy_result(
+                rule_id="no_monkeypatch",
+                status=status,
+                violations=[_serialize_violation(item) for item in violations],
+                baseline_mode="none",
+                source_tool="src/gabion/tooling/policy_rules/no_monkeypatch_rule.py",
+                input_scope={"root": str(root)},
+            ),
+        )
     if not violations:
         print("no-monkeypatch policy check passed")
         return 0
@@ -213,8 +238,9 @@ def run(*, root: Path) -> int:
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=".")
+    parser.add_argument("--output", type=Path)
     args = parser.parse_args(list(argv) if argv is not None else None)
-    return run(root=Path(args.root).resolve())
+    return run(root=Path(args.root).resolve(), output=args.output.resolve() if args.output else None)
 
 
 if __name__ == "__main__":

--- a/src/gabion/tooling/runtime/policy_result_schema.py
+++ b/src/gabion/tooling/runtime/policy_result_schema.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_POLICY_RESULT_REQUIRED_FIELDS = (
+    "rule_id",
+    "status",
+    "violations",
+    "baseline_mode",
+    "source_tool",
+    "timestamp_utc",
+    "input_scope",
+)
+
+
+def make_policy_result(
+    *,
+    rule_id: str,
+    status: str,
+    violations: list[dict[str, Any]],
+    baseline_mode: str,
+    source_tool: str,
+    input_scope: Mapping[str, Any],
+    timestamp_utc: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "rule_id": rule_id,
+        "status": status,
+        "violations": violations,
+        "baseline_mode": baseline_mode,
+        "source_tool": source_tool,
+        "timestamp_utc": timestamp_utc or datetime.now(timezone.utc).isoformat(),
+        "input_scope": dict(input_scope),
+    }
+
+
+def write_policy_result(*, path: Path, result: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_policy_result(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    for field in _POLICY_RESULT_REQUIRED_FIELDS:
+        if field not in raw:
+            return None
+    if not isinstance(raw.get("violations"), list):
+        return None
+    return dict(raw)
+
+
+__all__ = [
+    "load_policy_result",
+    "make_policy_result",
+    "write_policy_result",
+]

--- a/src/gabion/tooling/runtime/policy_scanner_suite.py
+++ b/src/gabion/tooling/runtime/policy_scanner_suite.py
@@ -15,6 +15,7 @@ from gabion.tooling.policy_rules import (
     runtime_narrowing_boundary_rule,
     typing_surface_rule,
 )
+from gabion.tooling.runtime import policy_result_schema
 
 _POLICY_ARTIFACT = Path("artifacts/out/policy_suite_results.json")
 _FORMAT_VERSION = 1
@@ -30,6 +31,23 @@ _LEGACY_MONOLITH_MODULE_PATH = Path("src/gabion/analysis/legacy_dataflow_monolit
 _ORCHESTRATOR_PRIMITIVE_BARREL_PATH = Path("src/gabion/server_core/command_orchestrator_primitives.py")
 _ORCHESTRATOR_PRIMITIVE_MAX_LINES = 2400
 _ORCHESTRATOR_PRIMITIVE_MAX_ALL_SYMBOLS = 220
+
+_EXTERNAL_POLICY_RESULT_RULE_IDS = (
+    "policy_check",
+    "structural_hash",
+    "deprecated_nonerasability",
+)
+
+
+def _normalize_policy_results(raw: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return {}
+    normalized: dict[str, dict[str, Any]] = {}
+    for key in _EXTERNAL_POLICY_RESULT_RULE_IDS:
+        item = raw.get(key)
+        if isinstance(item, dict):
+            normalized[key] = dict(item)
+    return normalized
 
 
 def _scan_orchestrator_primitive_barrel(*, root: Path) -> list[dict[str, Any]]:
@@ -78,6 +96,7 @@ class PolicySuiteResult:
     inventory_hash: str
     rule_set_hash: str
     violations_by_rule: dict[str, list[dict[str, Any]]]
+    policy_results: dict[str, dict[str, Any]]
     cached: bool
 
     def total_violations(self) -> int:
@@ -97,6 +116,7 @@ class PolicySuiteResult:
             "cached": self.cached,
             "counts": counts,
             "violations": self.violations_by_rule,
+            "policy_results": self.policy_results,
         }
 
 
@@ -105,16 +125,20 @@ def load_or_scan_policy_suite(
     *,
     root: Path,
     artifact_path: Path = _POLICY_ARTIFACT,
+    policy_results: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> PolicySuiteResult:
     resolved_root = root.resolve()
     files = _inventory_files(resolved_root)
     inventory_hash = _inventory_hash(files, resolved_root)
     rule_set_hash = _rule_set_hash()
+    normalized_policy_results = {key: dict(value) for key, value in (policy_results or {}).items() if isinstance(value, Mapping)}
+    policy_results_hash = hashlib.sha256(json.dumps(normalized_policy_results, sort_keys=True).encode("utf-8")).hexdigest()
     cached_payload = _load_cached_payload(artifact_path)
     if cached_payload is not None:
         if (
             str(cached_payload.get("inventory_hash", "")) == inventory_hash
             and str(cached_payload.get("rule_set_hash", "")) == rule_set_hash
+            and str(cached_payload.get("policy_results_hash", "")) == policy_results_hash
         ):
             violations = _violations_from_payload(cached_payload)
             return PolicySuiteResult(
@@ -122,18 +146,25 @@ def load_or_scan_policy_suite(
                 inventory_hash=inventory_hash,
                 rule_set_hash=rule_set_hash,
                 violations_by_rule=violations,
+                policy_results=_normalize_policy_results(cached_payload.get("policy_results")),
                 cached=True,
             )
 
-    result = scan_policy_suite(root=resolved_root, files=files)
+    result = scan_policy_suite(root=resolved_root, files=files, policy_results=normalized_policy_results)
     payload = result.to_payload()
+    payload["policy_results_hash"] = policy_results_hash
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
     artifact_path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
     return result
 
 
 # gabion:decision_protocol
-def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> PolicySuiteResult:
+def scan_policy_suite(
+    *,
+    root: Path,
+    files: tuple[Path, ...] | None = None,
+    policy_results: Mapping[str, Mapping[str, Any]] | None = None,
+) -> PolicySuiteResult:
     resolved_root = root.resolve()
     inventory = files if files is not None else _inventory_files(resolved_root)
     inventory_hash = _inventory_hash(inventory, resolved_root)
@@ -307,6 +338,7 @@ def scan_policy_suite(*, root: Path, files: tuple[Path, ...] | None = None) -> P
         inventory_hash=inventory_hash,
         rule_set_hash=rule_set_hash,
         violations_by_rule=violations_by_rule,
+        policy_results={key: dict(value) for key, value in (policy_results or {}).items() if isinstance(value, Mapping)},
         cached=False,
     )
 

--- a/tests/gabion/analysis/misc_s1/test_structural_hash_policy_check.py
+++ b/tests/gabion/analysis/misc_s1/test_structural_hash_policy_check.py
@@ -54,3 +54,17 @@ def test_structural_hash_policy_check_rejects_digest_identity_calls(tmp_path: Pa
     assert violations
     assert any("hashlib" in entry.call for entry in violations)
 
+
+
+# gabion:evidence E:call_footprint::tests/test_structural_hash_policy_check.py::test_structural_hash_policy_check_writes_policy_result_output::structural_hash_policy_check.py::scripts.structural_hash_policy_check.run
+def test_structural_hash_policy_check_writes_policy_result_output(tmp_path: Path) -> None:
+    _write(tmp_path / "src/gabion/analysis/derivation_contract.py", "VALUE = 1\n")
+    _write(tmp_path / "src/gabion/analysis/derivation_graph.py", "def f():\n    return 1\n")
+    _write(tmp_path / "src/gabion/analysis/derivation_cache.py", "def f():\n    return 1\n")
+    out = tmp_path / "out/result.json"
+    code = structural_hash_policy_check.run(root=tmp_path, output=out)
+    assert code == 0
+    payload = __import__("json").loads(out.read_text(encoding="utf-8"))
+    assert payload["rule_id"] == "structural_hash"
+    assert payload["status"] == "pass"
+    assert payload["violations"] == []

--- a/tests/gabion/tooling/runtime_policy/test_deprecated_nonerasability_policy_check.py
+++ b/tests/gabion/tooling/runtime_policy/test_deprecated_nonerasability_policy_check.py
@@ -84,3 +84,26 @@ def test_nonerasability_policy_check_allows_resolved_lifecycle(tmp_path: Path) -
         text=True,
     )
     assert result.returncode == 0
+
+
+# gabion:evidence E:function_site::tests/test_deprecated_nonerasability_policy_check.py::tests.test_deprecated_nonerasability_policy_check.test_nonerasability_policy_check_writes_policy_result_output
+def test_nonerasability_policy_check_writes_policy_result_output(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    current = tmp_path / "current.json"
+    output = tmp_path / "out/nonerasability.json"
+    _write_payload(baseline, {"deprecated_fibers": []})
+    _write_payload(current, {"deprecated_fibers": []})
+    result = subprocess.run([
+        sys.executable,
+        "scripts/policy/deprecated_nonerasability_policy_check.py",
+        "--baseline",
+        str(baseline),
+        "--current",
+        str(current),
+        "--output",
+        str(output),
+    ], cwd=REPO_ROOT, check=False, capture_output=True, text=True)
+    assert result.returncode == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["rule_id"] == "deprecated_nonerasability"
+    assert payload["status"] == "pass"

--- a/tests/gabion/tooling/runtime_policy/test_no_monkeypatch_policy_check.py
+++ b/tests/gabion/tooling/runtime_policy/test_no_monkeypatch_policy_check.py
@@ -42,3 +42,14 @@ def test_no_monkeypatch_policy_allows_di_style_tests(tmp_path: Path) -> None:
     )
 
     assert policy.run(root=tmp_path) == 0
+
+
+# gabion:evidence E:call_footprint::tests/test_no_monkeypatch_policy_check.py::test_no_monkeypatch_policy_check_writes_policy_result_output::no_monkeypatch_policy_check.py::scripts.no_monkeypatch_policy_check.run
+def test_no_monkeypatch_policy_check_writes_policy_result_output(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_good.py", "def test_ok():\n    assert True\n")
+    out = tmp_path / "out/no_monkeypatch.json"
+    result = policy.run(root=tmp_path, output=out)
+    assert result == 0
+    payload = __import__("json").loads(out.read_text(encoding="utf-8"))
+    assert payload["rule_id"] == "no_monkeypatch"
+    assert payload["status"] == "pass"

--- a/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
+++ b/tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py
@@ -442,3 +442,15 @@ def test_policy_scanner_suite_flags_invalid_runtime_narrowing_boundary_waiver_me
     result = policy_scanner_suite.scan_policy_suite(root=root)
     violations = policy_scanner_suite.violations_for_rule(result, rule="runtime_narrowing_boundary")
     assert any(item.get("kind") == "invalid_waiver" for item in violations)
+
+
+# gabion:evidence E:call_footprint::tests/test_policy_scanner_suite.py::test_policy_scanner_suite_carries_external_policy_results::policy_scanner_suite.py::gabion.tooling.policy_scanner_suite.scan_policy_suite
+def test_policy_scanner_suite_carries_external_policy_results(tmp_path: Path) -> None:
+    root = tmp_path
+    result = policy_scanner_suite.scan_policy_suite(
+        root=root,
+        policy_results={
+            "policy_check": {"rule_id": "policy_check", "status": "pass", "violations": []},
+        },
+    )
+    assert result.policy_results["policy_check"]["status"] == "pass"


### PR DESCRIPTION
### Motivation
- Provide a single, machine-readable policy-result envelope so gate-only checks (workflow/gate scripts) produce a stable audit artifact (`rule_id`, `status`, `violations`, `baseline_mode`, `source_tool`, `timestamp_utc`, `input_scope`).
- Allow existing gate-only checks to emit that envelope without changing their existing pass/fail semantics or human-facing stdout output.
- Surface per-rule envelopes to the scanner-suite so `artifacts/out/policy_suite_results.json` can act as the consolidated, audit-worthy source of truth for policy families.
- Document the consolidated artifact and define fallback behavior when a producer cannot emit its artifact.

### Description
- Add shared schema helpers in `src/gabion/tooling/runtime/policy_result_schema.py` with `make_policy_result`, `write_policy_result`, and `load_policy_result` for canonical envelopes.
- Extend gate-only checks to optionally emit envelopes when an output path is provided without changing pass/fail logic: `scripts/policy/policy_check.py`, `scripts/policy/structural_hash_policy_check.py`, `scripts/policy/deprecated_nonerasability_policy_check.py`, and `src/gabion/tooling/policy_rules/no_monkeypatch_rule.py` now accept `--output` (or `output` param) and write the unified artifact.
- Wire external gate producers into the orchestration wrapper `scripts/policy/policy_scanner_suite.py`, which runs the external checks, ingests their artifacts, and records fallback envelopes (derived from return code) or `skip` for missing baseline payloads to preserve forensic continuity.
- Extend the runtime scanner `src/gabion/tooling/runtime/policy_scanner_suite.py` to accept `policy_results`, persist `policy_results` in emitted payloads, compute a `policy_results_hash` for cache validation, and carry `policy_results` in `PolicySuiteResult.to_payload()`.
- Preserve human-readable stdout/stderr summaries and existing exit-code semantics when `--output` is not used, and keep pass/fail semantics unchanged for callers.
- Update governance docs to reference `artifacts/out/policy_suite_results.json` as the consolidated audit artifact and document the fallback/skip behavior; bump doc revisions accordingly.
- Add/adjust tests to exercise emission and suite carriage paths and refresh evidence mapping (`tests/...` updates and `out/test_evidence.json`).

### Testing
- Ran targeted pytest matrix with pinned PYTHONPATH: `PYTHONPATH=src python -m pytest -o addopts='' tests/gabion/analysis/misc_s1/test_structural_hash_policy_check.py tests/gabion/tooling/runtime_policy/test_no_monkeypatch_policy_check.py tests/gabion/tooling/runtime_policy/test_deprecated_nonerasability_policy_check.py tests/gabion/tooling/runtime_policy/test_policy_scanner_suite.py`, and all tests passed (23 passed).
- Exercised suite and gate runners end-to-end: `PYTHONPATH=src:. python scripts/policy/policy_check.py --workflows` and `PYTHONPATH=src:. python scripts/policy/policy_check.py --ambiguity-contract` succeeded and the `--output` envelope path was produced in validation runs; `scripts/policy/policy_scanner_suite.py --root . --out artifacts/out/policy_suite_results.json` produced a consolidated artifact containing `policy_results` entries.
- Verified evidence carrier generation with `PYTHONPATH=src:. python scripts/misc/extract_test_evidence.py --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` accordingly.
- Performed static/compile checks: `PYTHONPATH=src:. python -m py_compile` on modified modules succeeded.
- Note: an initial `mise`-based invocation was blocked in this environment due to local `mise` trust configuration; equivalent validated commands were run directly using `PYTHONPATH=src` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1aec0d4083248fe964714ab60082)