### PR TITLE
docs: clarify policy_check matrix row includes structured output artifact

### DIFF
--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 53
+doc_revision: 54
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: policy_seed
 doc_role: policy
@@ -727,7 +727,7 @@ Status classes:
 
 | Rule family (normative anchor) | Applicability class | Runtime scope | Enforcement/check cross-reference |
 | --- | --- | --- | --- |
-| Workflow structure + action pinning + allow-list (§§4.5, 5.1) | active now | All workflows under `.github/workflows/*.yml` | `scripts/policy/policy_check.py::check_workflows()` + `_check_actions(...)`; executed in `.github/workflows/ci.yml` (`Policy check (workflows)`). |
+| Workflow structure + action pinning + allow-list (§§4.5, 5.1) | active now | All workflows under `.github/workflows/*.yml` | `scripts/policy/policy_check.py::check_workflows()` + `_check_actions(...)`; gate behavior remains exit+console-output driven via `main(...)` argument parsing and `_fail(...)` (`SystemExit`). Structured output is also supported via `main(...)` `--output` argument (`parser.add_argument("--output", ...)`) with result-envelope serialization through `make_policy_result(...)` + `write_policy_result(...)`; executed in `.github/workflows/ci.yml` (`Policy check (workflows)`). |
 | Baseline permissions discipline (§4.4) | active now | All workflows/jobs | `scripts/policy/policy_check.py::_check_permissions(...)` and `_check_job_permissions(...)`; executed in `.github/workflows/ci.yml`. |
 | Manual-dispatch guardrails (§0.3, §4.1) | active now | Any `workflow_dispatch` workflow | `scripts/policy/policy_check.py::_check_workflow_dispatch_guards(...)`; currently applies to `.github/workflows/ci.yml` and `.github/workflows/release-tag.yml`. |
 | Trusted branch mirroring controls (§4.4) | conditional by event/branch | Push to `main` and promotion chain (`workflow_run`) | `.github/workflows/mirror-next.yml`, `.github/workflows/auto-test-tag.yml`, `.github/workflows/promote-release.yml`; validated by `scripts/policy/policy_check.py::_check_mirror_next_workflow(...)`, `_check_auto_test_tag_workflow(...)`, `_check_promote_release_workflow(...)`. |


### PR DESCRIPTION
### Motivation
- Ensure the policy applicability matrix documents both the gate behavior (exit + console output) and the machine-readable result artifact path for `scripts/policy/policy_check.py`, and reduce future regression risk by pointing to concrete entry points in the script.

### Description
- Bumped `POLICY_SEED.md` `doc_revision` to `54` and updated the Policy Applicability Matrix row for workflow/action pinning to retain gate semantics and explicitly reference `main(...)` argument parsing, `parser.add_argument("--output", ...)`, `_fail(...)`/`SystemExit`, and `make_policy_result(...)` + `write_policy_result(...)` for structured result-envelope serialization.

### Testing
- Executed `PYTHONPATH=src mise exec -- python -m scripts.policy.policy_check --workflows --output /tmp/policy_result.json` and verified that `/tmp/policy_result.json` was created and its `status` field is `"pass"` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa22b98aac832490f133c8d498c3fd)