### PR TITLE
Promote public CLI interfaces for artifact restore and response codecs

### DIFF
--- a/src/gabion/cli.py
+++ b/src/gabion/cli.py
@@ -30,8 +30,12 @@ from gabion.cli_support.check.execution_plan_payload import (
 from gabion.cli_support.check.check_runtime import run_check as _run_check_impl
 from gabion.cli_support.shared.dispatch_runtime import (
     dispatch_command as _dispatch_command_impl)
-from gabion.cli_support.shared import (
-    github_artifact_restore as _github_artifact_restore)
+from gabion.cli_support.shared.github_artifact_restore import (
+    NoRedirectHandler,
+    download_artifact_archive_bytes,
+    restore_aspf_state_from_github_artifacts,
+    state_requires_chunk_artifacts,
+)
 from gabion.cli_support.shared.parser_builder import dataflow_cli_parser as _build_dataflow_cli_parser
 from gabion.cli_support.shared.raw_argparse import (
     parse_dataflow_args_or_exit as _parse_dataflow_args_or_exit_impl)
@@ -634,8 +638,8 @@ def _emit_dataflow_result_outputs(result: JSONObject, opts: argparse.Namespace) 
         emit_result_json_to_stdout_fn=_emit_result_json_to_stdout,
         stdout_path=_STDOUT_PATH,
         check_deadline_fn=check_deadline,
-        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
-        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
+        normalize_dataflow_response_fn=command_orchestrator_primitives.normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives.serialize_dataflow_response,
     )
 
 
