### PR TITLE
Trim conversational preamble from POLICY_SEED canonical section

### DIFF
--- a/POLICY_SEED.md
+++ b/POLICY_SEED.md
@@ -90,17 +90,6 @@ doc_owner: maintainer
 ---
 
 <a id="policy_seed"></a>
-Excellent. What you’re asking for is not “documentation” in the usual sense. You’re asking for a **self-stabilizing policy nucleus**: a document that is simultaneously
-
-* **normative** (it constrains behavior),
-* **meta-normative** (it constrains how the constraints themselves may change),
-* **interpretable by LLMs as an active control**, and
-* **embedded in a feedback loop** so it can resist both *decay* (staleness) and *attack* (malice).
-
-Below is a **documentation seed** you can drop into the repo (e.g. `POLICY_SEED.md#policy_seed`). It is written deliberately as a *control object*, not as prose. Repo-native agents and LLMs should be instructed (elsewhere, e.g. in a system prompt or CONTRIBUTING.md#contributing_contract) to treat this file as **authoritative and executable guidance**.
-
----
-
 # POLICY_SEED.md#policy_seed
 
 **Title:** Self-Stabilizing Security & Execution Policy Seed


### PR DESCRIPTION
### Motivation
- Remove non-normative conversational scaffolding that appeared before the canonical `policy_seed` anchor so the file begins directly with the normative policy payload while preserving front matter and anchor stability.

### Description
- Deleted the informal/prose block that appeared between `<a id="policy_seed"></a>` and the `# POLICY_SEED.md#policy_seed` heading, keeping the YAML front matter and all existing anchor IDs unchanged.

### Testing
- Ran `mise exec -- env PYTHONPATH=src python -m gabion docflow`, which completed (emitted pre-existing repo warnings unrelated to this edit). 
- Ran `mise exec -- env PYTHONPATH=src python -m scripts.policy_check --normative-map`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b008257ae8832480d2412f8a8df5a8)