### PR TITLE
docs: remap ASPF fingerprint design anchors to live code

### DIFF
--- a/docs/aspf_fingerprint_contract.md
+++ b/docs/aspf_fingerprint_contract.md
@@ -1,5 +1,5 @@
 ---
-doc_revision: 1
+doc_revision: 2
 reader_reintern: "Reader-only: re-intern if doc_revision changed since you last read this doc."
 doc_id: aspf_fingerprint_contract
 doc_role: design
@@ -35,6 +35,44 @@ This document defines the formalized fingerprint contract used by analysis modul
 3. **Derived digest alias**: hash alias derived from canonical payload, explicitly marked `canonical: false`.
 
 Downstream consumers must treat only the canonical ASPF path as semantic source-of-truth.
+
+## Current-state map (live codepath anchors)
+
+This contract is grounded in the existing implementation surfaces below. Any
+implementation or refactor work must update these anchors directly instead of
+introducing detached abstractions.
+
+1. **ASPF carrier + canonical contract primitives**
+   - `src/gabion/analysis/aspf_core.py`
+   - `AspfOneCell` is the concrete canonical path carrier.
+   - `AspfCanonicalIdentityContract` is the canonical identity envelope.
+   - **Why change here:** semantic identity shape, path fields, or canonical
+     contract semantics are defined here.
+
+2. **Fingerprint → ASPF identity projection**
+   - `src/gabion/analysis/type_fingerprints.py`
+   - `fingerprint_to_aspf_path` builds the `AspfOneCell` representative from a
+     fingerprint.
+   - `fingerprint_identity_payload` materializes canonical + derived identity
+     projections consumed downstream.
+   - **Why change here:** representative selection, canonical payload emission,
+     and derived scalar/digest alias behavior are assembled here.
+
+3. **Identity layer decomposition for evidence keys**
+   - `src/gabion/analysis/evidence_keys.py`
+   - `fingerprint_identity_layers` computes layered identity components used by
+     evidence-key surfaces.
+   - **Why change here:** evidence-facing identity strata and layer stability
+     obligations are anchored here.
+
+## Remapping gate (required before implementation changes)
+
+Before any implementation work in this area, remap proposals to the
+current-state map above and identify the exact function/class touchpoints.
+Do not add new semantic-core wrappers or placeholder modules (for example,
+`identity_space.py`, `IdentityProjection`, or `canonical_site_identity`) unless
+a temporary boundary adapter is explicitly justified with lifecycle metadata per
+policy.
 
 ## Representative selection and drift rules
 


### PR DESCRIPTION
### Motivation

- The fingerprint/identity design doc referenced abstract placeholders (e.g. `identity_space.py` / `IdentityProjection`) that are not part of the live codepath, which risks introducing orphan abstractions during implementation work.
- Anchor the design guidance to the concrete, authoritative implementation surfaces so future changes target the code that actually shapes canonical identity and evidence payloads.

### Description

- Updated `docs/aspf_fingerprint_contract.md` and bumped `doc_revision` to `2` to remap identity guidance to existing code anchors.
- Added a `Current-state map (live codepath anchors)` section that lists the exact files and symbols to edit: `src/gabion/analysis/aspf_core.py` (`AspfOneCell`, `AspfCanonicalIdentityContract`), `src/gabion/analysis/type_fingerprints.py` (`fingerprint_to_aspf_path`, `fingerprint_identity_payload`), and `src/gabion/analysis/evidence_keys.py` (`fingerprint_identity_layers`).
- Added a `Remapping gate` section requiring proposals to explicitly map to those touchpoints and prohibiting new semantic-core wrappers (for example `identity_space.py`, `IdentityProjection`, or `canonical_site_identity`) unless a temporary adapter is justified with lifecycle metadata per policy.

### Testing

- Attempted to run the ambiguity-contract policy check via `mise exec -- python -m scripts.policy_check --ambiguity-contract`, but the run failed due to local environment/tooling bootstrap issues (`mise.toml` trust / tool resolution and missing installed package in the resolved interpreter).
- Ran `mise trust /workspace/gabion/mise.toml` which completed, but `mise exec` still failed due to offline/toolchain resolution and a missing `gabion` module in the resolved Python; running `.venv/bin/python -m scripts.policy_check` also failed because no `.venv` exists in this environment.
- No unit tests or runtime code were modified; this is a documentation-only change and therefore did not alter test artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f3b5ea588324bd1a2d054c50493e)