@@ -1105,12 +1109,10 @@ def _run_governance_runner(
         return 1
 
 
-_restore_aspf_state_from_github_artifacts = (
-    _github_artifact_restore._restore_aspf_state_from_github_artifacts
-)
-_NoRedirectHandler = _github_artifact_restore._NoRedirectHandler
-_download_artifact_archive_bytes = _github_artifact_restore._download_artifact_archive_bytes
-_state_requires_chunk_artifacts = _github_artifact_restore._state_requires_chunk_artifacts
+_restore_aspf_state_from_github_artifacts = restore_aspf_state_from_github_artifacts
+_NoRedirectHandler = NoRedirectHandler
+_download_artifact_archive_bytes = download_artifact_archive_bytes
+_state_requires_chunk_artifacts = state_requires_chunk_artifacts
 
 
 def _run_docflow_audit(

--- a/src/gabion/cli_support/shared/github_artifact_restore.py
+++ b/src/gabion/cli_support/shared/github_artifact_restore.py
@@ -14,7 +14,7 @@ import zipfile
 import typer
 
 
-def _restore_aspf_state_from_github_artifacts(
+def restore_aspf_state_from_github_artifacts(
     *,
     token: str,
     repo: str,
@@ -90,7 +90,7 @@ def _restore_aspf_state_from_github_artifacts(
     for artifact in artifact_candidates:
         download_url = str(artifact.get("archive_download_url", "") or "")
         try:
-            archive_bytes = _download_artifact_archive_bytes(
+            archive_bytes = download_artifact_archive_bytes(
                 download_url=download_url,
                 headers=headers,
                 urlopen_fn=urlopen_fn,
@@ -110,7 +110,7 @@ def _restore_aspf_state_from_github_artifacts(
                 if checkpoint_member is None:
                     continue
                 checkpoint_bytes = zf.read(checkpoint_member)
-                if _state_requires_chunk_artifacts(
+                if state_requires_chunk_artifacts(
                     checkpoint_bytes=checkpoint_bytes
                 ) and not chunk_members:
                     continue
@@ -149,7 +149,7 @@ def _restore_aspf_state_from_github_artifacts(
     return 0
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(
         self,
         req: urllib.request.Request,
@@ -163,7 +163,7 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def _download_artifact_archive_bytes(
+def download_artifact_archive_bytes(
     *,
     download_url: str,
     headers: Mapping[str, str],
@@ -176,7 +176,7 @@ def _download_artifact_archive_bytes(
         with urlopen_fn(req_zip, timeout=60) as response:
             return response.read()
     if no_redirect_open_fn is None:
-        no_redirect_open_fn = urllib.request.build_opener(_NoRedirectHandler()).open
+        no_redirect_open_fn = urllib.request.build_opener(NoRedirectHandler()).open
     if follow_redirect_open_fn is None:
         follow_redirect_open_fn = urllib.request.urlopen
     try:
@@ -195,7 +195,7 @@ def _download_artifact_archive_bytes(
             return response.read()
 
 
-def _state_requires_chunk_artifacts(*, checkpoint_bytes: bytes) -> bool:
+def state_requires_chunk_artifacts(*, checkpoint_bytes: bytes) -> bool:
     try:
         payload = json.loads(checkpoint_bytes.decode("utf-8"))
     except Exception:
@@ -210,3 +210,16 @@ def _state_requires_chunk_artifacts(*, checkpoint_bytes: bytes) -> bool:
         return False
     state_ref = analysis_index_resume.get("state_ref")
     return isinstance(state_ref, str) and bool(state_ref.strip())
+
+
+_restore_aspf_state_from_github_artifacts = restore_aspf_state_from_github_artifacts
+_NoRedirectHandler = NoRedirectHandler
+_download_artifact_archive_bytes = download_artifact_archive_bytes
+_state_requires_chunk_artifacts = state_requires_chunk_artifacts
+
+__all__ = [
+    "NoRedirectHandler",
+    "download_artifact_archive_bytes",
+    "restore_aspf_state_from_github_artifacts",
+    "state_requires_chunk_artifacts",
+]

--- a/src/gabion/server_core/command_orchestrator_primitives.py
+++ b/src/gabion/server_core/command_orchestrator_primitives.py
@@ -1767,7 +1767,7 @@ def _parse_lint_line_as_payload(line: str) -> dict[str, object] | None:
     entry = _parse_lint_line(line)
     return entry.model_dump() if entry is not None else None
 
-def _normalize_dataflow_response(response: Mapping[str, object]) -> DataflowResponseEnvelopeDTO:
+def normalize_dataflow_response(response: Mapping[str, object]) -> DataflowResponseEnvelopeDTO:
     lint_decision = LintEntriesDecision.from_response(response)
     lint_lines = list(lint_decision.lint_lines)
     lint_entries = lint_decision.normalize_entries(
@@ -1870,7 +1870,7 @@ def _normalize_dataflow_response(response: Mapping[str, object]) -> DataflowResp
     return DataflowResponseEnvelopeDTO(canonical=canonical, payload=normalized)
 
 
-def _serialize_dataflow_response(
+def serialize_dataflow_response(
     response: DataflowResponseEnvelopeDTO,
 ) -> dict[str, object]:
     normalized = dict(response.payload)
@@ -2195,6 +2195,11 @@ def _materialize_execution_plan(payload: Mapping[str, object]) -> ExecutionPlan:
         policy_metadata=ExecutionPlanPolicyMetadata(deadline={}, baseline_mode="none", docflow_mode="disabled"),
     )
 
+
+
+_normalize_dataflow_response = normalize_dataflow_response
+_serialize_dataflow_response = serialize_dataflow_response
+
 def _default_execute_command_deps() -> ExecuteCommandDeps:
     return ExecuteCommandDeps(
         analysis=AnalysisDeps(
@@ -2266,7 +2271,10 @@ __all__ = [
     '_is_stdout_target',
     '_latest_report_phase',
     '_materialize_execution_plan',
+    'normalize_dataflow_response',
     '_normalize_dataflow_response',
+    'serialize_dataflow_response',
+    '_serialize_dataflow_response',
     '_output_dirs',
     '_phase_timeline_header_block',
     '_phase_timeline_jsonl_path',

--- a/tests/gabion/cli/cli_output_emitters_cases.py
+++ b/tests/gabion/cli/cli_output_emitters_cases.py
@@ -60,8 +60,8 @@ def test_emit_dataflow_outputs_uses_canonical_lint_entry_normalization() -> None
         emit_result_json_to_stdout_fn=lambda **_kwargs: None,
         stdout_path="-",
         check_deadline_fn=lambda: None,
-        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
-        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
+        normalize_dataflow_response_fn=command_orchestrator_primitives.normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives.serialize_dataflow_response,
     )
 
     lint_entries = captured["lint_entries"]
@@ -96,8 +96,8 @@ def test_emit_dataflow_outputs_respects_canonical_aspf_presence_rules() -> None:
         emit_result_json_to_stdout_fn=lambda *, payload: emitted.append(payload),
         stdout_path="-",
         check_deadline_fn=lambda: None,
-        normalize_dataflow_response_fn=command_orchestrator_primitives._normalize_dataflow_response,
-        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
+        normalize_dataflow_response_fn=command_orchestrator_primitives.normalize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives.serialize_dataflow_response,
     )
 
     assert any(isinstance(payload, dict) and payload.get("trace_id") == "aspf-trace:abc123" for payload in emitted)
@@ -109,8 +109,8 @@ def test_emit_dataflow_outputs_uses_canonical_capability_field_normalization() -
     captured: dict[str, object] = {}
 
     def _normalize(response: dict[str, object]):
-        normalized = command_orchestrator_primitives._normalize_dataflow_response(response)
-        captured["normalized"] = command_orchestrator_primitives._serialize_dataflow_response(normalized)
+        normalized = command_orchestrator_primitives.normalize_dataflow_response(response)
+        captured["normalized"] = command_orchestrator_primitives.serialize_dataflow_response(normalized)
         return normalized
 
     emit_dataflow_result_outputs(
@@ -129,7 +129,7 @@ def test_emit_dataflow_outputs_uses_canonical_capability_field_normalization() -
         stdout_path="-",
         check_deadline_fn=lambda: None,
         normalize_dataflow_response_fn=_normalize,
-        serialize_dataflow_response_fn=command_orchestrator_primitives._serialize_dataflow_response,
+        serialize_dataflow_response_fn=command_orchestrator_primitives.serialize_dataflow_response,
     )
 
     normalized = captured["normalized"]

--- a/tests/gabion/cli_support/shared/test_github_artifact_restore.py
+++ b/tests/gabion/cli_support/shared/test_github_artifact_restore.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+
+from gabion.cli_support.shared import github_artifact_restore
+
+
+# gabion:evidence E:call_footprint::tests/test_github_artifact_restore.py::test_state_requires_chunk_artifacts_detects_state_ref::github_artifact_restore.py::gabion.cli_support.shared.github_artifact_restore.state_requires_chunk_artifacts
+def test_state_requires_chunk_artifacts_detects_state_ref() -> None:
+    payload = {
+        "collection_resume": {
+            "analysis_index_resume": {
+                "state_ref": "chunk://resume-state"
+            }
+        }
+    }
+    assert github_artifact_restore.state_requires_chunk_artifacts(
+        checkpoint_bytes=json.dumps(payload).encode("utf-8")
+    )
+
+
+# gabion:evidence E:call_footprint::tests/test_github_artifact_restore.py::test_no_redirect_handler_redirect_request_returns_none::github_artifact_restore.py::gabion.cli_support.shared.github_artifact_restore.NoRedirectHandler.redirect_request
+def test_no_redirect_handler_redirect_request_returns_none() -> None:
+    handler = github_artifact_restore.NoRedirectHandler()
+    request = urllib.request.Request("https://example.invalid/archive.zip")
+    assert (
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {"Location": "https://example.invalid/redirect"},
+            "https://example.invalid/redirect",
+        )
+        is None
+    )
+
+
+# gabion:evidence E:call_footprint::tests/test_github_artifact_restore.py::test_private_aliases_remain_mapped_to_public_entry_points::github_artifact_restore.py::gabion.cli_support.shared.github_artifact_restore.restore_aspf_state_from_github_artifacts
+def test_private_aliases_remain_mapped_to_public_entry_points() -> None:
+    assert (
+        github_artifact_restore._restore_aspf_state_from_github_artifacts
+        is github_artifact_restore.restore_aspf_state_from_github_artifacts
+    )
+    assert github_artifact_restore._NoRedirectHandler is github_artifact_restore.NoRedirectHandler
+    assert (
+        github_artifact_restore._download_artifact_archive_bytes
+        is github_artifact_restore.download_artifact_archive_bytes
+    )
+    assert (
+        github_artifact_restore._state_requires_chunk_artifacts
+        is github_artifact_restore.state_requires_chunk_artifacts
+    )


### PR DESCRIPTION
### Motivation
- Make CLI consumers import only documented/public symbols by promoting several internal underscore-prefixed helpers to public names for artifact restore and response codec concerns.
- Reduce ad-hoc private-symbol imports in `cli.py` and tests so the CLI surface depends on stable, shared APIs.
- Preserve behavior and compatibility by keeping module-level underscore aliases that map to the new public entry points at the boundary.

### Description
- Promoted artifact-restore helpers in `src/gabion/cli_support/shared/github_artifact_restore.py` by renaming `_restore_aspf_state_from_github_artifacts`, `_NoRedirectHandler`, `_download_artifact_archive_bytes`, and `_state_requires_chunk_artifacts` to public `restore_aspf_state_from_github_artifacts`, `NoRedirectHandler`, `download_artifact_archive_bytes`, and `state_requires_chunk_artifacts`, and exported them via `__all__` while retaining underscore aliases for compatibility.
- Promoted response codec entry points in `src/gabion/server_core/command_orchestrator_primitives.py` by exposing `normalize_dataflow_response` and `serialize_dataflow_response` (and creating underscore aliases back to them) so CLI code can call public normalization/serialization APIs.
- Updated `src/gabion/cli.py` to import and use only the new public symbols and to bind local underscore names to the new public functions at the ingress boundary.
- Updated tests to exercise the public APIs and added `tests/gabion/cli_support/shared/test_github_artifact_restore.py` to validate the promoted artifact-restore interfaces and compatibility aliases, and updated CLI output-emitter tests to use the public codec names; refreshed `out/test_evidence.json` accordingly.

### Testing
- Ran the repository policy checks with `PYTHONPATH=.:src mise exec -- python scripts/policy/policy_check.py --workflows` and `--ambiguity-contract` which completed (note: `mise` warned about remote version metadata resolution but did not block local checks).
- Ran targeted pytest suites with `PYTHONPATH=.:src mise exec -- python -m pytest -o addopts='' tests/gabion/cli/cli_helpers_cases.py` and `PYTHONPATH=.:src mise exec -- python -m pytest -o addopts='' tests/gabion/cli/cli_output_emitters_cases.py tests/gabion/cli_support/shared/test_github_artifact_restore.py`, and all tests passed (145 collected across targeted runs; focused runs passed).
- Ran evidence extraction `PYTHONPATH=.:src mise exec -- python -m scripts.misc.extract_test_evidence --root . --tests tests --out out/test_evidence.json` and updated `out/test_evidence.json` to include mappings for the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9b69f6d08324b9c54b6ef92d49e2)