### PR TITLE
ci: normalize workflow python interpreter for controller drift restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             exit 0
           fi
           gh api "$history_url" > artifacts/out/controller_drift_gate_history.zip
-          python -c 'import zipfile; from pathlib import Path; z=Path("artifacts/out/controller_drift_gate_history.zip"); zipfile.ZipFile(z).extractall("artifacts/out"); z.unlink(missing_ok=True)'
+          .venv/bin/python -c 'import zipfile; from pathlib import Path; z=Path("artifacts/out/controller_drift_gate_history.zip"); zipfile.ZipFile(z).extractall("artifacts/out"); z.unlink(missing_ok=True)'
       - name: Controller drift audit
         run: .venv/bin/python scripts/governance_controller_audit.py --out artifacts/out/controller_drift.json
       - name: Override lifecycle record emit


### PR DESCRIPTION
### Motivation
- Ensure the workflow uses the repository virtualenv Python for the controller drift history unzip step so repo tooling and dependencies run with the expected interpreter and avoid reliance on the runner system `python`.

### Description
- Replaced the inline unzip invocation in the `Restore controller drift gate history` step with `.venv/bin/python -c '...'` while keeping the unzip logic identical and leaving the venv bootstrap `mise exec -- python -m venv .venv` calls unchanged.

### Testing
- Ran `mise exec -- python -m scripts.policy_check --workflows`, which completed successfully and showed no workflow-policy regressions for the changed step.  
- Ran `mise exec -- python -m scripts.policy_check --ambiguity-contract`, which failed locally because `gabion` was not available in the interpreter used by that check.  
- Attempted a local venv bootstrap and dependency install to exercise broader checks, but network/proxy restrictions prevented installing `uv`, so full local validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0083982648324b35b5b0e06151dbf)